### PR TITLE
Changed the newProject Dialog buttons to QDialogButtonBox standard bu…

### DIFF
--- a/src/NewProject/new_project_dialog.h
+++ b/src/NewProject/new_project_dialog.h
@@ -42,15 +42,17 @@ class newProjectDialog : public QDialog {
   void Reset();
 
  private slots:
-  void on_m_btnBack_clicked();
-  void on_m_btnNext_clicked();
-  void on_m_btnFinish_clicked();
-  void on_m_btnCancel_clicked();
+
+  void on_buttonBox_accepted();
+  void on_buttonBox_rejected();
+  void on_next();
+  void on_back();
 
  private:
   Ui::newProjectDialog* ui;
   int m_index;
-
+  QPushButton* NextBtn;
+  QPushButton* BackBtn;
   locationForm* m_locationForm;
   projectTypeForm* m_proTypeForm;
   addSourceForm* m_addSrcForm;

--- a/src/NewProject/new_project_dialog.ui
+++ b/src/NewProject/new_project_dialog.ui
@@ -61,7 +61,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="50,10,10,10,10">
+       <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0">
         <property name="spacing">
          <number>15</number>
         </property>
@@ -85,30 +85,9 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="m_btnBack">
-          <property name="text">
-           <string>Back</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="m_btnNext">
-          <property name="text">
-           <string>Next</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="m_btnFinish">
-          <property name="text">
-           <string>Finish</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="m_btnCancel">
-          <property name="text">
-           <string>Cancel</string>
+         <widget class="QDialogButtonBox" name="buttonBox">
+          <property name="standardButtons">
+           <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
…ttons

> ### Motivate of the pull request
> - [ ] Addressing the issue->https://github.com/os-fpga/FOEDAG/issues/468
> - [ ] To avoid inconsistency from existing UI dialog buttons used in FOEDAG, A standard class to avoid this issue is used which is QDialogButtonBox. Qt provides many standard buttons based on their roles with this class which also helps in creating custom buttons by defining their roles as per the action required.

> ### Describe the technical details
> - QDialogButtonBox allows to add buttons to it and will automatically use the appropriate layout for the user's desktop environment. Most buttons for a dialog follow certain roles. Such roles include: Accepting or rejecting the dialog. Asking for help. A custom buttons can also be created with QDialogButtonBox by defining their roles and connect them with the buttons.
Ref: https://doc.qt.io/qt-6/qdialogbuttonbox.html
> #### What is currently done? (Provide issue link if applicable)
> - Cancel and OK buttons are replaced with QDialogButtonBox's standard button list.
> - Next and Back buttons are replaced with custom  buttons using QDialogButtonBox class.
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] New Project window will change


> ### Impact of the pull request

> - [ ] To have buttons in a consistence manner.
