### PR TITLE
Remove Tcl9.0 submodule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -296,7 +296,7 @@ jobs:
         # export Qt5_Dir=/mingw64/qt5-static/lib/cmake/Qt5/
         export Qt5_DIR=$Qt5_Dir
         export PATH=$Qt5_DIR:$PATH
-        make lib-only CPU_CORES=1
+        make lib-only
 # There are Qt linkage issues, so build only the libs for now        
 #        make VERBOSE=1 release
 #        make debug 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "third_party/tcl"]
-	path = third_party/tcl
-	url = https://github.com/tcltk/tcl
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,7 @@ endif()
 # Copy the init.tcl file from source to build directory
 add_custom_command(TARGET foedag POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy 
-          ${CMAKE_CURRENT_SOURCE_DIR}/third_party/tcl/library/init.tcl
+          ${CMAKE_CURRENT_SOURCE_DIR}/third_party/tcl8.6.12/library/init.tcl
           ${CMAKE_CURRENT_BINARY_DIR}/lib/tcl8.6/init.tcl)
 
 # Explicit lib build order

--- a/cmake/cmake_tcl.txt
+++ b/cmake/cmake_tcl.txt
@@ -18,10 +18,8 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-message("CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 
 if(MSVC)
-  message("WINDOWS MODE")
   set(TCL_STUBB_LIB tclstub86.lib)
   set(TCL_STATIC_LIB tcl86ts.lib)
   set(ZLIB_STATIC_LIB zlib.lib)
@@ -61,14 +59,12 @@ else()
   endif()  
 
   if(CMAKE_SYSTEM_NAME MATCHES "MSYS")
-    message("MSYS MODE")
     set(TCL_STATIC_LIB libtcl8.6.a)
     add_library(tcl_static STATIC IMPORTED )
     set_target_properties(tcl_static PROPERTIES
       IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/../../lib/${TCL_STATIC_LIB})
 
   else()
-    message("LINUX MODE")
     get_filename_component(buildDirRelFilePath ${TCL_STATIC_LIB}
                        REALPATH BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../lib)                   
     add_library(tcl_static SHARED IMPORTED )


### PR DESCRIPTION
We are now using Tcl8.6.12 which is supported by SWIG. Tcl9.0 is not supported by SWIG.
