### PR TITLE
Improve file loading

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -135,11 +135,12 @@ void MainWindow::newProjectDlg() {
 }
 
 void MainWindow::openProject() {
-  QString fileName = "";
+  QString fileName;
   fileName = QFileDialog::getOpenFileName(this, tr("Open Project"), "",
                                           "FOEDAG Project File(*.ospr)");
-  if ("" != fileName) {
+  if (!fileName.isEmpty()) {
     ReShowWindow(fileName);
+    loadFile(fileName);
   }
 }
 
@@ -167,6 +168,14 @@ void MainWindow::startStopButtonsState() {
   const bool consoleInProgress = m_console->isRunning();
   startAction->setEnabled(!inProgress && !consoleInProgress);
   stopAction->setEnabled(inProgress && consoleInProgress);
+}
+
+void MainWindow::loadFile(const QString& file) {
+  if (m_projectFileLoader) {
+    m_projectFileLoader->Load(file);
+    if (sourcesForm) sourcesForm->InitSourcesForm();
+    updatePRViewButton(static_cast<int>(m_compiler->CompilerState()));
+  }
 }
 
 void MainWindow::createMenus() {
@@ -264,7 +273,7 @@ void MainWindow::ReShowWindow(QString strProject) {
 
   QDockWidget* sourceDockWidget = new QDockWidget(tr("Source"), this);
   sourceDockWidget->setObjectName("sourcedockwidget");
-  SourcesForm* sourcesForm = new SourcesForm(this);
+  sourcesForm = new SourcesForm(this);
   connect(sourcesForm, &SourcesForm::CloseProject, this,
           &MainWindow::closeProject, Qt::QueuedConnection);
   sourceDockWidget->setWidget(sourcesForm);
@@ -355,19 +364,11 @@ void MainWindow::ReShowWindow(QString strProject) {
 
   // compiler task view
   QWidget* view = prepareCompilerView(m_compiler, &m_taskManager);
-  auto prViewButton = [&, view, this](int state) {
-    auto name = this->m_taskManager->task(PLACE_AND_ROUTE_VIEW)->title();
-    auto btn = view->findChild<QPushButton*>(name);
-    QVector<Compiler::State> availableState{
-        {Compiler::State::Routed, Compiler::State::TimingAnalyzed,
-         Compiler::State::PowerAnalyzed, Compiler::State::BistreamGenerated}};
-    if (btn) {
-      btn->setEnabled(
-          availableState.contains(static_cast<Compiler::State>(state)));
-    }
-  };
-  connect(compilerNotifier, &CompilerNotifier::compilerStateChanged,
-          prViewButton);
+  view->setObjectName("compilerTaskView");
+  view->setParent(this);
+
+  connect(compilerNotifier, &CompilerNotifier::compilerStateChanged, this,
+          &MainWindow::updatePRViewButton);
   m_projectFileLoader->registerComponent(
       new TaskManagerComponent{m_taskManager});
   m_projectFileLoader->registerComponent(new CompilerComponent(m_compiler));
@@ -380,11 +381,9 @@ void MainWindow::ReShowWindow(QString strProject) {
   connect(console, &TclConsoleWidget::stateChanged, this,
           [this, console]() { startStopButtonsState(); });
 
-  if (!strProject.isEmpty()) m_projectFileLoader->Load(strProject);
-
   sourcesForm->InitSourcesForm();
   // runForm->InitRunsForm();
-  prViewButton(static_cast<int>(m_compiler->CompilerState()));
+  updatePRViewButton(static_cast<int>(m_compiler->CompilerState()));
 }
 
 void MainWindow::clearDockWidgets() {
@@ -428,5 +427,19 @@ void MainWindow::reloadSettings() {
 
     // Load and merge all our json files
     settings->loadSettings(settingsFiles);
+  }
+}
+
+void MainWindow::updatePRViewButton(int state) {
+  auto name = m_taskManager->task(PLACE_AND_ROUTE_VIEW)->title();
+  auto view = findChild<QWidget*>("compilerTaskView");
+  if (!view) return;
+
+  if (auto btn = view->findChild<QPushButton*>(name)) {
+    const QVector<Compiler::State> availableState{
+        {Compiler::State::Routed, Compiler::State::TimingAnalyzed,
+         Compiler::State::PowerAnalyzed, Compiler::State::BistreamGenerated}};
+    btn->setEnabled(
+        availableState.contains(static_cast<Compiler::State>(state)));
   }
 }

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -56,6 +56,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void openFileSlot();
   void newDesignCreated(const QString& design);
   void reloadSettings();
+  void updatePRViewButton(int state);
 
  private: /* Menu bar builders */
   void createMenus();
@@ -67,6 +68,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void ReShowWindow(QString strProject);
   void clearDockWidgets();
   void startStopButtonsState();
+  void loadFile(const QString& file);
 
  private: /* Objects/Widgets under the main window */
   /* Menu bar objects */
@@ -94,6 +96,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   class TclConsoleWidget* m_console{nullptr};
   class ProjectManager* m_projectManager{nullptr};
   class ProjectFileLoader* m_projectFileLoader{nullptr};
+  class SourcesForm* sourcesForm{nullptr};
 };
 
 }  // namespace FOEDAG


### PR DESCRIPTION
### Motivate of the pull request
Improve file loading. Current implementation load file on every reopen main window. It doesn't make sense to do it every time. 
I reworked it in a way that load file only when user choose Open Project.


### Describe the technical details
#### What is currently done? (Provide issue link if applicable)
Move open file from reopen main window.

#### What does this pull request change?
We load file only when user open project.

### Which part of the code base require a change
Core

### Impact of the pull request
The P&R View button. This button need to update after file is loaded.