### PR TITLE
Make console single threaded and fix crash in replay mode (close #174)

### DIFF
--- a/src/Console/DummyParser.cpp
+++ b/src/Console/DummyParser.cpp
@@ -33,7 +33,6 @@ LineParser::Result DummyParser::handleLine(const QString &message,
   Q_UNUSED(format);
   const QRegularExpression getFile{"(?<=File: )(.*)(?= just)"};
   auto regExpMatch = getFile.match(message);
-  qDebug() << regExpMatch.hasMatch();
   if (regExpMatch.hasMatch()) {
     QString file = regExpMatch.captured();
     file.replace("\"", "");

--- a/src/Console/TclConsole.cpp
+++ b/src/Console/TclConsole.cpp
@@ -19,15 +19,11 @@ void TclConsole::registerInterpreter(TclInterp *interpreter) {
   m_tclWorkers.push_back(new TclWorker{interpreter, m_out});
 }
 
-TclConsole::~TclConsole() {
-  qDeleteAll(m_tclWorkers);
-  if (m_tclWorker->isRunning()) m_tclWorker->quit();
-  m_tclWorker->wait();
-}
+TclConsole::~TclConsole() { qDeleteAll(m_tclWorkers); }
 
 void TclConsole::run(const QString &command) {
   m_tclWorker->runCommand(command);
-  m_tclWorker->start();
+  m_tclWorker->run();
 }
 
 int TclConsole::returnCode() const { return m_tclWorker->returnCode(); }

--- a/src/Console/TclConsoleWidget.cpp
+++ b/src/Console/TclConsoleWidget.cpp
@@ -29,6 +29,7 @@ TclConsoleWidget::TclConsoleWidget(TclInterp *interp,
   setPrompt("# ");
   setTabAllowed(false);
   setMouseTracking(true);
+  setObjectName(consoleObjectName());
 }
 
 bool TclConsoleWidget::isRunning() const {
@@ -36,6 +37,10 @@ bool TclConsoleWidget::isRunning() const {
 }
 
 QString TclConsoleWidget::getPrompt() const { return prompt; }
+
+StreamBuffer *TclConsoleWidget::getBuffer() { return m_buffer; }
+
+const char *TclConsoleWidget::consoleObjectName() { return "TclConsole"; }
 
 void TclConsoleWidget::clearText() {
   clear();
@@ -50,9 +55,10 @@ QString TclConsoleWidget::interpretCommand(const QString &command, int *res) {
     QString histCommand;
     if (handleCommandFromHistory(command, histCommand))
       prepareCommand = histCommand;
+    QConsole::interpretCommand(prepareCommand, res);
     if (m_console) m_console->run(prepareCommand.toUtf8());
     setMultiLine(false);
-    return QConsole::interpretCommand(prepareCommand, res);
+    return QString();
   }
   return QString();
 }
@@ -136,7 +142,6 @@ void TclConsoleWidget::registerCommands(TclInterp *interp) {
   auto hist = [](ClientData clientData, Tcl_Interp *interp, int argc,
                  const char *argv[]) {
     TclConsoleWidget *console = static_cast<TclConsoleWidget *>(clientData);
-    if (!console) return TCL_ERROR;
     // Reset result data
     Tcl_ResetResult(interp);
 

--- a/src/Console/TclConsoleWidget.h
+++ b/src/Console/TclConsoleWidget.h
@@ -26,6 +26,8 @@ class TclConsoleWidget : public QConsole {
                             StreamBuffer *buffer, QWidget *parent = nullptr);
   bool isRunning() const override;
   QString getPrompt() const;
+  StreamBuffer *getBuffer();
+  static const char *consoleObjectName();
 
   State state() const;
 
@@ -57,7 +59,7 @@ class TclConsoleWidget : public QConsole {
   void mouseMoveEvent(QMouseEvent *e) override;
 
  private slots:
-  void put(const QString &str);
+  void put(const QString &str) override;
   void commandDone();
 
  private:

--- a/src/Console/TclWorker.cpp
+++ b/src/Console/TclWorker.cpp
@@ -33,7 +33,7 @@ int DriverBlockModeProc(ClientData instanceData, int mode) {
 }
 
 TclWorker::TclWorker(TclInterp *interpreter, std::ostream &out, QObject *parent)
-    : QThread(parent), m_interpreter(interpreter), m_out(out) {
+    : QObject(parent), m_interpreter(interpreter), m_out(out) {
   channelOut = new Tcl_ChannelType{
       "outconsole",
       CHANNEL_VERSION_5,
@@ -87,8 +87,8 @@ void TclWorker::setOutput(const QString &out) {
 }
 
 void TclWorker::init() {
-  static Tcl_Channel m_channel;
-  static Tcl_Channel errConsoleChannel;
+  static Tcl_Channel m_channel{nullptr};
+  static Tcl_Channel errConsoleChannel{nullptr};
 
   if (!m_channel) {
     m_channel = Tcl_CreateChannel(channelOut, "stdout",

--- a/src/Console/TclWorker.h
+++ b/src/Console/TclWorker.h
@@ -6,13 +6,13 @@
 
 namespace FOEDAG {
 
-class TclWorker : public QThread {
+class TclWorker : public QObject {
   Q_OBJECT
  public:
   TclWorker(TclInterp *interpreter, std::ostream &out,
             QObject *parent = nullptr);
 
-  void run() override;
+  void run();
   int returnCode() const;
   TclInterp *getInterpreter();
   std::ostream &out() { return m_out; }

--- a/src/Console/Test/ConsoleTestUtils.cpp
+++ b/src/Console/Test/ConsoleTestUtils.cpp
@@ -41,8 +41,9 @@ void sendCommand(const QString &command, QObject *receiver) {
 }
 
 TclConsoleWidget *InitConsole(void *clientData) {
-  FOEDAG::TclConsoleWidget *console =
-      static_cast<FOEDAG::TclConsoleWidget *>(clientData);
+  QWidget *w = static_cast<QWidget *>(clientData);
+  FOEDAG::TclConsoleWidget *console = w->findChild<FOEDAG::TclConsoleWidget *>(
+      FOEDAG::TclConsoleWidget::consoleObjectName());
   console->clearText();
   return console;
 }

--- a/src/Console/Test/console_test.cpp
+++ b/src/Console/Test/console_test.cpp
@@ -55,12 +55,14 @@ TCL_TEST(console_multiline) {
   FOEDAG::TclConsoleWidget *console = FOEDAG::InitConsole(clientData);
   QString script =
       R"(proc test {} {
-  puts test
+  debug test
 } 
 test
 )";
-  QString res = console->getPrompt() + script + console->getPrompt();
-  CHECK_EXPECTED(script, res)
+  const QString pt = console->getPrompt();
+  QString res =
+      pt + "proc test {} {\n  debug test\n} \n" + pt + "test\ntest\n" + pt;
+  CHECK_EXPECTED_FOR_FEW_COMMANDS(script, res, 2)
   return TCL_OK;
 }
 
@@ -80,20 +82,21 @@ TCL_TEST(console_cancel) {
 TCL_TEST(console_history) {
   FOEDAG::TclConsoleWidget *console = FOEDAG::InitConsole(clientData);
   QString command = R"(history clear
-proc test {} {
-puts test
+<pt>proc test {} {
+debug test
 }
-history
+<pt>history
 )";
 
   const QString pt = console->getPrompt();
-  QString result = pt + command + pt + "\n" +
+  QString script = command;
+  QString result = pt + command.replace("<pt>", pt) +
                    "1\tproc test {} {\n"
-                   "\tputs test\n"
+                   "\tdebug test\n"
                    "\t}\n"
                    "2\thistory\n" +
                    pt;
 
-  CHECK_EXPECTED_FOR_FEW_COMMANDS(command, result, 3)
+  CHECK_EXPECTED_FOR_FEW_COMMANDS(script.replace("<pt>", ""), result, 3)
   return TCL_OK;
 }

--- a/tests/TestGui/gui_console_proc.tcl
+++ b/tests/TestGui/gui_console_proc.tcl
@@ -18,11 +18,11 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 proc my1 {} {
-puts "Hello world1"
+debug "Hello world1"
 }
 
 proc my2 {} {
 my1
-puts "Hello world2"
+debug "Hello world2"
 }
 my2

--- a/third_party/QConsole/include/qconsole.h
+++ b/third_party/QConsole/include/qconsole.h
@@ -218,6 +218,9 @@ class QConsole : public QTextEdit {
   void setMultiLine(bool newMultiLine);
   int getPromptLength() const;
 
+ protected slots:
+  virtual void put(const QString &str);
+
  public Q_SLOTS:
   // Contextual menu slots
   void cut();

--- a/third_party/QConsole/src/qconsole.cpp
+++ b/third_party/QConsole/src/qconsole.cpp
@@ -629,18 +629,13 @@ bool QConsole::execCommand(const QString &command, bool writeCommand,
   // execute the command and get back its text result and its return value
   int res = 0;
   QString strRes = interpretCommand(modifiedCommand, &res);
-  // According to the return value, display the result either in red or in blue
-  if (res == 0)
-    setTextColor(outColor_);
-  else
-    setTextColor(errColor_);
 
   if (result) {
     *result = strRes;
   }
   if (!(strRes.isEmpty() || strRes.endsWith("\n"))) strRes.append("\n");
   if (command.isEmpty()) {  // prevent empty line after command
-    textCursor().insertText(strRes);
+    put(strRes);
     moveCursor(QTextCursor::End);
     // Display the prompt again
     if (showPrompt) displayPrompt();
@@ -690,6 +685,8 @@ void QConsole::setMultiLine(bool newMultiLine) { multiLine = newMultiLine; }
 int QConsole::getPromptLength() const {
   return isMultiLine() ? 0 : promptLength;
 }
+
+void QConsole::put(const QString &str) { textCursor().insertText(str); }
 
 // Implement paste with middle mouse button
 void QConsole::mousePressEvent(QMouseEvent *event) {


### PR DESCRIPTION
Close #174 
Make console single threaded and fixed crash when run in replay mode.

The **puts** command won't work in this case. So, for the tests I have replaces it with **debug** command for the redirection into the console widget.