### PR TITLE
Added ... ellipses in Menu Picks texts that invoke dialog 

### DIFF
--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -29,7 +29,7 @@ TaskManager::TaskManager(QObject *parent) : QObject{parent} {
   m_tasks.insert(SYNTHESIS, new Task{"Synthesis"});
   m_tasks.insert(SYNTHESIS_CLEAN, new Task{"Clean", TaskType::Clean});
   m_tasks.insert(SYNTHESIS_SETTINGS,
-                 new Task{"Edit settings", TaskType::Settings});
+                 new Task{"Edit settings...", TaskType::Settings});
   m_tasks.insert(SYNTHESIS_WRITE_NETLIST, new Task{"Write netlist"});
   m_tasks.insert(SYNTHESIS_TIMING_REPORT, new Task{"Timing report"});
   m_tasks.insert(PACKING, new Task{"Packing"});
@@ -39,13 +39,13 @@ TaskManager::TaskManager(QObject *parent) : QObject{parent} {
   m_tasks.insert(PLACEMENT, new Task{"Placement"});
   m_tasks.insert(PLACEMENT_CLEAN, new Task{"Clean", TaskType::Clean});
   m_tasks.insert(PLACEMENT_SETTINGS,
-                 new Task{"Edit settings", TaskType::Settings});
+                 new Task{"Edit settings...", TaskType::Settings});
   m_tasks.insert(PLACEMENT_WRITE_NETLIST, new Task{"Write netlist"});
   m_tasks.insert(PLACEMENT_TIMING_REPORT, new Task{"Timing report"});
   m_tasks.insert(ROUTING, new Task{"Routing"});
   m_tasks.insert(ROUTING_CLEAN, new Task{"Clean", TaskType::Clean});
   m_tasks.insert(ROUTING_SETTINGS,
-                 new Task{"Edit settings", TaskType::Settings});
+                 new Task{"Edit settings...", TaskType::Settings});
   m_tasks.insert(ROUTING_WRITE_NETLIST, new Task{"Write netlist"});
   m_tasks.insert(TIMING_SIGN_OFF, new Task{"Timing Analysis"});
   m_tasks.insert(POWER, new Task{"Power"});

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -198,13 +198,13 @@ void MainWindow::createToolBars() {
 }
 
 void MainWindow::createActions() {
-  newAction = new QAction(tr("&New"), this);
+  newAction = new QAction(tr("&New..."), this);
   newAction->setIcon(QIcon(":/images/icon_newfile.png"));
   newAction->setShortcut(QKeySequence::New);
   newAction->setStatusTip(tr("Create a new source file"));
   connect(newAction, SIGNAL(triggered()), this, SLOT(newFile()));
 
-  openProjectAction = new QAction(tr("&Open Project"), this);
+  openProjectAction = new QAction(tr("&Open Project..."), this);
   openProjectAction->setStatusTip(tr("Open a new project"));
   connect(openProjectAction, SIGNAL(triggered()), this, SLOT(openProject()));
 
@@ -213,11 +213,11 @@ void MainWindow::createActions() {
   connect(closeProjectAction, SIGNAL(triggered()), this, SLOT(closeProject()));
 
   newProjdialog = new newProjectDialog(this);
-  newProjectAction = new QAction(tr("&New Project"), this);
+  newProjectAction = new QAction(tr("&New Project..."), this);
   newProjectAction->setStatusTip(tr("Create a new project"));
   connect(newProjectAction, SIGNAL(triggered()), this, SLOT(newProjectDlg()));
 
-  openFile = new QAction(tr("&Open File"), this);
+  openFile = new QAction(tr("&Open File..."), this);
   openFile->setStatusTip(tr("Open file"));
   openFile->setIcon(QIcon(":/images/open-file.png"));
   connect(openFile, SIGNAL(triggered()), this, SLOT(openFileSlot()));

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -264,12 +264,12 @@ void MainWindow::ReShowWindow(QString strProject) {
 
   QDockWidget* sourceDockWidget = new QDockWidget(tr("Source"), this);
   sourceDockWidget->setObjectName("sourcedockwidget");
-  SourcesForm* sourForm = new SourcesForm(this);
-  connect(sourForm, &SourcesForm::CloseProject, this, &MainWindow::closeProject,
-          Qt::QueuedConnection);
-  sourceDockWidget->setWidget(sourForm);
+  SourcesForm* sourcesForm = new SourcesForm(this);
+  connect(sourcesForm, &SourcesForm::CloseProject, this,
+          &MainWindow::closeProject, Qt::QueuedConnection);
+  sourceDockWidget->setWidget(sourcesForm);
   addDockWidget(Qt::LeftDockWidgetArea, sourceDockWidget);
-  m_projectManager = sourForm->ProjManager();
+  m_projectManager = sourcesForm->ProjManager();
   // If the project manager path changes, reload settings
   QObject::connect(m_projectManager, &ProjectManager::projectPathChanged, this,
                    &MainWindow::reloadSettings, Qt::UniqueConnection);
@@ -277,7 +277,7 @@ void MainWindow::ReShowWindow(QString strProject) {
   delete m_projectFileLoader;
   m_projectFileLoader = new ProjectFileLoader;
   m_projectFileLoader->registerComponent(
-      new ProjectManagerComponent{sourForm->ProjManager()});
+      new ProjectManagerComponent{sourcesForm->ProjManager()});
   connect(Project::Instance(), &Project::saveFile, m_projectFileLoader,
           &ProjectFileLoader::Save);
   reloadSettings();  // This needs to be after
@@ -285,10 +285,11 @@ void MainWindow::ReShowWindow(QString strProject) {
                      // info exists
 
   QDockWidget* propertiesDockWidget = new QDockWidget(tr("Properties"), this);
-  PropertyWidget* propertyWidget = new PropertyWidget{sourForm->ProjManager()};
-  connect(sourForm, &SourcesForm::ShowProperty, propertyWidget,
+  PropertyWidget* propertyWidget =
+      new PropertyWidget{sourcesForm->ProjManager()};
+  connect(sourcesForm, &SourcesForm::ShowProperty, propertyWidget,
           &PropertyWidget::ShowProperty);
-  connect(sourForm, &SourcesForm::ShowPropertyPanel, propertiesDockWidget,
+  connect(sourcesForm, &SourcesForm::ShowPropertyPanel, propertiesDockWidget,
           &QDockWidget::show);
   propertiesDockWidget->setWidget(propertyWidget->Widget());
   addDockWidget(Qt::LeftDockWidgetArea, propertiesDockWidget);
@@ -298,9 +299,9 @@ void MainWindow::ReShowWindow(QString strProject) {
   textEditor->RegisterCommands(GlobalSession);
   textEditor->setObjectName("textEditor");
 
-  connect(sourForm, SIGNAL(OpenFile(QString)), textEditor,
+  connect(sourcesForm, SIGNAL(OpenFile(QString)), textEditor,
           SLOT(SlotOpenFile(QString)));
-  connect(textEditor, SIGNAL(CurrentFileChanged(QString)), sourForm,
+  connect(textEditor, SIGNAL(CurrentFileChanged(QString)), sourcesForm,
           SLOT(SetCurrentFileItem(QString)));
 
   QWidget* centralWidget = new QWidget(this);
@@ -338,7 +339,7 @@ void MainWindow::ReShowWindow(QString strProject) {
   m_compiler->SetErrStream(&console->getErrorBuffer()->getStream());
   auto compilerNotifier = new FOEDAG::CompilerNotifier{c};
   m_compiler->SetTclInterpreterHandler(compilerNotifier);
-  auto tclCommandIntegration = sourForm->createTclCommandIntegarion();
+  auto tclCommandIntegration = sourcesForm->createTclCommandIntegarion();
   m_compiler->setGuiTclSync(tclCommandIntegration);
   connect(tclCommandIntegration, &TclCommandIntegration::newDesign, this,
           &MainWindow::newDesignCreated);
@@ -381,7 +382,7 @@ void MainWindow::ReShowWindow(QString strProject) {
 
   if (!strProject.isEmpty()) m_projectFileLoader->Load(strProject);
 
-  sourForm->InitSourcesForm();
+  sourcesForm->InitSourcesForm();
   // runForm->InitRunsForm();
   prViewButton(static_cast<int>(m_compiler->CompilerState()));
 }

--- a/src/NewProject/source_grid.cpp
+++ b/src/NewProject/source_grid.cpp
@@ -14,22 +14,24 @@ using namespace FOEDAG;
 
 sourceGrid::sourceGrid(QWidget *parent) : QWidget(parent) {
   m_lisFileData.clear();
-  m_btnAddFile = new QPushButton(tr("AddFile..."), this);
+  m_btnAddFile = new QPushButton(tr("Add File..."), this);
   connect(m_btnAddFile, &QPushButton::clicked, this, &sourceGrid::AddFiles);
-  m_btnAddDri = new QPushButton(tr("AddDir..."), this);
+  m_btnAddDri = new QPushButton(tr("Add Directory"
+                                   "..."),
+                                this);
   connect(m_btnAddDri, &QPushButton::clicked, this,
           &sourceGrid::AddDirectories);
-  m_btnCreateFile = new QPushButton(tr("CreateFile..."), this);
+  m_btnCreateFile = new QPushButton(tr("Create File..."), this);
   connect(m_btnCreateFile, &QPushButton::clicked, this,
           &sourceGrid::CreateFile);
   m_btnDelete = new QPushButton(tr("Remove"), this);
   m_btnDelete->setEnabled(false);
   connect(m_btnDelete, &QPushButton::clicked, this,
           &sourceGrid::DeleteTableItem);
-  m_btnMoveUp = new QPushButton(tr("MoveUp"), this);
+  m_btnMoveUp = new QPushButton(tr("Move Up"), this);
   m_btnMoveUp->setEnabled(false);
   connect(m_btnMoveUp, &QPushButton::clicked, this, &sourceGrid::UpTableItem);
-  m_btnMoveDown = new QPushButton(tr("MoveDown"), this);
+  m_btnMoveDown = new QPushButton(tr("Move Down"), this);
   m_btnMoveDown->setEnabled(false);
   connect(m_btnMoveDown, &QPushButton::clicked, this,
           &sourceGrid::DownTableItem);

--- a/src/NewProject/source_grid.cpp
+++ b/src/NewProject/source_grid.cpp
@@ -14,12 +14,12 @@ using namespace FOEDAG;
 
 sourceGrid::sourceGrid(QWidget *parent) : QWidget(parent) {
   m_lisFileData.clear();
-  m_btnAddFile = new QPushButton(tr("AddFile"), this);
+  m_btnAddFile = new QPushButton(tr("AddFile..."), this);
   connect(m_btnAddFile, &QPushButton::clicked, this, &sourceGrid::AddFiles);
-  m_btnAddDri = new QPushButton(tr("AddDir"), this);
+  m_btnAddDri = new QPushButton(tr("AddDir..."), this);
   connect(m_btnAddDri, &QPushButton::clicked, this,
           &sourceGrid::AddDirectories);
-  m_btnCreateFile = new QPushButton(tr("CreateFile"), this);
+  m_btnCreateFile = new QPushButton(tr("CreateFile..."), this);
   connect(m_btnCreateFile, &QPushButton::clicked, this,
           &sourceGrid::CreateFile);
   m_btnDelete = new QPushButton(tr("Remove"), this);

--- a/src/ProjNavigator/sources_form.cpp
+++ b/src/ProjNavigator/sources_form.cpp
@@ -383,16 +383,16 @@ void SourcesForm::CreateActions() {
           SLOT(SlotRefreshSourceTree()));
 
   m_actEditConstrsSets =
-      new QAction(tr("Create Constraints Set"), m_treeSrcHierachy);
+      new QAction(tr("Create Constraints Set..."), m_treeSrcHierachy);
   connect(m_actEditConstrsSets, SIGNAL(triggered()), this,
           SLOT(SlotCreateConstrSet()));
 
   m_actEditSimulSets =
-      new QAction(tr("Create Simulation Set"), m_treeSrcHierachy);
+      new QAction(tr("Create Simulation Set..."), m_treeSrcHierachy);
   connect(m_actEditSimulSets, SIGNAL(triggered()), this,
           SLOT(SlotCreateSimSet()));
 
-  m_actAddFile = new QAction(tr("Add Sources"), m_treeSrcHierachy);
+  m_actAddFile = new QAction(tr("Add Sources..."), m_treeSrcHierachy);
   m_actAddFile->setIcon(QIcon(":/images/add.png"));
   connect(m_actAddFile, SIGNAL(triggered()), this, SLOT(SlotAddFile()));
 
@@ -416,7 +416,7 @@ void SourcesForm::CreateActions() {
   m_actMakeActive = new QAction(tr("Make Active"), m_treeSrcHierachy);
   connect(m_actMakeActive, SIGNAL(triggered()), this, SLOT(SlotSetActive()));
 
-  m_actProperties = new QAction(tr("Properties"), m_treeSrcHierachy);
+  m_actProperties = new QAction(tr("Properties..."), m_treeSrcHierachy);
   connect(m_actProperties, SIGNAL(triggered()), this,
           SLOT(SlotPropertiesTriggered()));
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] [To follow a UI Standard. Changes are made for this issue: <issue id>](https://github.com/os-fpga/FOEDAG/issues/465)
> - [ ] While menu commands are used for immediate actions, more information might be needed to perform the action. Indicate a command that needs additional information (including a confirmation) by adding an ellipses "..." at the end of the label.

> ### Describe the technical details
> - [ ]  UI standards call for all menu picks that require additional user input to have ... at the end of their text.

> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, FOEDAG has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> - [ ] Changed the menu picks from "New" , "Open File ", "New Project", Open Project" to "New...", "Open File...", "New Project...", "Open Project..." and vice versa.
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Menu Picks That Invoke Dialog

> ### Impact of the pull request

> - [ ] To have standardized form of Menu Picks for user actions. 
