### PR TITLE
Read constraint file before it added to the project

### DIFF
--- a/src/Compiler/CompilerDefines.cpp
+++ b/src/Compiler/CompilerDefines.cpp
@@ -25,9 +25,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Compiler.h"
 #include "Main/Tasks.h"
+#include "MainWindow/Session.h"
+#include "NewProject/ProjectManager/project.h"
+#include "NewProject/ProjectManager/project_manager.h"
 #include "TaskManager.h"
 #include "TaskModel.h"
 #include "TaskTableView.h"
+
+extern FOEDAG::Session *GlobalSession;
 
 QWidget *FOEDAG::prepareCompilerView(Compiler *compiler,
                                      TaskManager **taskManager) {
@@ -93,4 +98,12 @@ FOEDAG::Design::Language FOEDAG::FromFileType(const QString &type) {
   if (type == "sv") return Design::Language::SYSTEMVERILOG_2017;
   if (type == "vhd") return Design::Language::VHDL_2008;
   return Design::Language::VERILOG_2001;  // default
+}
+
+int FOEDAG::read_sdc(const QString &file) {
+  QString f = file;
+  f.replace(PROJECT_OSRCDIR, Project::Instance()->projectPath());
+  int res = Tcl_Eval(GlobalSession->TclInterp()->getInterp(),
+                     qPrintable(QString("read_sdc {%1}").arg(f)));
+  return (res == TCL_OK) ? 0 : -1;
 }

--- a/src/Compiler/CompilerDefines.h
+++ b/src/Compiler/CompilerDefines.h
@@ -93,4 +93,11 @@ QWidget *prepareCompilerView(Compiler *compiler,
 
 uint toTaskId(int action, const Compiler *const compiler);
 
+/*!
+ * \brief read_sdc
+ * Run TCL read_sdc command for file \a file.
+ * \return 0 if tcl command success otherwise return -1
+ */
+[[nodiscard]] int read_sdc(const QString &file);
+
 }  // namespace FOEDAG

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -863,7 +863,7 @@ bool CompilerOpenFPGA::Packing() {
            << std::endl;
   (*m_out) << "##################################################" << std::endl;
   const std::string sdcOut =
-      (std::filesystem::path(ProjManager()->projectName()) /
+      (std::filesystem::path(ProjManager()->projectPath()) /
        std::string(ProjManager()->projectName() + "_openfpga.sdc"))
           .string();
   std::ofstream ofssdc(sdcOut);

--- a/src/Main/ProjectFile/ProjectManagerComponent.cpp
+++ b/src/Main/ProjectFile/ProjectManagerComponent.cpp
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "ProjectManagerComponent.h"
 
+#include "Compiler/CompilerDefines.h"
+
 namespace FOEDAG {
 
 ProjectManagerComponent::ProjectManagerComponent(ProjectManager* pManager,
@@ -303,5 +305,16 @@ void ProjectManagerComponent::Load(QXmlStreamReader* r) {
       }
     }
   }
+  const auto constrSets = m_projectManager->getConstrFileSets();
+  for (const auto& set : constrSets) {
+    const auto files = m_projectManager->getConstrFiles(set);
+    for (const auto& f : files) {
+      const int ret = FOEDAG::read_sdc(f);
+      if (ret != 0) {
+        break;
+      }
+    }
+  }
 }
+
 }  // namespace FOEDAG

--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -505,16 +505,19 @@ int ProjectManager::setConstrsFile(const QString& strFileName, bool isFileCopy,
       suffix = QFileInfo(strfile).suffix();
       if (m_constrSuffixes.TestSuffix(suffix)) {
         ret = AddOrCreateFileToFileSet(strfile, isFileCopy);
+        if (ret == 0) ret = FOEDAG::read_sdc(strfile);
       }
     }
   } else if (fileInfo.exists()) {
     if (m_constrSuffixes.TestSuffix(suffix)) {
       ret = AddOrCreateFileToFileSet(strFileName, isFileCopy);
+      if (ret == 0) ret = FOEDAG::read_sdc(strFileName);
     }
   } else {
     if (strFileName.contains("/")) {
       if (m_constrSuffixes.TestSuffix(suffix)) {
         ret = CreateAndAddFile(suffix, strFileName, strFileName, false);
+        if (ret == 0) ret = FOEDAG::read_sdc(strFileName);
       }
     } else {
       QString filePath = ProjectFilesPath(Project::Instance()->projectPath(),
@@ -527,6 +530,7 @@ int ProjectManager::setConstrsFile(const QString& strFileName, bool isFileCopy,
       fileSetPath += "/" + strFileName;
       if (m_constrSuffixes.TestSuffix(suffix)) {
         ret = CreateAndAddFile(suffix, filePath, fileSetPath, false);
+        if (ret == 0) ret = FOEDAG::read_sdc(filePath);
       }
     }
   }


### PR DESCRIPTION
### Motivate of the pull request
Read constraint file before add it to the project.

We expect that after project build file <filename>_openfpga.sdc should appear in the project folder. It should be non empty.

How to test.
1. Create new project with all files via project wizard and build.
2. Create project and add files from the context menu and build.
3. Open project file and build.
