### PR TITLE
RG-32: Refactoring IpConfigurator

### DIFF
--- a/src/IpConfigurator/CMakeLists.txt
+++ b/src/IpConfigurator/CMakeLists.txt
@@ -44,6 +44,7 @@ include_directories(
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../lib)
 
 set (SRC_CPP_LIST
+  IpConfiguratorCreator.cpp
   IpCatalogTree.cpp
   IpConfigDlg.cpp
   IpConfigurator.cpp
@@ -52,15 +53,16 @@ set (SRC_CPP_LIST
 )
 
 set (SRC_H_INSTALL_LIST
+  IpConfiguratorCreator.h
+)
+
+set (SRC_H_LIST
+  ${SRC_H_INSTALL_LIST}
   IpCatalogTree.h
   IpConfigDlg.h
   IpConfigurator.h
   IpInstancesTree.h
   IpTreesWidget.h
-)
-
-set (SRC_H_LIST
-    ${SRC_H_INSTALL_LIST}
 )
 
 set (SRC_UI_LIST

--- a/src/IpConfigurator/IpConfigurator.cpp
+++ b/src/IpConfigurator/IpConfigurator.cpp
@@ -84,36 +84,25 @@ void FOEDAG::registerIpConfiguratorCommands(QWidget* widget,
                                             FOEDAG::Session* session) {
   auto show = [](void* clientData, Tcl_Interp* interp, int argc,
                  const char* argv[]) -> int {
-    Q_UNUSED(interp);
-    Q_UNUSED(argv);
-    Q_UNUSED(argc);
-    FOEDAG::IpConfigurator* configurator =
-        (FOEDAG::IpConfigurator*)(clientData);
-    configurator->ShowIpTrees();
-    return 0;
+    QWidget* w = static_cast<QWidget*>(clientData);
+    w->show();
+    return TCL_OK;
   };
   session->TclInterp()->registerCmd("ipconfigurator_show", show, widget, 0);
 
   auto hide = [](void* clientData, Tcl_Interp* interp, int argc,
                  const char* argv[]) -> int {
-    Q_UNUSED(interp);
-    Q_UNUSED(argv);
-    Q_UNUSED(argc);
-    FOEDAG::IpConfigurator* configurator =
-        (FOEDAG::IpConfigurator*)(clientData);
-    configurator->HideIpTrees();
-    return 0;
+    QWidget* w = static_cast<QWidget*>(clientData);
+    w->hide();
+    return TCL_OK;
   };
   session->TclInterp()->registerCmd("ipconfigurator_hide", hide, widget, 0);
 
   auto show_dlg = [](void* clientData, Tcl_Interp* interp, int argc,
                      const char* argv[]) -> int {
-    Q_UNUSED(interp);
-    Q_UNUSED(argv);
-    Q_UNUSED(argc);
-    FOEDAG::IpConfigurator* configurator =
-        (FOEDAG::IpConfigurator*)(clientData);
-    configurator->ShowConfigDlg();
+    IpConfigDlg* dlg = new IpConfigDlg();
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->exec();
     return 0;
   };
   session->TclInterp()->registerCmd("ipconfigurator_show_dlg", show_dlg, widget,

--- a/src/IpConfigurator/IpConfiguratorCreator.cpp
+++ b/src/IpConfigurator/IpConfiguratorCreator.cpp
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "IpConfiguratorCreator.h"
+
+#include <QBoxLayout>
+
+#include "IpCatalogTree.h"
+// #include "IpConfigurator.h"
+
+namespace FOEDAG {
+
+IpConfiguratorCreator::IpConfiguratorCreator() {
+  auto catalogTree = new IpCatalogTree;
+  m_availableIpsView = CreateLayoutedWidget(catalogTree);
+}
+
+QWidget *IpConfiguratorCreator::GetAvailableIpsWidget() {
+  return m_availableIpsView;
+}
+
+QWidget *IpConfiguratorCreator::CreateLayoutedWidget(QWidget *main) {
+  QWidget *w = new QWidget;
+  w->setLayout(new QVBoxLayout);
+  w->layout()->addWidget(main);
+  return w;
+}
+
+}  // namespace FOEDAG

--- a/src/IpConfigurator/IpConfiguratorCreator.h
+++ b/src/IpConfigurator/IpConfiguratorCreator.h
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <QWidget>
+
+namespace FOEDAG {
+
+class IpConfiguratorCreator {
+ public:
+  IpConfiguratorCreator();
+  QWidget *GetAvailableIpsWidget();
+
+ private:
+  QWidget *CreateLayoutedWidget(QWidget *main);
+
+ private:
+  QWidget *m_availableIpsView{nullptr};
+};
+
+}  // namespace FOEDAG

--- a/src/IpConfigurator/Test/ipconfigurator_main.cpp
+++ b/src/IpConfigurator/Test/ipconfigurator_main.cpp
@@ -20,15 +20,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <QApplication>
+#include <QHBoxLayout>
 
 #include "IpConfigurator/IpConfigurator.h"
+#include "IpConfiguratorCreator.h"
 #include "Main/Foedag.h"
 #include "Main/qttclnotifier.hpp"
 #include "Tcl/TclInterpreter.h"
 
 QWidget* ipconfiguratorBuilder(FOEDAG::Session* session) {
-  Q_UNUSED(session);
-  return new FOEDAG::IpConfigurator();
+  FOEDAG::IpConfiguratorCreator* creator = new FOEDAG::IpConfiguratorCreator;
+  QWidget* w = new QWidget;
+  w->setLayout(new QHBoxLayout);
+  w->layout()->addWidget(creator->GetAvailableIpsWidget());
+  return w;
 }
 
 int main(int argc, char** argv) {

--- a/src/Main/registerTclCommands.cpp
+++ b/src/Main/registerTclCommands.cpp
@@ -296,7 +296,5 @@ void registerAllFoedagCommands(QWidget* widget, FOEDAG::Session* session) {
       session->TclInterp()->registerCmd("EditTaskSettings", EditTaskSettingsFn,
                                         0, 0);
     }
-
-    FOEDAG::registerIpConfiguratorCommands(nullptr, session);
   }
 }

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -71,10 +71,10 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void clearDockWidgets();
   void startStopButtonsState();
   void loadFile(const QString& file);
-  void createIpConfiguratorUI(QDockWidget* prevTab = nullptr);
   QDockWidget* PrepareTab(const QString& name, const QString& objName,
                           QWidget* widget, QDockWidget* tabToAdd,
                           Qt::DockWidgetArea area = Qt::BottomDockWidgetArea);
+  void cleanUpDockWidgets(std::vector<QDockWidget*> dockWidgets);
 
  private: /* Objects/Widgets under the main window */
   /* Menu bar objects */
@@ -92,6 +92,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   QAction* stopAction = nullptr;
   QAction* aboutAction = nullptr;
   QAction* pinAssignmentAction = nullptr;
+  QAction* ipConfiguratorAction = nullptr;
   newProjectDialog* newProjdialog = nullptr;
   /* Tool bar objects */
   QToolBar* fileToolBar = nullptr;
@@ -99,7 +100,6 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   Session* m_session = nullptr;
   TclInterpreter* m_interpreter = nullptr;
   ProjectInfo m_projectInfo;
-  IpConfigurator m_ipConfigurator;
   class TaskManager* m_taskManager{nullptr};
   class Compiler* m_compiler{nullptr};
   class TclConsoleWidget* m_console{nullptr};
@@ -109,6 +109,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   QWidget* m_progressWidget{nullptr};
   QDockWidget* m_dockConsole{nullptr};
   std::vector<QDockWidget*> m_pinAssignmentDocks;
+  std::vector<QDockWidget*> m_ipConfiguratorDocks;
 };
 
 }  // namespace FOEDAG

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -24,7 +24,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QMainWindow>
 
-#include "IpConfigurator/IpConfigurator.h"
 #include "Main/AboutWidget.h"
 #include "NewProject/new_project_dialog.h"
 #include "TopLevelInterface.h"


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-32

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> The IpConfigurator's submodule creation wasn't correct and could lead to a segfault under testing
>
> #### What does this pull request change?
> This updates the IpConfigurator such that it copies the approach of other submodules

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts
> - [x] None

> ### Impact of the pull request
> - ipconfigurator_show & ipconfigurator_hide are are contained in the submodule and not longer installed in the foedag interpreter
> - The IP Configurator's available IP's tree is now displayed by using the View menu
> ![image](https://user-images.githubusercontent.com/103447061/186221746-353c2352-9d6d-40da-a382-dd49f4e1f953.png)

> ### Testing
> - Existing smoke tests already test this functionality. Refactor and view menu changes were manually tested in foedag and raptor.
