### PR TITLE
Show full file path in a tab tooltip

### DIFF
--- a/src/TextEditor/text_editor_form.cpp
+++ b/src/TextEditor/text_editor_form.cpp
@@ -84,7 +84,7 @@ int TextEditorForm::OpenFile(const QString &strFileName) {
 
   index = m_tab_editor->addTab(editor, filename);
   m_tab_editor->setCurrentIndex(index);
-  m_tab_editor->setTabToolTip(index, strFileName);
+  m_tab_editor->setTabToolTip(index, fileInfo.absoluteFilePath());
 
   QPair<int, Editor *> pair;
   pair.first = index;

--- a/src/TextEditor/text_editor_form.cpp
+++ b/src/TextEditor/text_editor_form.cpp
@@ -84,6 +84,7 @@ int TextEditorForm::OpenFile(const QString &strFileName) {
 
   index = m_tab_editor->addTab(editor, filename);
   m_tab_editor->setCurrentIndex(index);
+  m_tab_editor->setTabToolTip(index, strFileName);
 
   QPair<int, Editor *> pair;
   pair.first = index;


### PR DESCRIPTION
This commit extends file tabs with a tooltip, containing full file path (#537):

![image](https://user-images.githubusercontent.com/109239890/179827384-09526def-04e9-49b8-a5e6-fae1b3e839bc.png)
