### PR TITLE
show main window maximized; restore as 2/3 of primary screen

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -60,15 +60,15 @@ MainWindow::MainWindow(Session* session) : m_session(session) {
   m_compiler = session->GetCompiler();
   m_interpreter = session->TclInterp();
 
-  auto sceenGeometry = qApp->primaryScreen()->availableGeometry();
+  auto screenGeometry = qApp->primaryScreen()->availableGeometry();
 
-  // Take 2/3 part of the sceen.
+  // Take 2/3 part of the screen.
   auto mainWindowSize =
-      QSize(sceenGeometry.width() * 2 / 3, sceenGeometry.height() * 2 / 3);
+      QSize(screenGeometry.width() * 2 / 3, screenGeometry.height() * 2 / 3);
   // Center main window on the screen. It will get this geometry after switching
   // from maximized mode.
   setGeometry(QStyle::alignedRect(Qt::LeftToRight, Qt::AlignCenter,
-                                  mainWindowSize, sceenGeometry));
+                                  mainWindowSize, screenGeometry));
   // Initially, main window should be maximized.
   showMaximized();
 

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -57,12 +57,20 @@ extern const char* foedag_build_type;
 MainWindow::MainWindow(Session* session) : m_session(session) {
   /* Window settings */
   setWindowTitle(tr("FOEDAG"));
-  resize(350, 250);
   m_compiler = session->GetCompiler();
   m_interpreter = session->TclInterp();
-  QDesktopWidget dw;
-  setGeometry(dw.width() / 6, dw.height() / 6, dw.width() * 2 / 3,
-              dw.height() * 2 / 3);
+
+  auto sceenGeometry = qApp->primaryScreen()->availableGeometry();
+
+  // Take 2/3 part of the sceen.
+  auto mainWindowSize =
+      QSize(sceenGeometry.width() * 2 / 3, sceenGeometry.height() * 2 / 3);
+  // Center main window on the screen. It will get this geometry after switching
+  // from maximized mode.
+  setGeometry(QStyle::alignedRect(Qt::LeftToRight, Qt::AlignCenter,
+                                  mainWindowSize, sceenGeometry));
+  // Initially, main window should be maximized.
+  showMaximized();
 
   setDockNestingEnabled(true);
 


### PR DESCRIPTION
Given PR makes sure that GUI takes the full-screen size after startup. 
After switching to 'Normal' mode GUI takes 2/3 part of the screen, horizontally aligned.

Calculations are based on more recent QScreen instead of QDesktopWidget. It's also recommended by Qt:
https://doc.qt.io/qt-5/qdesktopwidget-obsolete.html