### PR TITLE
Adding tcl arg support for remaining widget types

### DIFF
--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -64,6 +64,67 @@
                 "default": "input field w/o a label provided"
             }
         },
+        "TclExample": {
+            "double_spinbox_ex": {
+                "label": "Double Spinbox Example",
+                "widgetType": "DoubleSpinbox",
+                "minVal": 2.4,
+                "maxVal": 11.4,
+                "stepVal": 1.1,
+                "default": 2.5,
+                "arg": "double_spin_ex"
+            },
+            "int_spinbox_ex": {
+                "label": "Int Spinbox Example",
+                "widgetType": "Spinbox",
+                "minVal": 2.4,
+                "maxVal": 11.4,
+                "stepVal": 1.1,
+                "default": 2.5,
+                "arg": "int_spin_ex"
+            },
+            "radiobuttons_horiz_ex": {
+                "label": "Radio Button Example",
+                "widgetType": "radiobuttons",
+                "options": [
+                    "B1",
+                    "B2",
+                    "B3"
+                ],
+                "optionsLookup": [
+                    "b1",
+                    "b2",
+                    "b3"
+                ],
+                "layout": "horizontal",
+                "default": "b2",
+                "arg": "radio_ex"
+            },
+            "checkbox_ex": {
+                "label": "Checkbox Example",
+                "text": "Checkbox Text",
+                "widgetType": "checkbox",
+                "default": "unchecked",
+                "arg": "check_ex"
+            },
+            "dropdown_ex": {
+                "label": "Dropdown Example",
+                "widgetType": "dropdown",
+                "options": [
+                    "option1",
+                    "option2",
+                    "option3"
+                ],
+                "default": "option2",
+                "arg": "dropdown_ex"
+            },
+            "input_ex_1": {
+                "label": "Text Input Example",
+                "widgetType": "input",
+                "default": "some text",
+                "arg": "input_ex"
+            }
+        },
         "Synthesis": {
             "opt_dropdown": {
                 "label": "Optimization",

--- a/src/Main/Tasks.cpp
+++ b/src/Main/Tasks.cpp
@@ -126,18 +126,34 @@ auto setSynthesisOptions = [](const QString& argsStr) {
   return moreOpts;
 };
 
+// Hardcoded example callbacks to demonstrate how to use TclArgs with the task
+// settings dialog
+static QString TclExampleArgs =
+    "-double_spin_ex 3.3 -int_spin_ex 3 -radio_ex b3 -check_ex -dropdown_ex "
+    "option3 -input_ex "
+    "spaces_TclArgSpace_require_TclArgSpace_extra_TclArgSpace_formatting";
+auto getTclExampleOptions = []() -> QString {
+  // std::cout << "returning args: " << TclExampleArgs.toStdString() <<
+  // std::endl;
+  return TclExampleArgs;
+};
+auto setTclExampleOptions = [](const QString& argsStr) {
+  TclExampleArgs = argsStr;
+  // std::cout << "Example Args set to: " << argsStr.toStdString() << std::endl;
+};
+
 // Map of Task names and tcl arguement list getters
 std::map<QString, std::function<QString()>> OptionsGetterMap = {
     {"Synthesis", getSynthesisOptions},
     // {"Placement", get},
     // {"Routing", get},
-};
+    {"TclExample", getTclExampleOptions}};
 // Map of Task names and tcl arguement list setters
 std::map<QString, std::function<void(const QString&)>> OptionsSetterMap = {
     {"Synthesis", setSynthesisOptions},
     // {"Placement", set},
     // {"Routing", set},
-};
+    {"TclExample", setTclExampleOptions}};
 
 QDialog* FOEDAG::createTaskDialog(const QString& taskName) {
   FOEDAG::Settings* settings = GlobalSession->GetSettings();

--- a/src/Main/registerTclCommands.cpp
+++ b/src/Main/registerTclCommands.cpp
@@ -235,7 +235,7 @@ void registerAllFoedagCommands(QWidget* widget, FOEDAG::Session* session) {
     if (FOEDAG::MainWindow* win = dynamic_cast<FOEDAG::MainWindow*>(widget)) {
       auto DemoWidgetsFn = [](void* clientData, Tcl_Interp* interp, int argc,
                               const char* argv[]) -> int {
-        FOEDAG::createTaskDialog("Placement")->show();
+        FOEDAG::createTaskDialog("TclExample")->show();
         return TCL_OK;
       };
       session->TclInterp()->registerCmd("DemoWidgets", DemoWidgetsFn, 0, 0);


### PR DESCRIPTION
> ### Motivate of the pull request
> - This adds tcl arg support to the settings/widget factory system for the remaining widgets (previously only comboboxes and checkboxes were supported)
> - The temporary console command DemoWidgets has been updated to show all the widget types using a tcl arg
> - Check the code for "TclExample" to see a basic example of how to add tcl arg support to a settings dialog.

