### PR TITLE
Rework project navigator.

### DIFF
--- a/src/ProjNavigator/sources_form.h
+++ b/src/ProjNavigator/sources_form.h
@@ -83,6 +83,14 @@ class SourcesForm : public QWidget {
 
   void CreateActions();
   void UpdateSrcHierachyTree();
+  void CreateFolderHierachyTree();
+  static QTreeWidgetItem* CreateFolderHierachyTree(QTreeWidgetItem* topItem,
+                                                   const QString& path);
+  static QTreeWidgetItem* CreateParentFolderItem(QTreeWidgetItem* parent,
+                                                 const QString& text);
+  static QTreeWidgetItem* ChildByText(QTreeWidgetItem* topItem,
+                                      const QString& text);
+  static QString StripPath(const QString& path);
 };
 }  // namespace FOEDAG
 


### PR DESCRIPTION
Files from the project folder are shown with folder tree.
Files outside the project are shown with full path (close #342)
![files_inside_project](https://user-images.githubusercontent.com/95262932/169053565-90f7e5ad-38ee-4cba-a065-58b1414f24b1.png)
![files_outside_project](https://user-images.githubusercontent.com/95262932/169053590-56c857a6-b346-4328-a195-18b59f3ba72a.png)

