### PR TITLE
Fixed device selection when new project started

### DIFF
--- a/src/Compiler/CompilerDefines.cpp
+++ b/src/Compiler/CompilerDefines.cpp
@@ -106,3 +106,9 @@ int FOEDAG::read_sdc(const QString &file) {
                      qPrintable(QString("read_sdc {%1}").arg(f)));
   return (res == TCL_OK) ? 0 : -1;
 }
+
+bool FOEDAG::target_device(const QString &target) {
+  const int res = Tcl_Eval(GlobalSession->TclInterp()->getInterp(),
+                           qPrintable(QString("target_device %1").arg(target)));
+  return (res == TCL_OK);
+}

--- a/src/Compiler/CompilerDefines.h
+++ b/src/Compiler/CompilerDefines.h
@@ -99,5 +99,6 @@ uint toTaskId(int action, const Compiler *const compiler);
  * \return 0 if tcl command success otherwise return -1
  */
 [[nodiscard]] int read_sdc(const QString &file);
+bool target_device(const QString &target);
 
 }  // namespace FOEDAG

--- a/src/Main/ProjectFile/ProjectManagerComponent.cpp
+++ b/src/Main/ProjectFile/ProjectManagerComponent.cpp
@@ -315,6 +315,13 @@ void ProjectManagerComponent::Load(QXmlStreamReader* r) {
       }
     }
   }
+
+  // set device
+  m_projectManager->setCurrentRun(DEFAULT_FOLDER_SYNTH);
+  const auto device = m_projectManager->getSynthOption(PROJECT_PART_DEVICE);
+  if (!device.isEmpty()) {
+    target_device(device);
+  }
 }
 
 }  // namespace FOEDAG

--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -88,22 +88,27 @@ void ProjectManager::CreateProject(const ProjectOptions& opt) {
 
   setCurrentRun(DEFAULT_FOLDER_SYNTH);
 
-  QStringList strlist = opt.device;
-  QList<QPair<QString, QString>> listParam;
-  QPair<QString, QString> pair;
-  pair.first = PROJECT_PART_SERIES;
-  pair.second = strlist.at(0);
-  listParam.append(pair);
-  pair.first = PROJECT_PART_FAMILY;
-  pair.second = strlist.at(1);
-  listParam.append(pair);
-  pair.first = PROJECT_PART_PACKAGE;
-  pair.second = strlist.at(2);
-  listParam.append(pair);
-  pair.first = PROJECT_PART_DEVICE;
-  pair.second = strlist.at(3);
-  listParam.append(pair);
-  setSynthesisOption(listParam);
+  if (opt.device.count() >= 4) {
+    QStringList strlist = opt.device;
+    QList<QPair<QString, QString>> listParam;
+    QPair<QString, QString> pair;
+    pair.first = PROJECT_PART_SERIES;
+    pair.second = strlist.at(0);
+    listParam.append(pair);
+    pair.first = PROJECT_PART_FAMILY;
+    pair.second = strlist.at(1);
+    listParam.append(pair);
+    pair.first = PROJECT_PART_PACKAGE;
+    pair.second = strlist.at(2);
+    listParam.append(pair);
+    pair.first = PROJECT_PART_DEVICE;
+    pair.second = strlist.at(3);
+    listParam.append(pair);
+    setSynthesisOption(listParam);
+
+    auto targetDevice = strlist.at(3);
+    target_device(targetDevice);
+  }
 
   FinishedProject();
 }
@@ -1137,6 +1142,14 @@ int ProjectManager::setSynthesisOption(
     proRun->setOption(pair.first, pair.second);
   }
   return ret;
+}
+
+QString ProjectManager::getSynthOption(const QString& optionName) const {
+  ProjectRun* proRun = Project::Instance()->getProjectRun(m_currentRun);
+  if (nullptr == proRun) {
+    return {};
+  }
+  return proRun->getOption(optionName);
 }
 
 int ProjectManager::setRunActive(const QString& strRunName) {

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -222,6 +222,7 @@ class ProjectManager : public QObject {
   // Please set currentrun before using this function, Unless you used
   // setSynthRun/setImpleRun before
   int setSynthesisOption(const QList<QPair<QString, QString>> &listParam);
+  QString getSynthOption(const QString &optionName) const;
 
   int setRunActive(const QString &strRunName);
 

--- a/src/ProjNavigator/tcl_command_integration.cpp
+++ b/src/ProjNavigator/tcl_command_integration.cpp
@@ -249,7 +249,7 @@ void TclCommandIntegration::createNewDesign(const QString &projName) {
                      "RTL",
                      {{}, false},
                      {{}, false},
-                     {"series1", "familyone", "SBG484", "fpga100t"},
+                     {},
                      true /*rewrite*/,
                      DEFAULT_FOLDER_SOURCE};
   m_projManager->CreateProject(opt);


### PR DESCRIPTION
### Motivate of the pull request
This is a fix of a bug that related to new project creation. When user wants create new project, the selection of the device doesn't taking into account.

### Describe the technical details
When user select device and press Ok in the wizard, target_device tcl command is running with corresponding device name. Also, the same happened when file is loading.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [ ] Library: <Specify the library name>
 - [ ] Plug-in: <Specify the plugin name>
 - [x] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts