### PR TITLE
Remove TCL default prompt from console

### DIFF
--- a/src/Console/TclWorker.cpp
+++ b/src/Console/TclWorker.cpp
@@ -86,6 +86,9 @@ TclWorker::TclWorker(TclInterp *interpreter, std::ostream &out,
       nullptr /*DriverThreadAction*/,
       nullptr /*DriverTruncate*/,
   };
+
+  // set to nullptr stdin to avoid prompt from TCL.
+  Tcl_SetStdChannel(nullptr, TCL_STDIN);
   init();
 }
 


### PR DESCRIPTION
Remove input channel from TCL to avoid default prompt when custom console is created.

![image](https://user-images.githubusercontent.com/95262932/167624028-2757de98-1202-4a12-8120-c1b014b6b479.png)
