### PR TITLE
Possible Settings Refactor

### DIFF
--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -125,6 +125,8 @@ install(
     FILES ${PROJECT_SOURCE_DIR}/../Main/CommandLine.h
     FILES ${PROJECT_SOURCE_DIR}/../Main/Foedag.h
     FILES ${PROJECT_SOURCE_DIR}/../Main/ToolContext.h
+    FILES ${PROJECT_SOURCE_DIR}/../Main/Settings.h
+    FILES ${PROJECT_SOURCE_DIR}/../Main/Tasks.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/foedag/Main/)
   
 install(

--- a/src/Main/Foedag.cpp
+++ b/src/Main/Foedag.cpp
@@ -124,11 +124,12 @@ static std::filesystem::path GetProgramNameAbsolutePath(const char* progname) {
 
 Foedag::Foedag(FOEDAG::CommandLine* cmdLine, MainWindowBuilder* mainWinBuilder,
                RegisterTclFunc* registerTclFunc, Compiler* compiler,
-               ToolContext* context)
+               Settings* settings, ToolContext* context)
     : m_cmdLine(cmdLine),
       m_mainWinBuilder(mainWinBuilder),
       m_registerTclFunc(registerTclFunc),
       m_compiler(compiler),
+      m_settings(settings),
       m_context(context) {
   if (context == nullptr)
     m_context = new ToolContext("Foedag", "OpenFPGA", "foedag");
@@ -157,7 +158,7 @@ bool Foedag::initGui() {
   QWidget* mainWin = nullptr;
 
   GlobalSession = new FOEDAG::Session(nullptr, interpreter, commands, m_cmdLine,
-                                      m_context, m_compiler);
+                                      m_context, m_compiler, m_settings);
   GlobalSession->setGuiType(GUI_TYPE::GT_WIDGET);
   if (m_mainWinBuilder) {
     mainWin = m_mainWinBuilder(GlobalSession);
@@ -241,7 +242,7 @@ bool Foedag::initQmlGui() {
   engine.load(url);
 
   GlobalSession = new FOEDAG::Session(nullptr, interpreter, commands, m_cmdLine,
-                                      m_context, m_compiler);
+                                      m_context, m_compiler, m_settings);
   GlobalSession->setGuiType(GUI_TYPE::GT_QML);
   GlobalSession->setWindowModel(windowModel);
 
@@ -321,8 +322,9 @@ bool Foedag::initBatch() {
   FOEDAG::TclInterpreter* interpreter =
       new FOEDAG::TclInterpreter(m_cmdLine->Argv()[0]);
   FOEDAG::CommandStack* commands = new FOEDAG::CommandStack(interpreter);
-  GlobalSession = new FOEDAG::Session(m_mainWin, interpreter, commands,
-                                      m_cmdLine, m_context, m_compiler);
+  GlobalSession =
+      new FOEDAG::Session(m_mainWin, interpreter, commands, m_cmdLine,
+                          m_context, m_compiler, m_settings);
   GlobalSession->setGuiType(GUI_TYPE::GT_NONE);
 
   registerBasicBatchCommands(GlobalSession);

--- a/src/Main/Foedag.h
+++ b/src/Main/Foedag.h
@@ -45,7 +45,8 @@ class Foedag {
  public:
   Foedag(FOEDAG::CommandLine* cmdLine, MainWindowBuilder* mainWinBuilder,
          RegisterTclFunc* registerTclFunc = nullptr,
-         Compiler* compiler = nullptr, ToolContext* context = nullptr);
+         Compiler* compiler = nullptr, Settings* settings = nullptr,
+         ToolContext* context = nullptr);
   virtual ~Foedag() = default;
 
   bool init(GUI_TYPE guiType);
@@ -66,6 +67,7 @@ class Foedag {
   RegisterTclFunc* m_registerTclFunc = nullptr;
   ToolContext* m_context = nullptr;
   Compiler* m_compiler = nullptr;
+  Settings* m_settings = nullptr;
 };
 
 }  // namespace FOEDAG

--- a/src/Main/Settings.cpp
+++ b/src/Main/Settings.cpp
@@ -9,15 +9,7 @@
 
 using namespace FOEDAG;
 
-Settings* Settings::m_instance = nullptr;
-Settings::Settings() { fprintf(stderr, "Settings Created\n"); }
-
-Settings* Settings::getInstance() {
-  if (!m_instance) {
-    m_instance = new Settings();
-  }
-  return m_instance;
-}
+Settings::Settings() {}
 
 void Settings::setValue(QJsonObject& parent, const QString& key,
                         const QJsonValue& value) {
@@ -25,7 +17,7 @@ void Settings::setValue(QJsonObject& parent, const QString& key,
 }
 
 void Settings::setValue(const QString& key, const QJsonValue& value) {
-  setValue(getInstance()->m_data, key, value);
+  setValue(m_data, key, value);
 }
 
 void Settings::setString(const QString& key, const QString& string) {
@@ -34,7 +26,7 @@ void Settings::setString(const QString& key, const QString& string) {
 }
 
 void Settings::updateJson(const QString& key, QJsonObject& newJson) {
-  updateJson(getInstance()->m_data, key, newJson);
+  updateJson(m_data, key, newJson);
 }
 
 void Settings::updateJson(QJsonObject& parent, const QString& key,
@@ -82,9 +74,7 @@ QJsonValue Settings::get(QJsonObject& parent, const QString& key) {
   return parent.value(key);
 }
 
-QJsonValue Settings::get(const QString& key) {
-  return getInstance()->m_data.value(key);
-}
+QJsonValue Settings::get(const QString& key) { return m_data.value(key); }
 
 QJsonValue Settings::getNested(QJsonObject& parent, const QString& keyPath,
                                const QString& pathSeparator) {
@@ -119,7 +109,7 @@ QJsonValue Settings::getNested(QJsonObject& parent, const QString& keyPath,
 
 QJsonValue Settings::getNested(const QString& keyPath,
                                const QString& pathSeparator) {
-  return getNested(getInstance()->m_data, keyPath, pathSeparator);
+  return getNested(m_data, keyPath, pathSeparator);
 }
 
 QString Settings::getJsonStr(const QJsonObject& object) {
@@ -128,10 +118,10 @@ QString Settings::getJsonStr(const QJsonObject& object) {
   return QString(jsonDoc.toJson(QJsonDocument::Indented));
 }
 
-QString Settings::getJsonStr() { return getJsonStr(getInstance()->m_data); }
+QString Settings::getJsonStr() { return getJsonStr(m_data); }
 
 void Settings::loadJsonFile(const QString& filePath, const QString& key) {
-  loadJsonFile(getInstance()->m_data, filePath, key);
+  loadJsonFile(m_data, filePath, key);
 }
 
 void Settings::loadJsonFile(QJsonObject& parent, const QString& filePath,

--- a/src/Main/Settings.h
+++ b/src/Main/Settings.h
@@ -10,33 +10,30 @@ namespace FOEDAG {
 
 class Settings {
  private:
-  Settings();
-
-  static Settings* m_instance;
   QJsonObject m_data;
 
  public:
-  static Settings* getInstance();
-  static void setValue(QJsonObject& parent, const QString& key,
-                       const QJsonValue& value);
-  static void setValue(const QString& key, const QJsonValue& value);
-  static void setString(const QString& key, const QString& string);
-  static void updateJson(const QString& key, QJsonObject& newJson);
-  static void updateJson(QJsonObject& parent, const QString& key,
-                         QJsonObject& newJson);
+  Settings();
+  void setValue(QJsonObject& parent, const QString& key,
+                const QJsonValue& value);
+  void setValue(const QString& key, const QJsonValue& value);
+  void setString(const QString& key, const QString& string);
+  void updateJson(const QString& key, QJsonObject& newJson);
+  void updateJson(QJsonObject& parent, const QString& key,
+                  QJsonObject& newJson);
 
-  static QJsonValue get(QJsonObject& parent, const QString& key);
-  static QJsonValue get(const QString& key);
-  static QJsonValue getNested(QJsonObject& parent, const QString& keyPath,
-                              const QString& pathSeparator = ".");
-  static QJsonValue getNested(const QString& keyPath,
-                              const QString& pathSeparator = ".");
-  static QString getJsonStr(const QJsonObject& object);
-  static QString getJsonStr();
+  QJsonValue get(QJsonObject& parent, const QString& key);
+  QJsonValue get(const QString& key);
+  QJsonValue getNested(QJsonObject& parent, const QString& keyPath,
+                       const QString& pathSeparator = ".");
+  QJsonValue getNested(const QString& keyPath,
+                       const QString& pathSeparator = ".");
+  QString getJsonStr(const QJsonObject& object);
+  QString getJsonStr();
 
-  static void loadJsonFile(const QString& filePath, const QString& key);
-  static void loadJsonFile(QJsonObject& parent, const QString& filePath,
-                           const QString& key);
+  void loadJsonFile(const QString& filePath, const QString& key);
+  void loadJsonFile(QJsonObject& parent, const QString& filePath,
+                    const QString& key);
 };
 
 }  // namespace FOEDAG

--- a/src/Main/Tasks.cpp
+++ b/src/Main/Tasks.cpp
@@ -7,18 +7,8 @@
 
 using namespace FOEDAG;
 
-Tasks* Tasks::m_instance = nullptr;
-Tasks::Tasks() { fprintf(stderr, "Tasks Created\n"); }
-
-Tasks* Tasks::getInstance() {
-  if (!m_instance) {
-    m_instance = new Tasks();
-  }
-  return m_instance;
-}
-
-void Tasks::getTasks() {
-  QJsonValue tasksVal = Settings::getNested("Settings.Tasks", ".");
+void FOEDAG::getTasks(Settings* settings) {
+  QJsonValue tasksVal = settings->getNested("Settings.Tasks", ".");
   if (tasksVal.isObject()) {
     qDebug() << "\nReading tasks w/ Settings::getNested(\"Settings.Tasks\"):";
 

--- a/src/Main/Tasks.h
+++ b/src/Main/Tasks.h
@@ -3,18 +3,11 @@
 #ifndef TASKS_H
 #define TASKS_H
 
+#include "Main/Settings.h"
+
 namespace FOEDAG {
 
-class Tasks {
- private:
-  Tasks();
-
-  static Tasks* m_instance;
-
- public:
-  static Tasks* getInstance();
-  static void getTasks();
-};
+void getTasks(Settings* settings);
 
 }  // namespace FOEDAG
 

--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -39,6 +39,7 @@ int main(int argc, char** argv) {
 
   FOEDAG::Compiler* compiler = nullptr;
   FOEDAG::CompilerOpenFPGA* opcompiler = nullptr;
+  FOEDAG::Settings* settings = new FOEDAG::Settings();
   if (cmd->CompilerName() == "openfpga") {
     opcompiler = new FOEDAG::CompilerOpenFPGA();
     compiler = opcompiler;
@@ -48,7 +49,7 @@ int main(int argc, char** argv) {
   }
 
   FOEDAG::Foedag* foedag = new FOEDAG::Foedag(
-      cmd, mainWindowBuilder, registerAllFoedagCommands, compiler);
+      cmd, mainWindowBuilder, registerAllFoedagCommands, compiler, settings);
   if (opcompiler) {
     const std::string& binpath = foedag->Context()->BinaryPath().string();
     opcompiler->YosysExecPath(binpath + "/yosys");

--- a/src/Main/registerTclCommands.cpp
+++ b/src/Main/registerTclCommands.cpp
@@ -237,27 +237,26 @@ void registerAllFoedagCommands(QWidget* widget, FOEDAG::Session* session) {
     if (FOEDAG::MainWindow* win = dynamic_cast<FOEDAG::MainWindow*>(widget)) {
       auto DemoSettingsFn = [](void* clientData, Tcl_Interp* interp, int argc,
                                const char* argv[]) -> int {
+        FOEDAG::Settings* settings = GlobalSession->GetSettings();
         qDebug() << "Storing version number under \"Version\"";
-        FOEDAG::Settings::setValue("Version", 0.1);
+        settings->setValue("Version", 0.1);
 
         qDebug() << "Example setting nested json";
         QJsonObject nested{{"nested", "test"}};
         QJsonObject val3{
             {"a", "1"}, {"b", 2}, {"c", 3.3}, {"nestTest", nested}};
-        FOEDAG::Settings::setValue("testing", val3);
-        fprintf(stderr, "Json: %s\n",
-                qPrintable(FOEDAG::Settings::getJsonStr()));
+        settings->setValue("testing", val3);
+        fprintf(stderr, "Json: %s\n", qPrintable(settings->getJsonStr()));
 
         QJsonObject nested2{{"nested", "test-replace"}};
         QJsonObject val4{
             {"a", "1_2"}, {"b", 6}, {"c", 8.8}, {"nestTest", nested2}};
-        FOEDAG::Settings::updateJson("testing", val4);
-        FOEDAG::Settings::updateJson("empty", val4);
+        settings->updateJson("testing", val4);
+        settings->updateJson("empty", val4);
 
         QJsonObject user{{"user_value", 3.5}};
-        FOEDAG::Settings::updateJson("empty", user);
-        fprintf(stderr, "Json: %s\n",
-                qPrintable(FOEDAG::Settings::getJsonStr()));
+        settings->updateJson("empty", user);
+        fprintf(stderr, "Json: %s\n", qPrintable(settings->getJsonStr()));
 
         // QString filepath =
         // "./dbuild/share/foedag/etc/settings/settings_test.json"; QString
@@ -266,25 +265,23 @@ void registerAllFoedagCommands(QWidget* widget, FOEDAG::Session* session) {
             "/usr/local/share/foedag/etc/settings/settings_test.json";
         qDebug() << "Load " << filepath
                  << " into \"Settings\" - "
-                    "FOEDAG::Settings::loadJsonFile(\""
+                    "settings->loadJsonFile(\""
                  << filepath
                  << "\", "
                     "\"Settings\")";
-        FOEDAG::Settings::loadJsonFile(filepath, "Settings");
+        settings->loadJsonFile(filepath, "Settings");
         fprintf(stderr, "Settings JSON after loadJsonFile(): %s\n",
-                qPrintable(FOEDAG::Settings::getJsonStr()));
+                qPrintable(settings->getJsonStr()));
 
-        qDebug() << "\nGet Test - FOEDAG::Settings::get(\"Version\");";
-        qDebug() << "\t" << FOEDAG::Settings::get("Version");
+        qDebug() << "\nGet Test - settings->get(\"Version\");";
+        qDebug() << "\t" << settings->get("Version");
 
-        qDebug()
-            << "\nGetNested Test - "
-               "FOEDAG::Settings::getNested(\"Settings.Tasks.Synth\", \".\");";
-        qDebug() << "\t"
-                 << FOEDAG::Settings::getNested("Settings.Tasks.Synth", ".");
+        qDebug() << "\nGetNested Test - "
+                    "settings->getNested(\"Settings.Tasks.Synth\", \".\");";
+        qDebug() << "\t" << settings->getNested("Settings.Tasks.Synth", ".");
 
         // Try reading some data
-        FOEDAG::Tasks::getTasks();
+        FOEDAG::getTasks(settings);
 
         return TCL_OK;
       };

--- a/src/MainWindow/Session.h
+++ b/src/MainWindow/Session.h
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Command/CommandStack.h"
 #include "Compiler/WorkerThread.h"
 #include "Main/CommandLine.h"
+#include "Main/Settings.h"
 #include "Main/ToolContext.h"
 #include "MainWindow/mainwindowmodel.h"
 #include "Tcl/TclInterpreter.h"
@@ -43,13 +44,15 @@ enum class GUI_TYPE { GT_NONE, GT_WIDGET, GT_QML };
 class Session {
  public:
   Session(QWidget *mainWindow, TclInterpreter *interp, CommandStack *stack,
-          CommandLine *cmdLine, ToolContext *context, Compiler *compiler)
+          CommandLine *cmdLine, ToolContext *context, Compiler *compiler,
+          Settings *settings)
       : m_mainWindow(mainWindow),
         m_interp(interp),
         m_stack(stack),
         m_cmdLine(cmdLine),
         m_context(context),
-        m_compiler(compiler) {
+        m_compiler(compiler),
+        m_settings(settings) {
     m_compiler->SetSession(this);
     m_compiler->SetInterpreter(interp);
   }
@@ -62,6 +65,7 @@ class Session {
   CommandLine *CmdLine() { return m_cmdLine; }
   ToolContext *Context() { return m_context; }
   Compiler *GetCompiler() { return m_compiler; }
+  Settings *GetSettings() { return m_settings; }
   void windowShow();
   void windowHide();
 
@@ -81,6 +85,7 @@ class Session {
   FOEDAG::GUI_TYPE m_guiType = GUI_TYPE::GT_NONE;
   ToolContext *m_context = nullptr;
   Compiler *m_compiler = nullptr;
+  Settings *m_settings = nullptr;
   int m_returnStatus =
       0;  // When running in batch mode, executable returned status
 };

--- a/src/NewFile/Test/newfile_main.cpp
+++ b/src/NewFile/Test/newfile_main.cpp
@@ -43,12 +43,13 @@ int main(int argc, char** argv) {
   cmd->processArgs();
 
   FOEDAG::Compiler* compiler = new FOEDAG::Compiler();
+  FOEDAG::Settings* settings = new FOEDAG::Settings();
 
   FOEDAG::GUI_TYPE guiType =
       FOEDAG::Foedag::getGuiType(cmd->WithQt(), cmd->WithQml());
 
   FOEDAG::Foedag* foedag = new FOEDAG::Foedag(
-      cmd, newFileBuilder, registerNewFileCommands, compiler);
+      cmd, newFileBuilder, registerNewFileCommands, compiler, settings);
 
   return foedag->init(guiType);
 }

--- a/src/NewProject/Main/newproject_main.cpp
+++ b/src/NewProject/Main/newproject_main.cpp
@@ -37,12 +37,13 @@ int main(int argc, char** argv) {
   cmd->processArgs();
 
   FOEDAG::Compiler* compiler = new FOEDAG::Compiler();
+  FOEDAG::Settings* settings = new FOEDAG::Settings();
 
   FOEDAG::GUI_TYPE guiType =
       FOEDAG::Foedag::getGuiType(cmd->WithQt(), cmd->WithQml());
 
   FOEDAG::Foedag* foedag = new FOEDAG::Foedag(
-      cmd, newProjectBuilder, registerNewProjectCommands, compiler);
+      cmd, newProjectBuilder, registerNewProjectCommands, compiler, settings);
 
   return foedag->init(guiType);
 }

--- a/src/ProjNavigator/Test/projnavigator_main.cpp
+++ b/src/ProjNavigator/Test/projnavigator_main.cpp
@@ -48,12 +48,14 @@ int main(int argc, char** argv) {
   cmd->processArgs();
 
   FOEDAG::Compiler* compiler = new FOEDAG::Compiler();
+  FOEDAG::Settings* settings = new FOEDAG::Settings();
 
   FOEDAG::GUI_TYPE guiType =
       FOEDAG::Foedag::getGuiType(cmd->WithQt(), cmd->WithQml());
 
-  FOEDAG::Foedag* foedag = new FOEDAG::Foedag(
-      cmd, proNavigatorBuilder, registerProjNavigatorCommands, compiler);
+  FOEDAG::Foedag* foedag =
+      new FOEDAG::Foedag(cmd, proNavigatorBuilder,
+                         registerProjNavigatorCommands, compiler, settings);
 
   return foedag->init(guiType);
 }

--- a/src/TextEditor/Test/texteditor_main.cpp
+++ b/src/TextEditor/Test/texteditor_main.cpp
@@ -36,12 +36,14 @@ int main(int argc, char** argv) {
   cmd->processArgs();
 
   FOEDAG::Compiler* compiler = new FOEDAG::Compiler();
+  FOEDAG::Settings* settings = new FOEDAG::Settings();
 
   FOEDAG::GUI_TYPE guiType =
       FOEDAG::Foedag::getGuiType(cmd->WithQt(), cmd->WithQml());
 
   FOEDAG::Foedag* foedag = new FOEDAG::Foedag(
-      cmd, textEditorBuilder, FOEDAG::registerTextEditorCommands, compiler);
+      cmd, textEditorBuilder, FOEDAG::registerTextEditorCommands, compiler,
+      settings);
 
   return foedag->init(guiType);
 }


### PR DESCRIPTION
Per a conversation regarding singleton use in the previous settings PR (https://github.com/os-fpga/FOEDAG/pull/319#discussion_r861167792), I've refactored the settings object to remove singleton and static elements and instead tried to copy the way data is passed around in the Session class.

@alain-rs & @volodymyrkochyn does this look like a better approach to you?

I had to touch a lot more files with this approach which makes me feel like it's a bit more tightly coupled, but wanted to get your opinion.

I also had to re-arrange the order of the last parameters on FOEDAG::Foedag() instantiation as ToolContext is passed w/ a default arg and not provided in a number of our instantiations.

Leaving this as a draft PR for now to make sure this is a desired change.
