### PR TITLE
Now init.tcl will be copied to the binary directory once build is completed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,11 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib/libtcl9.0.a
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/third_party/tcl/unix"
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/tcl/generic/tcl.h
 )
+# Copy the init.tcl file from source to build directory
+add_custom_command(TARGET foedag POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy 
+          ${CMAKE_CURRENT_SOURCE_DIR}/third_party/tcl/library/init.tcl
+          ${CMAKE_CURRENT_BINARY_DIR}/lib/tcl9.0/init.tcl)
 add_dependencies(foedag tcl_build)
 
 

--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -59,8 +59,6 @@ static int GuiStartCmd(ClientData clientData, Tcl_Interp* interp, int argc,
 }
 
 static int Tcl_AppInit(Tcl_Interp* interp) {
-  int Mymodule_Init(Tcl_Interp*);
-
   //  interpreter.registerCmd("gui_start", GuiStartCmd, 0, nullptr);
   //  CommandStack commands(&interpreter);
 
@@ -70,9 +68,6 @@ static int Tcl_AppInit(Tcl_Interp* interp) {
 
   if (Tcl_Init(interp) == TCL_ERROR) return TCL_ERROR;
 
-  /* Now initialize our functions */
-  // if (Mymodule_Init(interp) == TCL_ERROR)
-  //  return TCL_ERROR;
   return TCL_OK;
 }
 


### PR DESCRIPTION


> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: 
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, FOEDAG has the following limitations:
- Tcl initialization failed due to the missing init.tcl file in the binary directory
```
alain@alain-xps:~/FOEDAG$ ./build/bin/foedag 
application-specific initialization failed: Can't find a usable init.tcl in the following directories: 
    /home/alain/FOEDAG/build/lib/tcl9.0 {} /home/alain/FOEDAG/build/lib/tcl9.0 /home/alain/FOEDAG/lib/tcl9.0 /home/alain/FOEDAG/build/library /home/alain/FOEDAG/library /home/alain/FOEDAG/tcl9.0/library /home/alain/FOEDAG/tcl9.0a4/library /home/alain/tcl9.0a4/library
```
> <!-- - [ ] more limitations  -->

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects: 
- [x] Update Cmakefile to copy the file from submodule to binary file
> <!-- - [ ] <more technical highlights -->
- [x] tested on both ``make`` and ``make install``

The warning message seen now is only 
```
tangxifan@DESKTOP-21ACCO4:~/FOEDAG$ foedag 
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-tangxifan'
% start_gui
```

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [x] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
