### PR TITLE
Adding persistence to task settings dialog system

### DIFF
--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -1,7 +1,50 @@
 {
     "Tasks": {
-        "Synthesis": {
-            "synth_dropdown_ex": {
+        "Example": {
+            "double_spinbox_ex": {
+                "label": "Double Spinbox Example",
+                "widgetType": "DoubleSpinbox",
+                "minVal": 2.4,
+                "maxVal": 11.4,
+                "stepVal": 1.1,
+                "default": 2.5
+            },
+            "int_spinbox_ex": {
+                "label": "Int Spinbox Example",
+                "widgetType": "Spinbox",
+                "minVal": 2.4,
+                "maxVal": 11.4,
+                "stepVal": 1.1,
+                "default": 2.5
+            },
+            "radiobuttons_vert_ex": {
+                "label": "Radio Button Example (vertical/default)",
+                "widgetType": "radiobuttons",
+                "options": [
+                    "b1",
+                    "b2",
+                    "b3"
+                ],
+                "default": "b2"
+            },
+            "radiobuttons_horiz_ex": {
+                "label": "Radio Button Example (horizontal)",
+                "widgetType": "radiobuttons",
+                "options": [
+                    "b1",
+                    "b2",
+                    "b3"
+                ],
+                "layout": "horizontal",
+                "default": "b2"
+            },
+            "checkbox_ex": {
+                "label": "Checkbox Example",
+                "text": "Checkbox Text",
+                "widgetType": "checkbox",
+                "default": "unchecked"
+            },
+            "dropdown_ex": {
                 "label": "Dropdown Example",
                 "widgetType": "dropdown",
                 "options": [
@@ -9,16 +52,29 @@
                     "option2",
                     "option3"
                 ],
-                "default": "option3"
+                "default": "option2"
             },
-            "synth_input_ex_1": {
+            "input_ex_1": {
                 "label": "Text Input Example",
                 "widgetType": "input",
-                "default": "some synthesis related text"
+                "default": "some text"
             },
-            "synth_input_ex_2": {
+            "input_ex_2": {
                 "widgetType": "input",
                 "default": "input field w/o a label provided"
+            }
+        },
+        "Synthesis": {
+            "opt_dropdown": {
+                "label": "Optimization",
+                "widgetType": "dropdown",
+                "options": [
+                    "Mixed",
+                    "Array",
+                    "Delay",
+                    "None"
+                ],
+                "default": "None"
             }
         },
         "Placement": {
@@ -63,7 +119,7 @@
                 "label": "Checkbox Example",
                 "text": "Checkbox Text",
                 "widgetType": "checkbox",
-                "default": "unchecked"
+                "default": "checked"
             },
             "placement_dropdown_ex": {
                 "label": "Dropdown Example",

--- a/src/Compiler/CompilerDefines.cpp
+++ b/src/Compiler/CompilerDefines.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QHeaderView>
 
 #include "Compiler.h"
+#include "Main/Tasks.h"
 #include "TaskManager.h"
 #include "TaskModel.h"
 #include "TaskTableView.h"
@@ -33,6 +34,8 @@ QWidget *FOEDAG::prepareCompilerView(Compiler *compiler,
   TaskManager *tManager = new TaskManager;
   TaskModel *model = new TaskModel{tManager};
   TaskTableView *view = new TaskTableView{tManager};
+  QObject::connect(view, &TaskTableView::TaskDialogRequested,
+                   FOEDAG::handleTaskDialogRequested);
   view->setModel(model);
 
   view->setColumnWidth(0, 30);

--- a/src/Compiler/CompilerDefines.h
+++ b/src/Compiler/CompilerDefines.h
@@ -53,6 +53,7 @@ static constexpr uint UserActionRole = Qt::UserRole + 1;
 static constexpr uint ExpandAreaRole = Qt::UserRole + 2;
 static constexpr uint RowVisibilityRole = Qt::UserRole + 3;
 static constexpr uint ParentDataRole = Qt::UserRole + 4;
+static constexpr uint TaskTypeRole = Qt::UserRole + 5;
 
 /*!
  * \brief prepareCompilerView

--- a/src/Compiler/Task.cpp
+++ b/src/Compiler/Task.cpp
@@ -51,6 +51,12 @@ void Task::setStatus(TaskStatus newStatus) {
   }
 }
 
+TaskType Task::type() const { return m_type; }
+void Task::setTaskType(TaskType newType) { m_type = newType; }
+
+QString Task::settingsKey() const { return m_settings_key; }
+void Task::setSettingsKey(QString key) { m_settings_key = key; }
+
 void Task::trigger() {
   if (m_status != TaskStatus::InProgress) emit taskTriggered();
 }

--- a/src/Compiler/Task.h
+++ b/src/Compiler/Task.h
@@ -34,6 +34,12 @@ enum class TaskStatus {
   Fail,
 };
 
+enum class TaskType {
+  None,
+  Action,
+  Settings,
+};
+
 /*!
  * \brief The Task class
  * Implements task entity.
@@ -51,6 +57,12 @@ class Task : public QObject {
 
   TaskStatus status() const;
   void setStatus(TaskStatus newStatus);
+
+  TaskType type() const;
+  void setTaskType(TaskType newType);
+
+  QString settingsKey() const;
+  void setSettingsKey(QString key);
 
   /*!
    * \brief trigger
@@ -88,7 +100,9 @@ class Task : public QObject {
 
  private:
   QString m_title;
+  QString m_settings_key;
   TaskStatus m_status{TaskStatus::None};
+  TaskType m_type{TaskType::Action};
   QVector<Task *> m_subTask;
   Task *m_parent{nullptr};
   bool m_valid{false};

--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -52,6 +52,13 @@ TaskManager::TaskManager(QObject *parent) : QObject{parent} {
   m_tasks[ROUTING]->appendSubTask(m_tasks[ROUTING_SETTINGS]);
   m_tasks[ROUTING]->appendSubTask(m_tasks[ROUTING_WRITE_NETLIST]);
 
+  m_tasks[SYNTHESIS_SETTINGS]->setTaskType(TaskType::Settings);
+  m_tasks[SYNTHESIS_SETTINGS]->setSettingsKey("Synthesis");
+  m_tasks[PLACEMENT_SETTINGS]->setTaskType(TaskType::Settings);
+  m_tasks[PLACEMENT_SETTINGS]->setSettingsKey("Placement");
+  m_tasks[ROUTING_SETTINGS]->setTaskType(TaskType::Settings);
+  m_tasks[ROUTING_SETTINGS]->setSettingsKey("Routing");
+
   for (auto task = m_tasks.begin(); task != m_tasks.end(); task++) {
     connect((*task), &Task::statusChanged, this,
             &TaskManager::taskStateChanged);

--- a/src/Compiler/TaskModel.cpp
+++ b/src/Compiler/TaskModel.cpp
@@ -97,6 +97,10 @@ QVariant TaskModel::data(const QModelIndex &index, int role) const {
     if (auto task = m_taskManager->task(index.row())) {
       return task->parentTask() != nullptr;
     }
+  } else if (role == TaskTypeRole) {
+    if (auto task = m_taskManager->task(index.row())) {
+      return QVariant((uint)task->type());
+    }
   }
   return QVariant();
 }

--- a/src/Compiler/TaskTableView.h
+++ b/src/Compiler/TaskTableView.h
@@ -61,6 +61,9 @@ class TaskTableView : public QTableView {
   void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
                    const QVector<int> &roles = QVector<int>()) override;
 
+ signals:
+  void TaskDialogRequested(const QString &category);
+
  private:
   QRect expandArea(const QModelIndex &index) const;
 

--- a/src/Main/Foedag.cpp
+++ b/src/Main/Foedag.cpp
@@ -87,19 +87,6 @@ bool getFullPath(const std::filesystem::path& path,
   return found;
 }
 
-void loadSettings(FOEDAG::Settings* settings) {
-  if (settings) {
-    const std::string separator(1, std::filesystem::path::preferred_separator);
-    std::string settingsPath = Config::Instance()->dataPath().string() +
-                               separator + std::string("etc") + separator +
-                               std::string("settings") + separator;
-    QString settingsDir = QString::fromStdString(settingsPath);
-
-    QStringList settingsFiles = {settingsDir + "settings_test.json"};
-    settings->loadSettings(settingsFiles);
-  }
-}
-
 // Try to find the full absolute path of the program currently running.
 static std::filesystem::path GetProgramNameAbsolutePath(const char* progname) {
 #if defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__)
@@ -172,8 +159,6 @@ bool Foedag::initGui() {
       new FOEDAG::CommandStack(interpreter, logFile);
   Config::Instance()->dataPath(m_context->DataPath());
   QWidget* mainWin = nullptr;
-
-  loadSettings(m_settings);
 
   GlobalSession = new FOEDAG::Session(nullptr, interpreter, commands, m_cmdLine,
                                       m_context, m_compiler, m_settings);

--- a/src/Main/Settings.cpp
+++ b/src/Main/Settings.cpp
@@ -24,9 +24,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QFile>
 #include <iostream>
 
+#include "NewProject/ProjectManager/config.h"
+
 using namespace FOEDAG;
 
+#define SETTINGS_DEBUG false
+auto DBG_PRINT = [](std::string printStr) {
+  if (SETTINGS_DEBUG) {
+    std::cout << printStr << std::flush;
+  }
+};
+
 Settings::Settings() {}
+
+void Settings::clear() {
+  m_json.clear();
+  DBG_PRINT("Settings: Cleared\n");
+}
 
 void Settings::loadSettings(const QStringList& jsonFiles) {
   for (const QString& filepath : jsonFiles) {
@@ -40,6 +54,14 @@ QString Settings::getJsonStr(const json& object) {
 
 QString Settings::getJsonStr() { return getJsonStr(m_json); }
 
+QString Settings::getSystemDefaultSettingsDir() {
+  const std::string separator(1, std::filesystem::path::preferred_separator);
+  std::string settingsPath = Config::Instance()->dataPath().string() +
+                             separator + std::string("etc") + separator +
+                             std::string("settings") + separator;
+  return QString::fromStdString(settingsPath);
+}
+
 void Settings::loadJsonFile(const QString& filePath) {
   loadJsonFile(&m_json, filePath);
 }
@@ -52,8 +74,10 @@ void Settings::loadJsonFile(json* jsonObject, const QString& filePath) {
     // Read/parse json from file and update the passed jsonObject w/ new vals
     QString jsonStr = jsonFile.readAll();
 
+    DBG_PRINT("Settings: Loading " + filePath.toStdString() + "\n");
     try {
-      jsonObject->update(json::parse(jsonStr.toStdString()));
+      // Merge the json
+      jsonObject->update(json::parse(jsonStr.toStdString()), true);
     } catch (json::parse_error& e) {
       // output exception information
       std::cerr << "Json Error: " << e.what() << '\n'

--- a/src/Main/Settings.h
+++ b/src/Main/Settings.h
@@ -44,12 +44,15 @@ class Settings {
 
  public:
   Settings();
+  void clear();
   void loadSettings(const QStringList& jsonFiles);
   QString getJsonStr(const json& object);
   QString getJsonStr();
+  QString getSystemDefaultSettingsDir();
 
   void loadJsonFile(const QString& filePath);
   void loadJsonFile(json* jsonObject, const QString& filePath);
+  void saveJsonFile(const json& jsonObject, const QString& filePath);
 
   json& getJson() { return m_json; }
 };

--- a/src/Main/Tasks.cpp
+++ b/src/Main/Tasks.cpp
@@ -21,15 +21,98 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Tasks.h"
 
+#include <QDir>
+#include <QFileInfo>
+#include <QTextStream>
+
 #include "Foedag.h"
+#include "Settings.h"
 #include "WidgetFactory.h"
 
 using namespace FOEDAG;
 
-QDialog* FOEDAG::createTaskDialog(const QString& taskName) {
-  // Get widget parameters from json settings
-  json& widgetsJson =
-      GlobalSession->GetSettings()->getJson()["Tasks"][taskName.toStdString()];
+#define TASKS_KEY "Tasks"
 
-  return createSettingsDialog(widgetsJson, "Edit " + taskName + " Settings");
+#define TASKS_DEBUG false
+auto DBG_PRINT = [](std::string printStr) {
+  if (TASKS_DEBUG) {
+    std::cout << printStr << std::flush;
+  }
+};
+
+QDialog* FOEDAG::createTaskDialog(const QString& taskName) {
+  FOEDAG::Settings* settings = GlobalSession->GetSettings();
+  QDialog* dlg = nullptr;
+  if (settings) {
+    // Get widget parameters from json settings
+    json& widgetsJson = settings->getJson()[TASKS_KEY][taskName.toStdString()];
+
+    // Create dialog
+    dlg = createSettingsDialog(widgetsJson, "Edit " + taskName + " Settings");
+
+    QObject::connect(dlg, &QDialog::accepted, [dlg, taskName]() {
+      // Find the settings widget contained by the dialog
+      QRegularExpression regex(".*" + QString(SETTINGS_WIDGET_SUFFIX));
+      auto settingsWidget = dlg->findChildren<QWidget*>(regex);
+
+      // If we found a settings widget
+      if (settingsWidget.count() > 0) {
+        // Look up changed value json
+        QString patch = settingsWidget[0]->property("userPatch").toString();
+        if (!patch.isEmpty()) {
+          // Create the parent json structure and add userPatch data
+          json cleanJson;
+          cleanJson[TASKS_KEY][taskName.toStdString()] =
+              json::parse(patch.toStdString());
+
+          // Create user settings dir
+          QString userDir = getTaskUserSettingsPath();
+          // A user setting dir only exists when a project has been loaded so
+          // ignore saving when there isn't a project
+          if (!userDir.isEmpty()) {
+            QFileInfo filepath(userDir + TASKS_KEY + "_" + taskName + ".json");
+            QDir dir;
+            dir.mkpath(filepath.dir().path());
+
+            // Save settings for this specific Task category
+            QFile file(filepath.filePath());
+            if (file.open(QFile::WriteOnly)) {
+              QTextStream out(&file);
+              out << QString::fromStdString(cleanJson.dump());
+
+              DBG_PRINT("Saving Tasks: user values saved to " +
+                        filepath.filePath().toStdString() + "\n");
+            }
+          } else {
+            DBG_PRINT("Saving Tasks: No user settings path, skipping save.\n");
+          }
+        }
+      }
+    });
+  }
+
+  return dlg;
+}
+
+QString FOEDAG::getTaskUserSettingsPath() {
+  QString path;
+  QString projPath =
+      GlobalSession->GetCompiler()->ProjManager()->getProjectPath();
+  QString projName =
+      GlobalSession->GetCompiler()->ProjManager()->getProjectName();
+  QString separator = QString::fromStdString(
+      std::string(1, std::filesystem::path::preferred_separator));
+
+  if (!projPath.isEmpty() && !projName.isEmpty()) {
+    path = projPath + separator + projName + ".settings/";
+  }
+
+  return path;
+}
+
+void FOEDAG::handleTaskDialogRequested(const QString& category) {
+  QDialog* dlg = createTaskDialog(category);
+  if (dlg) {
+    dlg->exec();
+  }
 }

--- a/src/Main/Tasks.h
+++ b/src/Main/Tasks.h
@@ -22,11 +22,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef TASKS_H
 #define TASKS_H
 
-#include <QWidget>
+#include <QDialog>
 
 namespace FOEDAG {
 
 QDialog* createTaskDialog(const QString& taskName);
+QString getTaskUserSettingsPath();
+void handleTaskDialogRequested(const QString& category);
 
 }  // namespace FOEDAG
 

--- a/src/Main/WidgetFactory.cpp
+++ b/src/Main/WidgetFactory.cpp
@@ -26,10 +26,32 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QMetaEnum>
+#include <iostream>
 
 using namespace FOEDAG;
 
 const QString DlgBtnBoxName{"SettingsDialogButtonBox"};
+
+// Local debug helpers
+#define WIDGET_FACTORY_DEBUG false
+auto DBG_PRINT = [](std::string printStr) {
+  if (WIDGET_FACTORY_DEBUG) {
+    std::cout << printStr << std::flush;
+  }
+};
+auto DBG_PRINT_VAL_SET = [](const QObject* obj, const QString& userVal) {
+  std::string dbgStr = std::string(obj->metaObject()->className()) +
+                       ": setting user value -> " + userVal.toStdString() +
+                       "\n";
+  DBG_PRINT(dbgStr);
+};
+auto DBG_PRINT_JSON_PATCH = [](const QObject* obj, const std::string& valStr) {
+  if (WIDGET_FACTORY_DEBUG) {
+    std::cout << "Setting json[\"jsonPatch\"] = " << valStr << " for "
+              << obj->objectName().toStdString() << "("
+              << obj->metaObject()->className() << ")" << std::endl;
+  }
+};
 
 // Local helper function to convert a nlohmann::json array of std::strings to
 // QStringLists This assumes the json object contains an array of strings
@@ -42,13 +64,15 @@ QStringList JsonArrayToQStringList(const json& jsonArray) {
   return strings;
 }
 
-template <typename T>
-T getUserValOrDefault(const json& jsonObj) {
-  T val = jsonObj["default"].get<T>();
-  if (jsonObj.contains("userValue")) {
-    val = jsonObj["userValue"].get<T>();
-  }
+void storeJsonPatch(QObject* obj, const json& patch) {
+  DBG_PRINT_JSON_PATCH(obj, patch.dump());
+  obj->setProperty("changed", true);
+  obj->setProperty("jsonPatch", QString::fromStdString(patch.dump()));
+}
 
+template <typename T>
+T getDefault(const json& jsonObj) {
+  T val = jsonObj["default"].get<T>();
   return val;
 }
 
@@ -60,6 +84,7 @@ QDialog* FOEDAG::createSettingsDialog(
   dlg->setAttribute(Qt::WA_DeleteOnClose);
   dlg->setWindowTitle(dialogTitle);
   QVBoxLayout* layout = new QVBoxLayout();
+  layout->setContentsMargins(0, 0, 0, 0);
   dlg->setLayout(layout);
 
   QWidget* task = FOEDAG::createSettingsWidget(widgetsJson, objectNamePrefix);
@@ -83,7 +108,7 @@ QWidget* FOEDAG::createSettingsWidget(json& widgetsJson,
   // Create a parent widget to contain all generated widgets
   QWidget* widget = new QWidget();
 
-  widget->setObjectName(objNamePrefix + "SettingsWidget");
+  widget->setObjectName(objNamePrefix + SETTINGS_WIDGET_SUFFIX);
   QVBoxLayout* VLayout = new QVBoxLayout();
   widget->setLayout(VLayout);
 
@@ -101,19 +126,24 @@ QWidget* FOEDAG::createSettingsWidget(json& widgetsJson,
 
   // This will collect value changes for each widget/setting, save those
   // settings to a user file and add the changes to the passed in settings
-  auto checkVals = [VLayout, &widgetsJson]() {
+  auto checkVals = [VLayout, &widgetsJson, widget]() {
     bool save = false;
     QHash<QString, QString> patchHash;
     for (int i = 0; i < VLayout->count(); i++) {
-      QWidget* widget = VLayout->itemAt(i)->widget();
-      if (widget) {
+      QWidget* settingsWidget = VLayout->itemAt(i)->widget();
+      if (settingsWidget) {
         QObject* targetObject =
-            qvariant_cast<QObject*>(widget->property("targetObject"));
+            qvariant_cast<QObject*>(settingsWidget->property("targetObject"));
 
         if (targetObject && targetObject->property("changed").toBool()) {
           save = true;
-          QString settingsId = widget->property("settingsId").toString();
+          QString settingsId =
+              settingsWidget->property("settingsId").toString();
           QString patchStr = targetObject->property("jsonPatch").toString();
+
+          DBG_PRINT("createSettingsWidget: saving value " +
+                    settingsId.toStdString() + " -> " + patchStr.toStdString() +
+                    "\n");
 
           patchHash[settingsId] = patchStr;
         }
@@ -122,6 +152,7 @@ QWidget* FOEDAG::createSettingsWidget(json& widgetsJson,
 
     // Step through each child patch and apply it to the original settings json
     QHashIterator<QString, QString> patch(patchHash);
+    json changes;
     while (patch.hasNext()) {
       patch.next();
 
@@ -129,16 +160,22 @@ QWidget* FOEDAG::createSettingsWidget(json& widgetsJson,
         std::string patchIdStr = patch.key().toStdString();
         std::string patchStr = patch.value().toStdString();
 
+        // Store clean json changes
+        changes[patchIdStr].merge_patch(json::parse(patchStr));
+
+        // Store json changes in the passed in widgetsJson
         widgetsJson[patchIdStr].merge_patch(json::parse(patchStr));
       }
     }
 
+    // If there were changes to save, store all the json changes in a property
+    // that can be retrieved and saved by whomever called this
     if (save) {
-      // sma save not yet implemented
-      // settings->saveJsonFile("./saveTest.json");
+      widget->setProperty("userPatch", QString::fromStdString(changes.dump()));
     }
   };
 
+  // Check and store value changes if the dialog is accepted
   QObject::connect(btnBox, &QDialogButtonBox::accepted, widget, checkVals);
 
   return widget;
@@ -178,58 +215,59 @@ QWidget* FOEDAG::createWidget(const json& widgetJsonObj,
     // Get widget type and create respective widget if it's supported
     if (type == "input" || type == "lineedit") {
       // QLineEdit - "input" or "lineedit"
+      QString sysDefaultVal =
+          QString::fromStdString(getDefault<std::string>(widgetJsonObj));
 
-      // QString defaultVal = getStr(widgetJsonObj, "default");
-      QString defaultVal = QString::fromStdString(
-          getUserValOrDefault<std::string>(widgetJsonObj));
+      // Callback to handle value changes
+      std::function<void(QLineEdit*, const QString&)> handleChange =
+          [](QLineEdit* ptr, const QString& val) {
+            json changeJson;
+            changeJson["userValue"] = ptr->text().toStdString();
+            storeJsonPatch(ptr, changeJson);
+          };
 
-      auto ptr = createLineEdit(objName, defaultVal);
+      // Create our widget
+      auto ptr = createLineEdit(objName, sysDefaultVal, handleChange);
       createdWidget = ptr;
 
-      // Add value change tracking
-      auto initialVal = ptr->text();
-      QObject::connect(ptr, &QLineEdit::textChanged,
-                       [widgetJsonObj, ptr, initialVal](const QString& val) {
-                         bool changed = (val != initialVal);
-                         ptr->setProperty("changed", changed);
-                         if (changed) {
-                           // store value changes as a json string in the
-                           // widget's property system
-                           json changeJson;
-                           changeJson["userValue"] = ptr->text().toStdString();
-                           ptr->setProperty(
-                               "jsonPatch",
-                               QString::fromStdString(changeJson.dump()));
-                         }
-                       });
+      // Load and set user value
+      if (widgetJsonObj.contains("userValue")) {
+        QString userVal = QString::fromStdString(
+            widgetJsonObj["userValue"].get<std::string>());
+        ptr->setText(userVal);
+
+        DBG_PRINT_VAL_SET(ptr, userVal);
+      }
 
       targetObject = createdWidget;
     } else if (type == "dropdown" || type == "combobox") {
       // QComboBox - "dropdown" or "combobox"
-      QString defaultVal = QString::fromStdString(
-          getUserValOrDefault<std::string>(widgetJsonObj));
+      QString sysDefaultVal =
+          QString::fromStdString(getDefault<std::string>(widgetJsonObj));
       QStringList comboOptions =
           JsonArrayToQStringList(widgetJsonObj["options"]);
-      auto ptr = createComboBox(objName, comboOptions, defaultVal);
+
+      // Callback to handle value changes
+      std::function<void(QComboBox*, const QString&)> handleChange =
+          [](QComboBox* ptr, const QString& val) {
+            json changeJson;
+            changeJson["userValue"] = ptr->currentText().toStdString();
+            storeJsonPatch(ptr, changeJson);
+          };
+
+      // Create Widget
+      auto ptr =
+          createComboBox(objName, comboOptions, sysDefaultVal, handleChange);
       createdWidget = ptr;
 
-      // Add value change tracking
-      auto initialVal = ptr->currentIndex();
-      QObject::connect(
-          ptr, qOverload<int>(&QComboBox::currentIndexChanged),
-          [ptr, initialVal](int val) {
-            //  changeJson.emplace( "userValue", ptr->currentText() );
-            bool changed = (val != initialVal);
-            ptr->setProperty("changed", changed);
-            if (changed) {
-              // store value changes as a json string in the widget's property
-              // system
-              json changeJson;
-              changeJson["userValue"] = ptr->currentText().toStdString();
-              ptr->setProperty("jsonPatch",
-                               QString::fromStdString(changeJson.dump()));
-            }
-          });
+      // Load and set user value
+      if (widgetJsonObj.contains("userValue")) {
+        QString userVal = QString::fromStdString(
+            widgetJsonObj["userValue"].get<std::string>());
+        ptr->setCurrentText(userVal);
+
+        DBG_PRINT_VAL_SET(ptr, userVal);
+      }
 
       targetObject = createdWidget;
     } else if (type == "spinbox") {
@@ -238,27 +276,29 @@ QWidget* FOEDAG::createWidget(const json& widgetJsonObj,
       int maxVal =
           widgetJsonObj.value("maxVal", std::numeric_limits<int>::max());
       int stepVal = widgetJsonObj.value("stepVal", 1);
-      // int defaultVal = widgetJsonObj.value("default", 0);
-      int defaultVal = getUserValOrDefault<int>(widgetJsonObj);
-      auto ptr = createSpinBox(objName, minVal, maxVal, stepVal, defaultVal);
+      int sysDefaultVal = getDefault<int>(widgetJsonObj);
+
+      // Callback to handle value changes
+      std::function<void(QSpinBox*, const int&)> handleChange =
+          [](QSpinBox* ptr, const int& val) {
+            json changeJson;
+            changeJson["userValue"] = ptr->value();
+
+            storeJsonPatch(ptr, changeJson);
+          };
+
+      // Create Widget
+      auto ptr = createSpinBox(objName, minVal, maxVal, stepVal, sysDefaultVal,
+                               handleChange);
       createdWidget = ptr;
 
-      // Add value change tracking
-      auto initialVal = ptr->value();
-      QObject::connect(ptr, qOverload<int>(&QSpinBox::valueChanged),
-                       [ptr, initialVal](int val) {
-                         bool changed = (val != initialVal);
-                         ptr->setProperty("changed", changed);
-                         if (changed) {
-                           // store value changes as a json string in the
-                           // widget's property system
-                           json changeJson;
-                           changeJson["userValue"] = ptr->value();
-                           ptr->setProperty(
-                               "jsonPatch",
-                               QString::fromStdString(changeJson.dump()));
-                         }
-                       });
+      // Load and set user value
+      if (widgetJsonObj.contains("userValue")) {
+        int userVal = widgetJsonObj["userValue"].get<int>();
+        ptr->setValue(userVal);
+
+        DBG_PRINT_VAL_SET(ptr, QString::number(userVal));
+      }
 
       targetObject = createdWidget;
     } else if (type == "doublespinbox") {
@@ -267,39 +307,64 @@ QWidget* FOEDAG::createWidget(const json& widgetJsonObj,
       double maxVal =
           widgetJsonObj.value("maxVal", std::numeric_limits<double>::max());
       double stepVal = widgetJsonObj.value("stepVal", 1.0);
-      double defaultVal = getUserValOrDefault<double>(widgetJsonObj);
+      double sysDefaultVal = getDefault<double>(widgetJsonObj);
 
-      auto ptr =
-          createDoubleSpinBox(objName, minVal, maxVal, stepVal, defaultVal);
+      // Callback to handle value changes
+      std::function<void(QDoubleSpinBox*, const double&)> handleChange =
+          [](QDoubleSpinBox* ptr, const double& val) {
+            json changeJson;
+            changeJson["userValue"] = ptr->value();
+
+            storeJsonPatch(ptr, changeJson);
+          };
+
+      // Create Widget
+      auto ptr = createDoubleSpinBox(objName, minVal, maxVal, stepVal,
+                                     sysDefaultVal, handleChange);
       createdWidget = ptr;
 
-      // Add value change tracking
-      auto initialVal = ptr->value();
-      QObject::connect(ptr, qOverload<double>(&QDoubleSpinBox::valueChanged),
-                       [ptr, initialVal](int val) {
-                         bool changed = (val != initialVal);
-                         ptr->setProperty("changed", changed);
-                         if (changed) {
-                           // store value changes as a json string in the
-                           // widget's property system
-                           json changeJson;
-                           changeJson["userValue"] = ptr->value();
-                           ptr->setProperty(
-                               "jsonPatch",
-                               QString::fromStdString(changeJson.dump()));
-                         }
-                       });
+      // Load and set user value
+      if (widgetJsonObj.contains("userValue")) {
+        double userVal = widgetJsonObj["userValue"].get<double>();
+        ptr->setValue(userVal);
+
+        DBG_PRINT_VAL_SET(ptr, QString::number(userVal));
+      }
 
       targetObject = createdWidget;
     } else if (type == "radiobuttons") {
       // QButtonGroup of QRadioButtons - "radiobuttons"
-      QString defaultVal = QString::fromStdString(
-          getUserValOrDefault<std::string>(widgetJsonObj));
+      QString sysDefaultVal =
+          QString::fromStdString(getDefault<std::string>(widgetJsonObj));
       QStringList options = JsonArrayToQStringList(widgetJsonObj["options"]);
 
+      // Callback to handle value changes
+      std::function<void(QRadioButton*, QButtonGroup*, const bool&)>
+          handleChange = [](QRadioButton* btnPtr, QButtonGroup* btnGroup,
+                            const bool& checked) {
+            json changeJson;
+            changeJson["userValue"] = btnPtr->text().toStdString();
+            storeJsonPatch(btnGroup, changeJson);
+          };
+
       // Create radiobuttons in a QButtonGroup
-      QButtonGroup* btnGroup =
-          FOEDAG::createRadioButtons(objName, options, defaultVal);
+      QButtonGroup* btnGroup = FOEDAG::createRadioButtons(
+          objName, options, sysDefaultVal, handleChange);
+
+      // Load and set user value
+      if (widgetJsonObj.contains("userValue")) {
+        QString userVal = QString::fromStdString(
+            widgetJsonObj["userValue"].get<std::string>());
+
+        for (auto btn : btnGroup->buttons()) {
+          if (btn->text() == userVal) {
+            btn->setChecked(true);
+          }
+        }
+
+        DBG_PRINT_VAL_SET(btnGroup, userVal);
+      }
+
       // ButtonGroups aren't real QWidgets so we need to add their child
       // radiobuttons to a container widget
       QWidget* container = new QWidget();
@@ -313,27 +378,10 @@ QWidget* FOEDAG::createWidget(const json& widgetJsonObj,
         containerLayout = new QVBoxLayout();
       }
 
-      // record initial val for change tracking later
-      auto initialVal = btnGroup->checkedId();
-
       // Add radiobuttons to container widget's layout
       container->setLayout(containerLayout);
       for (auto* btn : btnGroup->buttons()) {
         containerLayout->addWidget(btn);
-        // Add value change tracking
-        QObject::connect(
-            btn, &QRadioButton::toggled, [btn, btnGroup, initialVal](bool val) {
-              bool changed = (btnGroup->checkedId() != initialVal);
-              btnGroup->setProperty("changed", changed);
-              if (changed) {
-                // store value changes as a json string in the widget's property
-                // system
-                json changeJson;
-                changeJson["userValue"] = btn->text().toStdString();
-                btnGroup->setProperty(
-                    "jsonPatch", QString::fromStdString(changeJson.dump()));
-              }
-            });
       }
 
       // RadioButtons is a non-standard case, copy another type if looking for
@@ -342,37 +390,45 @@ QWidget* FOEDAG::createWidget(const json& widgetJsonObj,
       createdWidget = container;
     } else if (type == "checkbox") {
       // QCheckBox - "checkbox"
+      auto stringToCheckState = [](const QString& stateStr) -> Qt::CheckState {
+        Qt::CheckState state = Qt::Unchecked;
+        if (stateStr.toLower() == "checked") {
+          state = Qt::Checked;
+        } else if (stateStr.toLower() == "partiallychecked") {
+          state = Qt::PartiallyChecked;
+        }
+        return state;
+      };
+
+      // Determine Widget Details
       QString text = getStr(widgetJsonObj, "text");
+      QString sysDefaultVal =
+          QString::fromStdString(getDefault<std::string>(widgetJsonObj))
+              .toLower();
+      Qt::CheckState state = stringToCheckState(sysDefaultVal);
 
-      // Determine checkstate
-      QString defaultVal = QString::fromStdString(
-                               getUserValOrDefault<std::string>(widgetJsonObj))
-                               .toLower();
-      Qt::CheckState state = Qt::Unchecked;
-      if (defaultVal == "checked") {
-        state = Qt::Checked;
-      } else if (defaultVal == "partiallychecked") {
-        state = Qt::PartiallyChecked;
-      }
+      // Callback to handle value changes
+      std::function<void(QCheckBox*, const int&)> handleChange =
+          [](QCheckBox* ptr, const int& val) {
+            json changeJson;
+            changeJson["userValue"] =
+                QMetaEnum::fromType<Qt::CheckState>().valueToKey(val);
 
-      // Add value change tracking
-      auto ptr = createCheckBox(objName, text, state);
+            storeJsonPatch(ptr, changeJson);
+          };
+
+      // Create Widget
+      auto ptr = createCheckBox(objName, text, state, handleChange);
       createdWidget = ptr;
-      auto initialVal = ptr->checkState();
-      QObject::connect(
-          ptr, &QCheckBox::stateChanged, [ptr, initialVal](int val) {
-            bool changed = (val != initialVal);
-            ptr->setProperty("changed", changed);
-            if (changed) {
-              // store value changes as a json string in the widget's property
-              // system
-              json changeJson;
-              changeJson["userValue"] =
-                  QMetaEnum::fromType<Qt::CheckState>().valueToKey(val);
-              ptr->setProperty("jsonPatch",
-                               QString::fromStdString(changeJson.dump()));
-            }
-          });
+
+      // Load and set user value
+      if (widgetJsonObj.contains("userValue")) {
+        QString userVal = QString::fromStdString(
+            widgetJsonObj["userValue"].get<std::string>());
+        ptr->setCheckState(stringToCheckState(userVal));
+
+        DBG_PRINT_VAL_SET(ptr, userVal);
+      }
 
       targetObject = createdWidget;
     }
@@ -406,6 +462,7 @@ QWidget* FOEDAG::createLabelWidget(const QString& label, QWidget* widget) {
   // Create a container widget w/ an H layout
   QWidget* retVal = new QWidget();
   QHBoxLayout* HLayout = new QHBoxLayout();
+  HLayout->setContentsMargins(0, 0, 0, 0);
   retVal->setLayout(HLayout);
 
   // Add a label and our widget to the container
@@ -420,101 +477,143 @@ QWidget* FOEDAG::createLabelWidget(const QString& label, QWidget* widget) {
   return retVal;
 }
 
-QComboBox* FOEDAG::createComboBox(const QString& objectName,
-                                  const QStringList& options,
-                                  const QString& selectedValue) {
+QComboBox* FOEDAG::createComboBox(
+    const QString& objectName, const QStringList& options,
+    const QString& selectedValue,
+    std::function<void(QComboBox*, const QString&)> onChange) {
   QComboBox* widget = new QComboBox();
   widget->setObjectName(objectName);
   widget->insertItems(0, options);
+  widget->setCurrentText(selectedValue);
 
-  // Select a default if selectedValue was set
-  int idx = options.indexOf(selectedValue);
-  if (idx > -1) {
-    widget->setCurrentIndex(idx);
+  if (onChange != nullptr) {
+    // onChange needs the widget so we capture that in a closure we
+    // can then pass to the normal qt handler
+    std::function<void(const QString&)> changeCb =
+        [onChange, widget](const QString& newText) {
+          onChange(widget, newText);
+        };
+    QObject::connect(widget, &QComboBox::currentTextChanged, changeCb);
   }
 
   return widget;
 }
 
-QLineEdit* FOEDAG::createLineEdit(const QString& objectName,
-                                  const QString& text) {
+QLineEdit* FOEDAG::createLineEdit(
+    const QString& objectName, const QString& text,
+    std::function<void(QLineEdit*, const QString&)> onChange) {
   QLineEdit* widget = new QLineEdit();
   widget->setObjectName(objectName);
-
   widget->setText(text);
+
+  if (onChange != nullptr) {
+    // onChange needs the widget so we capture that in a closure we
+    // can then pass to the normal qt handler
+    std::function<void(const QString&)> changeCb =
+        [onChange, widget](const QString& newText) {
+          onChange(widget, newText);
+        };
+    QObject::connect(widget, &QLineEdit::textChanged, changeCb);
+  }
 
   return widget;
 }
 
-QDoubleSpinBox* FOEDAG::createDoubleSpinBox(const QString& objectName,
-                                            double minVal, double maxVal,
-                                            double stepVal, double defaultVal) {
+QDoubleSpinBox* FOEDAG::createDoubleSpinBox(
+    const QString& objectName, double minVal, double maxVal, double stepVal,
+    double defaultVal,
+    std::function<void(QDoubleSpinBox*, const double&)> onChange) {
   QDoubleSpinBox* widget = new QDoubleSpinBox();
   widget->setObjectName(objectName);
 
   widget->setMinimum(minVal);
   widget->setMaximum(maxVal);
   widget->setSingleStep(stepVal);
-  // SMA this will currently not set a value if a user passes a valid -1
-  if (defaultVal != -1) {
-    widget->setValue(defaultVal);
+  widget->setValue(defaultVal);
+
+  if (onChange != nullptr) {
+    // onChange needs the widget so we capture that in a closure we
+    // can then pass to the normal qt handler
+    std::function<void(const double&)> changeCb =
+        [onChange, widget](const double& newVal) { onChange(widget, newVal); };
+    QObject::connect(widget, qOverload<double>(&QDoubleSpinBox::valueChanged),
+                     changeCb);
   }
 
   return widget;
 }
 
-QSpinBox* FOEDAG::createSpinBox(const QString& objectName, int minVal,
-                                int maxVal, int stepVal, int defaultVal) {
+QSpinBox* FOEDAG::createSpinBox(
+    const QString& objectName, int minVal, int maxVal, int stepVal,
+    int defaultVal, std::function<void(QSpinBox*, const int&)> onChange) {
   QSpinBox* widget = new QSpinBox();
   widget->setObjectName(objectName);
 
   widget->setMinimum(minVal);
   widget->setMaximum(maxVal);
   widget->setSingleStep(stepVal);
-  // SMA this will currently not set a value if a user passes a valid -1
-  if (defaultVal != -1) {
-    widget->setValue(defaultVal);
+  widget->setValue(defaultVal);
+
+  if (onChange != nullptr) {
+    // onChange needs the widget so we capture that in a closure we
+    // can then pass to the normal qt handler
+    std::function<void(const int&)> changeCb =
+        [onChange, widget](const int& newVal) { onChange(widget, newVal); };
+    QObject::connect(widget, qOverload<int>(&QSpinBox::valueChanged), changeCb);
   }
 
   return widget;
 }
 
-QRadioButton* FOEDAG::createRadioButton(const QString& objectName,
-                                        const QString& text) {
-  QRadioButton* widget = new QRadioButton();
-  widget->setObjectName(objectName);
-
-  widget->setText(text);
-
-  return widget;
-}
-
-QButtonGroup* FOEDAG::createRadioButtons(const QString& objectName,
-                                         const QStringList& nameList,
-                                         const QString& selectedValue) {
+QButtonGroup* FOEDAG::createRadioButtons(
+    const QString& objectName, const QStringList& nameList,
+    const QString& selectedValue,
+    std::function<void(QRadioButton*, QButtonGroup*, const bool&)> onChange) {
   QButtonGroup* widget = new QButtonGroup();
   widget->setObjectName(objectName);
 
+  // Create QRadiobuttons and add to QButtonGroup
   for (const QString& name : nameList) {
     QRadioButton* radioBtn = new QRadioButton();
     radioBtn->setObjectName(objectName + "_" + name);
+
     radioBtn->setText(name);
     if (name == selectedValue) {
       radioBtn->setChecked(true);
     }
+
+    if (onChange != nullptr) {
+      // onChange needs the widget so we capture that in a closure we
+      // can then pass to the normal qt handler
+      std::function<void(const int&)> changeCb = [onChange, radioBtn,
+                                                  widget](const bool& newVal) {
+        onChange(radioBtn, widget, newVal);
+      };
+      QObject::connect(radioBtn, &QRadioButton::toggled, changeCb);
+    }
+
     widget->addButton(radioBtn);
   }
 
   return widget;
 }
 
-QCheckBox* FOEDAG::createCheckBox(const QString& objectName,
-                                  const QString& text, Qt::CheckState checked) {
+QCheckBox* FOEDAG::createCheckBox(
+    const QString& objectName, const QString& text, Qt::CheckState checked,
+    std::function<void(QCheckBox*, const int&)> onChange) {
   QCheckBox* widget = new QCheckBox();
   widget->setObjectName(objectName);
 
   widget->setText(text);
   widget->setCheckState(checked);
+
+  if (onChange != nullptr) {
+    // onChange needs the widget so we capture that in a closure we
+    // can then pass to the normal qt handler
+    std::function<void(const int&)> changeCb =
+        [onChange, widget](const int& newVal) { onChange(widget, newVal); };
+    QObject::connect(widget, &QCheckBox::stateChanged, changeCb);
+  };
 
   return widget;
 }

--- a/src/Main/WidgetFactory.h
+++ b/src/Main/WidgetFactory.h
@@ -32,6 +32,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "nlohmann_json/json.hpp"
 using json = nlohmann::ordered_json;
 
+#define SETTINGS_WIDGET_SUFFIX "SettingsWidget"
+
 namespace FOEDAG {
 
 QDialog* createSettingsDialog(json& widgetsJson, const QString& dialogTitle,
@@ -43,20 +45,29 @@ QWidget* createWidget(const json& widgetJsonObj, const QString& objName = "");
 QWidget* createWidget(const QString& widgetJsonStr,
                       const QString& objName = "");
 QWidget* createLabelWidget(const QString& label, QWidget* widget);
-QComboBox* createComboBox(const QString& objectName, const QStringList& options,
-                          const QString& selectedValue = "");
-QLineEdit* createLineEdit(const QString& objectName, const QString& text = "");
-QDoubleSpinBox* createDoubleSpinBox(const QString& objectName, double minVal,
-                                    double maxVal, double stepVal,
-                                    double defaultVal);
-QSpinBox* createSpinBox(const QString& objectName, int minVal, int maxVal,
-                        int stepVal, int defaultVal = -1);
-QRadioButton* createRadioButton(const QString& objectName, const QString& text);
-QButtonGroup* createRadioButtons(const QString& objectName,
-                                 const QStringList& nameList,
-                                 const QString& selectedValue = "");
-QCheckBox* createCheckBox(const QString& objectName, const QString& text,
-                          Qt::CheckState checked);
+QComboBox* createComboBox(
+    const QString& objectName, const QStringList& options,
+    const QString& selectedValue = "",
+    std::function<void(QComboBox*, const QString&)> onChange = nullptr);
+QLineEdit* createLineEdit(
+    const QString& objectName, const QString& text = "",
+    std::function<void(QLineEdit*, const QString&)> onChange = nullptr);
+QDoubleSpinBox* createDoubleSpinBox(
+    const QString& objectName, double minVal, double maxVal, double stepVal,
+    double defaultVal,
+    std::function<void(QDoubleSpinBox*, const double&)> onChange = nullptr);
+QSpinBox* createSpinBox(
+    const QString& objectName, int minVal, int maxVal, int stepVal,
+    int defaultVal,
+    std::function<void(QSpinBox*, const int&)> onChange = nullptr);
+QButtonGroup* createRadioButtons(
+    const QString& objectName, const QStringList& nameList,
+    const QString& selectedValue = "",
+    std::function<void(QRadioButton*, QButtonGroup*, const bool&)> onChange =
+        nullptr);
+QCheckBox* createCheckBox(
+    const QString& objectName, const QString& text, Qt::CheckState checked,
+    std::function<void(QCheckBox*, const int&)> onChange = nullptr);
 
 }  // namespace FOEDAG
 

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -36,6 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "DesignRuns/runs_form.h"
 #include "Main/CompilerNotifier.h"
 #include "Main/Foedag.h"
+#include "Main/Tasks.h"
 #include "MainWindow/Session.h"
 #include "NewFile/new_file.h"
 #include "NewProject/Main/registerNewProjectCommands.h"
@@ -235,6 +236,10 @@ void MainWindow::ReShowWindow(QString strProject) {
   sourceDockWidget->setWidget(sourForm);
   addDockWidget(Qt::LeftDockWidgetArea, sourceDockWidget);
 
+  reloadSettings();  // This needs to be after
+                     // sourForm->InitSourcesForm(strProject); so the project
+                     // info exists
+
   TextEditor* textEditor = new TextEditor(this);
   textEditor->RegisterCommands(GlobalSession);
   textEditor->setObjectName("textEditor");
@@ -309,5 +314,42 @@ void MainWindow::clearDockWidgets() {
   auto docks = findChildren<QDockWidget*>();
   for (auto dock : docks) {
     removeDockWidget(dock);
+  }
+}
+
+void MainWindow::reloadSettings() {
+  FOEDAG::Settings* settings = GlobalSession->GetSettings();
+  if (settings) {
+    // Clear out old settings
+    settings->clear();
+
+    QString separator = QString::fromStdString(
+        std::string(1, std::filesystem::path::preferred_separator));
+
+    // List of json files that will get loaded
+    QStringList settingsFiles = {};
+
+    // Helper function to add all json files in a dir to settingsFiles
+    auto addFilesFromDir = [&settingsFiles](const QString& dirPath) {
+      if (!dirPath.isEmpty()) {
+        QDir dir(dirPath);
+        QFileInfoList files =
+            dir.entryInfoList(QStringList() << "*.json", QDir::Files);
+        for (auto file : files) {
+          settingsFiles << file.filePath();
+        }
+      }
+    };
+
+    // Add any json files from the system defaults json path
+    QString settingsDir =
+        GlobalSession->GetSettings()->getSystemDefaultSettingsDir();
+    addFilesFromDir(settingsDir);
+
+    // Add any json files from the [projectName].settings folder
+    addFilesFromDir(FOEDAG::getTaskUserSettingsPath());
+
+    // Load and merge all our json files
+    settings->loadSettings(settingsFiles);
   }
 }

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -60,6 +60,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void ReShowWindow(QString strProject);
   void clearDockWidgets();
   void startStopButtonsState();
+  void reloadSettings();
 
  private: /* Objects/Widgets under the main window */
   /* Menu bar objects */


### PR DESCRIPTION
Task tree "Edit Settings" entries now render as buttons and will dynamically load a settings dialog for the parent Task.

Current settings are still test values and aren't integrated with the respective tasks.

If no project is loaded, editing task settings will persist for the session only(currently).

If a project has been loaded, settings will be saved in the project folder under [projectName].settings/ as json files.

When a project is loaded or created, current settings are cleared, system defaults are reloaded and project settings are loaded (see below).

When a project is loaded, all .json files found in the project folder [projectName].settings/ anr loaded and merged into the current settings json.
