### PR TITLE
Resize task view columns to their contents instead of explicitly sett…

### DIFF
--- a/src/Compiler/CompilerDefines.cpp
+++ b/src/Compiler/CompilerDefines.cpp
@@ -43,8 +43,7 @@ QWidget *FOEDAG::prepareCompilerView(Compiler *compiler,
                    FOEDAG::handleTaskDialogRequested);
   view->setModel(model);
 
-  view->setColumnWidth(0, 30);
-  view->setColumnWidth(1, 160);
+  view->resizeColumnsToContents();
   view->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
   view->horizontalHeader()->setStretchLastSection(true);
   view->setMinimumWidth(340);


### PR DESCRIPTION
Given change improves tasks view initialization. We ask Qt to initialize column widths to their content in order to avoid truncating some text.

It's supposed to solve #522 issue, but I neither on Ubuntu nor on CentOS could I reproduce it. I theory, with previous approach of setting column widths, it was possible. Current commit should avoid it.

![image](https://user-images.githubusercontent.com/109239890/181789948-2cba64b3-ec8c-4ec6-8e4c-36048d599431.png)
