### PR TITLE
Add IO ports table and sync with package pin table

### DIFF
--- a/etc/templates/ports_test.json
+++ b/etc/templates/ports_test.json
@@ -1,0 +1,8 @@
+{
+  "Top Module": "NAME_OF_THE_TOP_MODULE",
+  "Ports": [
+    {"name": "inp1", "direction": "Input", "range": {"msb":0, "lsb":0}, "type": "LOGIC"},
+    {"name": "out1", "direction": "Output", "range": {"msb":4, "lsb":0}, "type": "REG"},
+    {"name": "inout1", "direction": "Inout", "range": {"msb":2, "lsb":0}, "type": "LOGIC"}
+  ]
+}

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -174,6 +174,7 @@ void MainWindow::openFileSlot() {
 
 void MainWindow::newDesignCreated(const QString& design) {
   setWindowTitle(m_projectInfo.name + " - " + design);
+  pinAssignmentAction->setChecked(false);
 }
 
 void MainWindow::startStopButtonsState() {
@@ -322,13 +323,17 @@ void MainWindow::createActions() {
   pinAssignmentAction->setCheckable(true);
   connect(pinAssignmentAction, &QAction::triggered, this, [this]() {
     if (pinAssignmentAction->isChecked()) {
-      PinAssignmentCreator creator{m_projectManager, GlobalSession->Context()};
+      PinAssignmentCreator* creator = new PinAssignmentCreator{
+          m_projectManager, GlobalSession->Context(), this};
+      connect(creator, &PinAssignmentCreator::selectionHasChanged, this,
+              []() { /* TODO @volodymyrk RG-9*/ });
+
       auto portsDockWidget =
-          PrepareTab(tr("IO Ports"), "portswidget", creator.GetPortsWidget(),
+          PrepareTab(tr("IO Ports"), "portswidget", creator->GetPortsWidget(),
                      m_dockConsole);
       auto packagePinDockWidget =
           PrepareTab(tr("Package Pins"), "packagepinwidget",
-                     creator.GetPackagePinsWidget(), portsDockWidget);
+                     creator->GetPackagePinsWidget(), portsDockWidget);
       m_pinAssignmentDocks = {portsDockWidget, packagePinDockWidget};
     } else {
       cleanUpDockWidgets(m_pinAssignmentDocks);

--- a/src/PinAssignment/BufferedComboBox.cpp
+++ b/src/PinAssignment/BufferedComboBox.cpp
@@ -18,26 +18,18 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#pragma once
+#include "BufferedComboBox.h"
 
-#include "PinAssignmentBaseView.h"
-
-class QComboBox;
 namespace FOEDAG {
 
-class PortsView : public PinAssignmentBaseView {
-  Q_OBJECT
- public:
-  PortsView(PinsBaseModel *model, QWidget *parent = nullptr);
+BufferedComboBox::BufferedComboBox(QWidget *parent) : QComboBox(parent) {
+  connect(this, SIGNAL(currentIndexChanged(int)), this, SLOT(textChanged(int)));
+}
 
- signals:
-  void selectionHasChanged();
+QString BufferedComboBox::previousText() const { return m_previousText; }
 
- private:
-  void packagePinSelectionHasChanged(const QModelIndex &index);
-
- private slots:
-  void itemHasChanged(const QModelIndex &index, const QString &pin);
-};
-
+void BufferedComboBox::textChanged(int) {
+  m_previousText = m_currentText;
+  m_currentText = currentText();
+}
 }  // namespace FOEDAG

--- a/src/PinAssignment/BufferedComboBox.h
+++ b/src/PinAssignment/BufferedComboBox.h
@@ -20,34 +20,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <QWidget>
-
-#include "NewProject/ProjectManager/project_manager.h"
+#include <QComboBox>
 
 namespace FOEDAG {
 
-class ToolContext;
-class PinAssignmentCreator : public QObject {
+/*!
+ * \brief The BufferedComboBox class
+ * This implementation of combo box holds previous value of the combo box
+ * after user changed current selection
+ */
+class BufferedComboBox : public QComboBox {
   Q_OBJECT
  public:
-  PinAssignmentCreator(ProjectManager *projectManager, ToolContext *context,
-                       QObject *parent = nullptr);
-  QWidget *GetPackagePinsWidget();
-  QWidget *GetPortsWidget();
+  explicit BufferedComboBox(QWidget *parent = nullptr);
+  QString previousText() const;
 
- signals:
-  void selectionHasChanged();
+ private slots:
+  void textChanged(int);
 
  private:
-  QWidget *CreateLayoutedWidget(QWidget *main);
-  QString searchCsvFile(const QString &targetDevice,
-                        ToolContext *context) const;
-  QString targetDevice(ProjectManager *projectManager) const;
-  QString searchPortsFile(ToolContext *context) const;
-
- private:
-  QWidget *m_portsView{nullptr};
-  QWidget *m_packagePinsView{nullptr};
+  QString m_previousText;
+  QString m_currentText;
 };
 
 }  // namespace FOEDAG

--- a/src/PinAssignment/CMakeLists.txt
+++ b/src/PinAssignment/CMakeLists.txt
@@ -51,6 +51,8 @@ set (SRC_CPP_LIST
   PackagePinsLoader.cpp
   PortsLoader.cpp
   ConstraintCreator.cpp
+  BufferedComboBox.cpp
+  PinAssignmentBaseView.cpp
 )
 
 set (H_INSTALL_LIST
@@ -67,6 +69,8 @@ set (SRC_H_LIST
   PackagePinsLoader.h
   PortsLoader.h
   ConstraintCreator.h
+  BufferedComboBox.h
+  PinAssignmentBaseView.h
 )
 
 set (SRC_UI_LIST

--- a/src/PinAssignment/PackagePinsLoader.cpp
+++ b/src/PinAssignment/PackagePinsLoader.cpp
@@ -62,6 +62,7 @@ bool PackagePinsLoader::load(const QString &fileName) {
     group.pinData.append({data});
   }
   m_model->append(group);  // append last
+  m_model->initListModel();
 
   return true;
 }

--- a/src/PinAssignment/PackagePinsModel.cpp
+++ b/src/PinAssignment/PackagePinsModel.cpp
@@ -22,7 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FOEDAG {
 
-PackagePinsModel::PackagePinsModel(QObject *parent) : QObject(parent) {}
+PackagePinsModel::PackagePinsModel(QObject *parent)
+    : QObject(parent), m_listModel(new QStringListModel) {}
 
 QStringList PackagePinsModel::headerList() const {
   return {"Name", "Available",  "Ports",     "Ref clock",   "Bank",
@@ -34,6 +35,27 @@ void PackagePinsModel::append(const PackagePinGroup &g) { m_pinData.append(g); }
 
 const QVector<PackagePinGroup> &PackagePinsModel::pinData() const {
   return m_pinData;
+}
+
+QStringListModel *PackagePinsModel::listModel() const { return m_listModel; }
+
+void PackagePinsModel::initListModel() {
+  QStringList pinsList;
+  pinsList.append(QString());
+  for (const auto &group : m_pinData) {
+    for (const auto &pin : group.pinData) {
+      pinsList.append(pin.data.at(PinName));
+    }
+  }
+  m_listModel->setStringList(pinsList);
+}
+
+void PackagePinsModel::insert(const QString &name, const QModelIndex &index) {
+  m_indexes.insert(name, index);
+}
+
+void PackagePinsModel::itemChange(const QString &name, const QString &pin) {
+  emit itemHasChanged(m_indexes.value(name), pin);
 }
 
 }  // namespace FOEDAG

--- a/src/PinAssignment/PackagePinsModel.h
+++ b/src/PinAssignment/PackagePinsModel.h
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 #include <QObject>
 #include <QStringList>
+#include <QStringListModel>
 #include <QVector>
 
 namespace FOEDAG {
@@ -52,15 +53,27 @@ struct PackagePinGroup {
 };
 
 class PackagePinsModel : public QObject {
+  Q_OBJECT
  public:
-  PackagePinsModel(QObject* parent = nullptr);
+  PackagePinsModel(QObject *parent = nullptr);
   QStringList headerList() const;
 
-  void append(const PackagePinGroup& g);
-  const QVector<PackagePinGroup>& pinData() const;
+  void append(const PackagePinGroup &g);
+  const QVector<PackagePinGroup> &pinData() const;
+
+  QStringListModel *listModel() const;
+  void initListModel();
+
+  void insert(const QString &name, const QModelIndex &index);
+  void itemChange(const QString &name, const QString &pin);
+
+ signals:
+  void itemHasChanged(const QModelIndex &index, const QString &pin);
 
  private:
   QVector<PackagePinGroup> m_pinData;
+  QStringListModel *m_listModel{nullptr};
+  QMap<QString, QModelIndex> m_indexes;
 };
 
 }  // namespace FOEDAG

--- a/src/PinAssignment/PackagePinsView.h
+++ b/src/PinAssignment/PackagePinsView.h
@@ -20,23 +20,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <QTreeWidget>
+#include "PinAssignmentBaseView.h"
+#include "PinsBaseModel.h"
 
-#include "PackagePinsModel.h"
-
+class QComboBox;
 namespace FOEDAG {
 
-class PackagePinsView : public QTreeWidget {
+class PackagePinsView : public PinAssignmentBaseView {
   Q_OBJECT
  public:
-  PackagePinsView(PackagePinsModel *model, QWidget *parent = nullptr);
+  PackagePinsView(PinsBaseModel *model, QWidget *parent = nullptr);
 
- private slots:
-  void ioPortsSelectionHasChanged(const QModelIndex &index);
+ signals:
+  void selectionHasChanged();
 
  private:
+  void ioPortsSelectionHasChanged(const QModelIndex &index);
   void insertData(const QStringList &data, int index, int column,
                   QTreeWidgetItem *item);
+
+ private slots:
+  void itemHasChanged(const QModelIndex &index, const QString &pin);
 };
 
 }  // namespace FOEDAG

--- a/src/PinAssignment/PinAssignmentBaseView.cpp
+++ b/src/PinAssignment/PinAssignmentBaseView.cpp
@@ -18,26 +18,23 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#pragma once
-
 #include "PinAssignmentBaseView.h"
 
-class QComboBox;
+#include <QComboBox>
+
 namespace FOEDAG {
 
-class PortsView : public PinAssignmentBaseView {
-  Q_OBJECT
- public:
-  PortsView(PinsBaseModel *model, QWidget *parent = nullptr);
+PinAssignmentBaseView::PinAssignmentBaseView(PinsBaseModel *model,
+                                             QWidget *parent)
+    : QTreeWidget(parent), m_model(model) {}
 
- signals:
-  void selectionHasChanged();
-
- private:
-  void packagePinSelectionHasChanged(const QModelIndex &index);
-
- private slots:
-  void itemHasChanged(const QModelIndex &index, const QString &pin);
-};
-
+void PinAssignmentBaseView::removeDuplications(const QString &text,
+                                               QComboBox *current) {
+  for (auto &c : m_allCombo) {
+    if ((c != current) && (c->currentText() == text)) {
+      c->setCurrentIndex(0);
+      break;
+    }
+  }
+}
 }  // namespace FOEDAG

--- a/src/PinAssignment/PinAssignmentBaseView.h
+++ b/src/PinAssignment/PinAssignmentBaseView.h
@@ -20,34 +20,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <QWidget>
+#include <QTreeWidget>
 
-#include "NewProject/ProjectManager/project_manager.h"
-
+class QComboBox;
 namespace FOEDAG {
 
-class ToolContext;
-class PinAssignmentCreator : public QObject {
-  Q_OBJECT
+class PinsBaseModel;
+
+/*!
+ * \brief The PinAssignmentBaseView class
+ * The implemenation provide common funtionality to Package pin table and Ports
+ * table.
+ */
+class PinAssignmentBaseView : public QTreeWidget {
  public:
-  PinAssignmentCreator(ProjectManager *projectManager, ToolContext *context,
-                       QObject *parent = nullptr);
-  QWidget *GetPackagePinsWidget();
-  QWidget *GetPortsWidget();
+  PinAssignmentBaseView(PinsBaseModel *model, QWidget *parent = nullptr);
 
- signals:
-  void selectionHasChanged();
+ protected:
+  void removeDuplications(const QString &text, QComboBox *current);
 
- private:
-  QWidget *CreateLayoutedWidget(QWidget *main);
-  QString searchCsvFile(const QString &targetDevice,
-                        ToolContext *context) const;
-  QString targetDevice(ProjectManager *projectManager) const;
-  QString searchPortsFile(ToolContext *context) const;
-
- private:
-  QWidget *m_portsView{nullptr};
-  QWidget *m_packagePinsView{nullptr};
+ protected:
+  PinsBaseModel *m_model{nullptr};
+  bool m_blockUpdate{false};
+  QVector<QComboBox *> m_allCombo;
 };
 
 }  // namespace FOEDAG

--- a/src/PinAssignment/PinsBaseModel.cpp
+++ b/src/PinAssignment/PinsBaseModel.cpp
@@ -24,27 +24,27 @@ namespace FOEDAG {
 
 PinsBaseModel::PinsBaseModel() {}
 
-QStringList PinsBaseModel::banks() const { return {"Bank 0", "Bank 1"}; }
-
-QVector<IOPort> PinsBaseModel::ioPorts() const {
-  QVector<IOPort> ports;
-  ports.append({"IN0", "INPUT", {}, {}});
-  ports.append({"IN1", "INPUT", {}, {}});
-  ports.append({"OUT", "OUTPUT", {}, {}});
-  return ports;
+bool PinsBaseModel::exists(const QString &port, const QString &pin) const {
+  return m_pinsMap.contains(port) &&
+         std::find(m_pinsMap.constBegin(), m_pinsMap.constEnd(), pin) !=
+             m_pinsMap.constEnd();
 }
 
-QVector<PinBank> PinsBaseModel::packagePins() const {
-  QVector<PinBank> banks;
-  banks.append({"System", {{"RST_N", {}}, {"XIN", {}}}});
-  banks.append({"JTAG", {{"JTAG_TDI", {}}, {"JTAG_TDO", {}}}});
-  banks.append({"GPIO", {{"GPIO_A_0", {}}, {"GPIO_A_1", {}}}});
-  banks.append({"GBe", {{"MDIO_MDCÂ", {}}, {"MDIO_DATAÂ", {}}}});
-  banks.append({"USB", {{"USB_DPÂ", {}}, {"USB_DNÂ", {}}}});
-  banks.append({"I2C CLK", {{"I2C_SCLÂ", {}}}});
-  banks.append({"SPI CLK", {{"SPI_SCLKÂ", {}}}});
-  banks.append({"GPT", {{"GPT_RTC", {}}}});
-  banks.append({"DDR", {{"PAD_MEM_DQS_N[0]", {}}, {"PAD_MEM_DQS_N[1]", {}}}});
-  return banks;
+void PinsBaseModel::insert(const QString &port, const QString &pin) {
+  m_pinsMap.insert(port, pin);
+}
+
+PackagePinsModel *PinsBaseModel::packagePinModel() const {
+  return m_packagePinModel;
+}
+
+void PinsBaseModel::setPackagePinModel(PackagePinsModel *newPackagePinModel) {
+  m_packagePinModel = newPackagePinModel;
+}
+
+PortsModel *PinsBaseModel::portsModel() const { return m_portsModel; }
+
+void PinsBaseModel::setPortsModel(PortsModel *newPortsModel) {
+  m_portsModel = newPortsModel;
 }
 }  // namespace FOEDAG

--- a/src/PinAssignment/PinsBaseModel.h
+++ b/src/PinAssignment/PinsBaseModel.h
@@ -22,31 +22,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QStringList>
 #include <QVector>
 
+#include "PackagePinsModel.h"
+#include "PortsModel.h"
+
 namespace FOEDAG {
-
-struct IOPort {
-  QString name;
-  QString dir;
-  QString packagePin;
-  QString bank;
-};
-
-struct PackagePin {
-  QString name;
-  QString ioPort;
-};
-
-struct PinBank {
-  QString id;
-  QVector<PackagePin> pins;
-};
 
 class PinsBaseModel {
  public:
   PinsBaseModel();
-  QStringList banks() const;
-  QVector<IOPort> ioPorts() const;
-  QVector<PinBank> packagePins() const;
+
+  bool exists(const QString &port, const QString &pin) const;
+  void insert(const QString &port, const QString &pin);
+
+  PackagePinsModel *packagePinModel() const;
+  void setPackagePinModel(PackagePinsModel *newPackagePinModel);
+
+  PortsModel *portsModel() const;
+  void setPortsModel(PortsModel *newPortsModel);
+
+ private:
+  QMap<QString, QString> m_pinsMap;
+  PackagePinsModel *m_packagePinModel;
+  PortsModel *m_portsModel;
 };
 
 }  // namespace FOEDAG

--- a/src/PinAssignment/PortsLoader.h
+++ b/src/PinAssignment/PortsLoader.h
@@ -20,11 +20,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
 
+#include <QObject>
+
+#include "PortsModel.h"
+
 namespace FOEDAG {
 
-class PortsLoader {
+class PortsLoader : public QObject {
  public:
-  PortsLoader();
+  PortsLoader(PortsModel *model, QObject *parent = nullptr);
+  virtual ~PortsLoader();
+  virtual bool load(const QString &file);
+
+ protected:
+  PortsModel *m_model{nullptr};
 };
 
 }  // namespace FOEDAG

--- a/src/PinAssignment/PortsModel.cpp
+++ b/src/PinAssignment/PortsModel.cpp
@@ -22,5 +22,32 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FOEDAG {
 
-PortsModel::PortsModel() {}
+PortsModel::PortsModel(QObject *parent)
+    : QObject(parent), m_model(new QStringListModel(this)) {}
+
+QStringList PortsModel::headerList() const {
+  return {"Name", "Dir", "Package Pin", "Type", "Range"};
+}
+
+void PortsModel::append(const IOPortGroup &p) { m_ioPorts.append(p); }
+
+const QVector<IOPortGroup> &PortsModel::ports() const { return m_ioPorts; }
+
+void PortsModel::initListModel() {
+  QStringList portsList;
+  portsList.append(QString());
+  for (const auto &group : qAsConst(m_ioPorts))
+    for (const auto &p : qAsConst(group.ports)) portsList.append(p.name);
+  m_model->setStringList(portsList);
+}
+
+QStringListModel *PortsModel::listModel() const { return m_model; }
+
+void PortsModel::insert(const QString &name, const QModelIndex &index) {
+  m_indexes.insert(name, index);
+}
+
+void PortsModel::itemChange(const QString &name, const QString &newPin) {
+  emit itemHasChanged(m_indexes.value(name), newPin);
+}
 }  // namespace FOEDAG

--- a/src/PinAssignment/PortsModel.h
+++ b/src/PinAssignment/PortsModel.h
@@ -20,11 +20,46 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
 
+#include <QObject>
+#include <QStringList>
+#include <QStringListModel>
+#include <QVector>
+
 namespace FOEDAG {
 
-class PortsModel {
+struct IOPort {
+  QString name;
+  QString dir;
+  QString packagePin;
+  QString type;
+  QString range;
+};
+
+struct IOPortGroup {
+  QString name;
+  QVector<IOPort> ports;
+};
+
+class PortsModel : public QObject {
+  Q_OBJECT
  public:
-  PortsModel();
+  PortsModel(QObject *parent = nullptr);
+  QStringList headerList() const;
+  void append(const IOPortGroup &p);
+  const QVector<IOPortGroup> &ports() const;
+  void initListModel();
+
+  QStringListModel *listModel() const;
+  void insert(const QString &name, const QModelIndex &index);
+  void itemChange(const QString &name, const QString &newPin);
+
+ signals:
+  void itemHasChanged(const QModelIndex &index, const QString &newPin);
+
+ private:
+  QVector<IOPortGroup> m_ioPorts;
+  QStringListModel *m_model;
+  QMap<QString, QModelIndex> m_indexes;
 };
 
 }  // namespace FOEDAG


### PR DESCRIPTION
### Motivate of the pull request
Add Ports table for the pin assignment feature. Synchronize selections between ports and package pins

### Describe the technical details
Load ports data from json file and show it in the ports table. Selection in Ports table and Package Pin table are synchronized.

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/187192048-b1db095d-fe1a-4645-8472-1781bd45bb3e.png)
