### PR TITLE
Default ProjectName Logic Improved

### DIFF
--- a/src/NewProject/location_form.cpp
+++ b/src/NewProject/location_form.cpp
@@ -22,7 +22,7 @@ locationForm::locationForm(QWidget *parent)
          "Next, you will specify the type of flow you'll be working with. "
          "Finally, you will specify your project sources and choose a default "
          "part."));
-  // int count = 1;
+
   ui->m_labelPname->setText(tr("Project Name:"));
   ui->m_labelPpath->setText(tr("Project Location:"));
   ui->m_checkBox->setText(tr("Create Project Subdirectory"));

--- a/src/NewProject/location_form.cpp
+++ b/src/NewProject/location_form.cpp
@@ -8,6 +8,11 @@ using namespace FOEDAG;
 locationForm::locationForm(QWidget *parent)
     : QWidget(parent), ui(new Ui::locationForm) {
   ui->setupUi(this);
+  int count = 1;
+  QString project_prefix = "project_";
+  while (QDir(project_prefix + QString::number(count)).exists()) {
+    count++;
+  }
   ui->m_labelTitle->setText(tr("Project Location"));
   ui->m_labelCont->setText(
       tr("This wizard will guide you through the creation of a new project."));
@@ -17,22 +22,23 @@ locationForm::locationForm(QWidget *parent)
          "Next, you will specify the type of flow you'll be working with. "
          "Finally, you will specify your project sources and choose a default "
          "part."));
+  // int count = 1;
   ui->m_labelPname->setText(tr("Project Name:"));
   ui->m_labelPpath->setText(tr("Project Location:"));
   ui->m_checkBox->setText(tr("Create Project Subdirectory"));
   ui->m_labelPath0->setText(tr("Project will be created at:"));
   ui->m_btnBrowse->setText(tr("Browse..."));
-  ui->m_lineEditPname->setText(QString("project_") + QString::number(count));
+  ui->m_lineEditPname->setText(project_prefix + QString::number(count));
   ui->m_lineEditPpath->setText(QDir::currentPath());
   ui->m_labelPath1->setText(ui->m_lineEditPpath->text());
   ui->m_checkBox->setCheckState(Qt::CheckState::Checked);
 
-  QString name = ui->m_lineEditPname->text();
-  while (QDir(name).exists()) {
-    ui->m_lineEditPname->setText(QString("project_") +
-                                 QString::number(count++));
-    name = ui->m_lineEditPname->text();
-  };
+  //  QString name = ui->m_lineEditPname->text();
+  //  while (QDir(name).exists()) {
+  //    ui->m_lineEditPname->setText(QString("project_") +
+  //                                 QString::number(count++));
+  //    name = ui->m_lineEditPname->text();
+  //  };
 }
 
 locationForm::~locationForm() { delete ui; }

--- a/src/NewProject/location_form.cpp
+++ b/src/NewProject/location_form.cpp
@@ -3,7 +3,6 @@
 #include <QFileDialog>
 
 #include "ui_location_form.h"
-
 using namespace FOEDAG;
 
 locationForm::locationForm(QWidget *parent)
@@ -23,10 +22,17 @@ locationForm::locationForm(QWidget *parent)
   ui->m_checkBox->setText(tr("Create Project Subdirectory"));
   ui->m_labelPath0->setText(tr("Project will be created at:"));
   ui->m_btnBrowse->setText(tr("Browse..."));
-  ui->m_lineEditPname->setText("project_1");
+  ui->m_lineEditPname->setText(QString("project_") + QString::number(count));
   ui->m_lineEditPpath->setText(QDir::currentPath());
   ui->m_labelPath1->setText(ui->m_lineEditPpath->text());
   ui->m_checkBox->setCheckState(Qt::CheckState::Checked);
+
+  QString name = ui->m_lineEditPname->text();
+  while (QDir(name).exists()) {
+    ui->m_lineEditPname->setText(QString("project_") +
+                                 QString::number(count++));
+    name = ui->m_lineEditPname->text();
+  };
 }
 
 locationForm::~locationForm() { delete ui; }

--- a/src/NewProject/location_form.cpp
+++ b/src/NewProject/location_form.cpp
@@ -22,7 +22,6 @@ locationForm::locationForm(QWidget *parent)
          "Next, you will specify the type of flow you'll be working with. "
          "Finally, you will specify your project sources and choose a default "
          "part."));
-
   ui->m_labelPname->setText(tr("Project Name:"));
   ui->m_labelPpath->setText(tr("Project Location:"));
   ui->m_checkBox->setText(tr("Create Project Subdirectory"));

--- a/src/NewProject/location_form.cpp
+++ b/src/NewProject/location_form.cpp
@@ -32,13 +32,6 @@ locationForm::locationForm(QWidget *parent)
   ui->m_lineEditPpath->setText(QDir::currentPath());
   ui->m_labelPath1->setText(ui->m_lineEditPpath->text());
   ui->m_checkBox->setCheckState(Qt::CheckState::Checked);
-
-  //  QString name = ui->m_lineEditPname->text();
-  //  while (QDir(name).exists()) {
-  //    ui->m_lineEditPname->setText(QString("project_") +
-  //                                 QString::number(count++));
-  //    name = ui->m_lineEditPname->text();
-  //  };
 }
 
 locationForm::~locationForm() { delete ui; }

--- a/src/NewProject/location_form.h
+++ b/src/NewProject/location_form.h
@@ -15,11 +15,11 @@ class locationForm : public QWidget {
  public:
   explicit locationForm(QWidget *parent = nullptr);
   ~locationForm();
+
   QString getProjectName();
   QString getProjectPath();
   bool IsCreateDir();
   bool IsProjectNameExit();
-
  private slots:
   void on_m_btnBrowse_clicked();
   void on_m_checkBox_stateChanged(int arg1);

--- a/src/NewProject/location_form.h
+++ b/src/NewProject/location_form.h
@@ -15,12 +15,11 @@ class locationForm : public QWidget {
  public:
   explicit locationForm(QWidget *parent = nullptr);
   ~locationForm();
-  int count = 1;
-
   QString getProjectName();
   QString getProjectPath();
   bool IsCreateDir();
   bool IsProjectNameExit();
+
  private slots:
   void on_m_btnBrowse_clicked();
   void on_m_checkBox_stateChanged(int arg1);

--- a/src/NewProject/location_form.h
+++ b/src/NewProject/location_form.h
@@ -15,6 +15,7 @@ class locationForm : public QWidget {
  public:
   explicit locationForm(QWidget *parent = nullptr);
   ~locationForm();
+  int count = 1;
 
   QString getProjectName();
   QString getProjectPath();


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue, Open --> https://github.com/os-fpga/FOEDAG/issues/466
> - [ ] The New Project wizard defaults to project_1 and project name check action was set on Next Button. Now logic is updated to automatically set the project name which doesn't exist in the directory without pressing Next Button. 

> ### Describe the technical details
> - When New Project Menu option is clicked, project name automatically sets to new name which doesn't exist in the directory. Each time creating a new project it increments "x" in  project_x as project name. By default it sets to project_1.
> #### What is currently done? (Provide issue link if applicable)

> <!-- Please provide a list of limitations if not specified in any issue --> https://github.com/os-fpga/FOEDAG/issues/466 
>- Project Name updated until a unique path is found without any button clicked.

> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. --> Unique Project Name Automated



> ### Impact of the pull request

> - [ ] It will add flexibility for user to have good user experience.
