### PR TITLE
Allow show/hide LICENSE at About window

### DIFF
--- a/src/Main/AboutWidget.cpp
+++ b/src/Main/AboutWidget.cpp
@@ -32,14 +32,18 @@ AboutWidget::AboutWidget(const ProjectInfo &info, QWidget *parent)
     : QDialog{parent} {
   QLabel *label = new QLabel(this);
   QPushButton *close = new QPushButton("Close", this);
-  label->setText(QString("<p><b>%1 %2</b></p>"
-                         "<p>Build on %3</p>"
-                         "<p>From revision <a "
-                         "href=\"%4%5\">%5</a></p>"
-                         "<p>Build type: %6</p>"
-                         "<p>%7</p>")
+  QString text = QString(
+                     "<p><b>%1 %2</b></p>"
+                     "<p>Build on %3</p>"
+                     "<p>From revision <a "
+                     "href=\"%4%5\">%5</a></p>"
+                     "<p>Build type: %6</p>")
                      .arg(info.name, info.version, __DATE__, info.url,
-                          info.git_hash, info.build_type, License()));
+                          info.git_hash, info.build_type);
+  if (info.showLicense) {
+    text += QString("<p>%7</p>").arg(License());
+  }
+  label->setText(text);
   label->setAlignment(Qt::AlignTop);
   connect(label, &QLabel::linkActivated, this, [this](const QString &link) {
     QDesktopServices::openUrl(QUrl(link));

--- a/src/Main/AboutWidget.cpp
+++ b/src/Main/AboutWidget.cpp
@@ -41,7 +41,7 @@ AboutWidget::AboutWidget(const ProjectInfo &info, QWidget *parent)
                      .arg(info.name, info.version, __DATE__, info.url,
                           info.git_hash, info.build_type);
   if (info.showLicense) {
-    text += QString("<p>%7</p>").arg(License());
+    text += QString("<p>%1</p>").arg(License());
   }
   label->setText(text);
   label->setAlignment(Qt::AlignTop);

--- a/src/Main/AboutWidget.h
+++ b/src/Main/AboutWidget.h
@@ -30,6 +30,7 @@ struct ProjectInfo {
   QString git_hash;
   QString url;
   QString build_type;
+  bool showLicense{false};
 };
 
 class AboutWidget : public QDialog {

--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -27,7 +27,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "MainWindow/main_window.h"
 
 QWidget* mainWindowBuilder(FOEDAG::Session* session) {
-  return new FOEDAG::MainWindow{session};
+  auto m = new FOEDAG::MainWindow{session};
+  auto info = m->Info();
+  info.showLicense = true;
+  m->Info(info);
+  return m;
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
### Motivate of the pull request
Allow to show/hide LICENSE at about window.

### Describe the technical details
Added into the FOEDAG::ProjectInfo showLicense flag which indicates whether need to show license or not.

