### PR TITLE
Add Qt main window to be triggered by ``start_gui``

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ set(foedag_SRC
   src/Tcl/TclInterpreter.cpp
   src/Command/Command.cpp
   src/Command/CommandStack.cpp
+  src/MainWindow/main_window.cpp
 )
 
 add_library(foedag STATIC ${foedag_SRC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,10 @@ if (WIN32 AND $<CONFIG:Debug>)
 endif()
 
 install(
+  FILES ${PROJECT_SOURCE_DIR}/src/MainWindow/main_window.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/foedag/MainWindow)
+
+install(
   FILES ${PROJECT_SOURCE_DIR}/src/Tcl/TclInterpreter.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/foedag/Tcl)
 

--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -35,12 +35,13 @@
 
 #include "Command/CommandStack.h"
 #include "Tcl/TclInterpreter.h"
+#include "main_window.h"
 
 static int GuiStartCmd(ClientData clientData, Tcl_Interp* interp, int argc,
                        const char** argv) {
   QApplication app(argc, (char**)argv);
-  QLabel* label = new QLabel("Hello Qt!");
-  label->show();
+  MainWindow main_win;
+  main_win.show();
   return app.exec();
 }
 

--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -35,7 +35,7 @@
 
 #include "Command/CommandStack.h"
 #include "Tcl/TclInterpreter.h"
-#include "main_window.h"
+#include "MainWindow/main_window.h"
 
 static int GuiStartCmd(ClientData clientData, Tcl_Interp* interp, int argc,
                        const char** argv) {

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -1,0 +1,20 @@
+#include <QtWidgets>
+
+#include "main_window.h"
+
+MainWindow::MainWindow() {
+  createActions();
+  createMenus();
+}
+
+void MainWindow::createMenus() {
+  fileMenu = menuBar()->addMenu(tr("&File"));
+  fileMenu->addAction(exitAction);
+}
+
+void MainWindow::createActions() {
+  exitAction = new QAction(tr("E&xit"), this);
+  exitAction->setShortcut(tr("Ctrl+Q"));
+  exitAction->setStatusTip(tr("Exit the application"));
+  connect(exitAction, SIGNAL(triggered()), this, SLOT(closeAllWindows()));
+}

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -14,8 +14,6 @@ class MainWindow : public QMainWindow {
     MainWindow();
  
   private slots: /* slots */
-    /* Show intro about the program */
-    void about();
 
   private: /* Menu bar builders */
     void createMenus();

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -1,0 +1,30 @@
+#ifndef MAIN_WINDOW_H
+#define MAIN_WINDOW_H
+
+#include <QMainWindow>
+
+class QAction;
+class QLabel;
+
+/** Main window of the program */
+class MainWindow : public QMainWindow {
+    Q_OBJECT
+
+  public: /*-- Constructor --*/ 
+    MainWindow();
+ 
+  private slots: /* slots */
+    /* Show intro about the program */
+    void about();
+
+  private: /* Menu bar builders */
+    void createMenus();
+    void createActions();
+
+  private: /* Objects/Widgets under the main window */
+    /* Menu bar objects */
+    QMenu* fileMenu;
+    QAction* exitAction;
+};
+
+#endif


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue:  #34 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, FOEDAG has the following limitations:
- ``start_gui`` only triggers a toy Qt widget
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Replace the Qt widget with a Qt main window 

![image](https://user-images.githubusercontent.com/11499826/137612525-a0445be8-0dfe-4c40-ba5d-b20e2d5b64a4.png)


> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [x] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
