### PR TITLE
Improve error message when file is not exists (close #515)

### DIFF
--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -125,6 +125,10 @@ class ProjectManager : public QObject {
     EC_ProjRunNotExist = -2,
     EC_FileNotExist = -3,
   };
+  struct ErrorInfo {
+    ErrorCode code;
+    QString message = QString();
+  };
   explicit ProjectManager(QObject *parent = nullptr);
   void CreateProject(const ProjectOptions &opt);
   static QString ProjectFilesPath(const QString &projPath,
@@ -147,8 +151,8 @@ class ProjectManager : public QObject {
 
   int setProjectType(const QString &strType);
 
-  int addDesignFiles(const QString &fileNames, int lang, bool isFileCopy = true,
-                     bool localToProject = true);
+  ErrorInfo addDesignFiles(const QString &fileNames, int lang,
+                           bool isFileCopy = true, bool localToProject = true);
   int setDesignFiles(const QString &fileNames, int lang, bool isFileCopy = true,
                      bool localToProject = true);
   // Please set currentfileset before using this function

--- a/src/ProjNavigator/tcl_command_integration.cpp
+++ b/src/ProjNavigator/tcl_command_integration.cpp
@@ -135,9 +135,9 @@ bool TclCommandIntegration::TclAddDesignFiles(const QString &files, int lang,
 
   const QString strSetName = m_projManager->getDesignActiveFileSet();
   m_projManager->setCurrentFileSet(strSetName);
-  const int ret = m_projManager->addDesignFiles(files, lang, false, false);
-  if (ProjectManager::EC_Success != ret) {
-    error(ret, files, out);
+  const auto ret = m_projManager->addDesignFiles(files, lang, false, false);
+  if (ProjectManager::EC_Success != ret.code) {
+    error(ret.code, ret.message, out);
     return false;
   }
 


### PR DESCRIPTION
### Motivate of the pull request
Provide user more clear and full information which file is not exists for the command add_design_file. Close #515 

### Describe the technical details
Return from the function list of all files that are not exists.

Error before:
![image](https://user-images.githubusercontent.com/95262932/179021599-58d53624-5376-4f15-96a4-f90c9e9052bc.png)

Error after:
![image](https://user-images.githubusercontent.com/95262932/179021747-a08a0477-5819-41fc-b60a-5f0534e15d7e.png)
