### PR TITLE
[RG-25] Renaming New Project Wizard Ok button to Finish

### DIFF
--- a/src/NewProject/new_project_dialog.cpp
+++ b/src/NewProject/new_project_dialog.cpp
@@ -21,6 +21,8 @@ newProjectDialog::newProjectDialog(QWidget *parent)
   ui->buttonBox->addButton(NextBtn, QDialogButtonBox::ButtonRole::ActionRole);
   connect(NextBtn, &QPushButton::clicked, this, &newProjectDialog::on_next);
 
+  ui->buttonBox->button(QDialogButtonBox::Ok)->setText("Finish");
+
   Reset();
 
   m_projectManager = new ProjectManager(this);


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-25
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> The standard OK button was used when dialog was switched to QDialogButtonBox
>
> #### What does this pull request change?
> This renames the QDialogButtonBox OK button to "Finish"

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

<img width="461" alt="image" src="https://user-images.githubusercontent.com/103447061/185438914-0e9fffb9-4499-4cb5-b452-08c46f0c5b0b.png">

> ### Testing
> - Testing via CI smoke tests as well as manual integration testing w/ Raptor
> - This change is in text only and has no real testable results or logic changes that require testing
