### PR TITLE
Fixed Stop button, when it become disable event operation is still running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ test/batch: run-cmake-release
 	./build/bin/foedag --batch --script tests/Testcases/aes_decrypt_fpga/aes_decrypt.tcl
 	./build/bin/foedag --batch --script tests/TestGui/compiler_flow.tcl
 	./build/bin/foedag --batch --script tests/TestBatch/test_compiler_mt.tcl
+	./build/bin/foedag --batch --script tests/TestBatch/test_compiler_stop.tcl
 	./build/bin/foedag --batch --script tests/TestBatch/test_compiler_batch.tcl
 
 lib-only: run-cmake-release

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -246,7 +246,6 @@ void MainWindow::createActions() {
   connect(startAction, &QAction::triggered, this, [this]() {
     m_compiler->start();
     m_taskManager->startAll();
-    m_compiler->finish();
   });
   connect(stopAction, &QAction::triggered, this,
           [this]() { m_compiler->Stop(); });
@@ -366,6 +365,9 @@ void MainWindow::ReShowWindow(QString strProject) {
   QWidget* view = prepareCompilerView(m_compiler, &m_taskManager);
   view->setObjectName("compilerTaskView");
   view->setParent(this);
+
+  connect(m_taskManager, &TaskManager::done, this,
+          [this]() { m_compiler->finish(); });
 
   connect(compilerNotifier, &CompilerNotifier::compilerStateChanged, this,
           &MainWindow::updatePRViewButton);

--- a/tests/TestBatch/test_compiler_stop.tcl
+++ b/tests/TestBatch/test_compiler_stop.tcl
@@ -1,0 +1,27 @@
+#Copyright 2021 The Foedag team
+
+#GPL License
+
+#Copyright (c) 2021 The Open-Source FPGA Foundation
+
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+batch {
+synth
+place
+}
+
+# 100 ms delay here, make sure synth has started
+after 100
+stop


### PR DESCRIPTION
### Motivate of the pull request
Fixed issue with Stop button. It become disable event when process still in progress

### Describe the technical details
Steps to reproduce:
* Open some project with openfpga compiler
* Press Start button
*Actual results:* Stop button become disable after second task has started.
*Expected results:* Stop button enabled until all tasks done.
![image](https://user-images.githubusercontent.com/95262932/181763826-4b497dfc-6931-4630-bc2e-ce04e4315696.png)

 
#### What is currently done? (Provide issue link if applicable)
Call Compiler::finish only after all tasks done.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [ ] Library: <Specify the library name>
 - [ ] Plug-in: <Specify the plugin name>
 - [x] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts

### Impact of the pull request
Need to test Stop button when run some script.

- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
