### PR TITLE
extend add_Design_files command with -work and -l arguments.

### DIFF
--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -90,10 +90,11 @@ void Compiler::Help(std::ostream* out) {
   (*out) << "   help                       : This help" << std::endl;
   (*out) << "   create_design <name>       : Creates a design with <name> name"
          << std::endl;
-  (*out) << "   add_design_file <file>... <type> (-VHDL_1987, -VHDL_1993, "
-            "-VHDL_2000, -VHDL_2008, -V_1995, "
-            "-V_2001, -SV_2005, -SV_2009, -SV_2012, -SV_2017) "
-         << std::endl;
+  (*out)
+      << "   add_design_file <option> (-work, -L) <libName> <file>... <type> "
+         "(-VHDL_1987, -VHDL_1993, -VHDL_2000, -VHDL_2008, -V_1995, "
+         "-V_2001, -SV_2005, -SV_2009, -SV_2012, -SV_2017) "
+      << std::endl;
   (*out) << "   read_netlist <file>        : Read a netlist instead of an RTL "
             "design (Skip Synthesis)"
          << std::endl;

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -96,12 +96,13 @@ void CompilerOpenFPGA::Help(std::ostream* out) {
          << std::endl;
   (*out) << "   set_channel_width <int>    : VPR Routing channel setting"
          << std::endl;
-  (*out) << "   add_design_file <file>... <type> (-VHDL_1987, -VHDL_1993, "
-            "-VHDL_2000, "
-            "-VHDL_2008 (.vhd default), -V_1995, "
-            "-V_2001 (.v default), -SV_2005, -SV_2009, -SV_2012, -SV_2017 (.sv "
-            "default)) "
-         << std::endl;
+  (*out)
+      << "   add_design_file <option> (-work, -L) <libName> <file>... <type> "
+         "(-VHDL_1987, -VHDL_1993, -VHDL_2000, "
+         "-VHDL_2008 (.vhd default), -V_1995, "
+         "-V_2001 (.v default), -SV_2005, -SV_2009, -SV_2012, -SV_2017 (.sv "
+         "default)) "
+      << std::endl;
   (*out) << "   read_netlist <file>        : Read a netlist instead of an RTL "
             "design (Skip Synthesis)"
          << std::endl;

--- a/src/Main/ProjectFile/ProjectManagerComponent.cpp
+++ b/src/Main/ProjectFile/ProjectManagerComponent.cpp
@@ -221,7 +221,7 @@ void ProjectManagerComponent::Load(QXmlStreamReader* r) {
             }
             for (const auto& i : langList) {
               projectFileset.addFiles(
-                  ProjectManager::StringSplit(i.second, " "), i.first);
+                  {}, {}, ProjectManager::StringSplit(i.second, " "), i.first);
             }
             for (auto iter = mapOption.begin(); iter != mapOption.end();
                  ++iter) {

--- a/src/NewProject/ProjectManager/project_fileset.cpp
+++ b/src/NewProject/ProjectManager/project_fileset.cpp
@@ -27,8 +27,11 @@ void ProjectFileSet::addFile(const QString &strFileName,
   m_mapFiles.push_back(std::make_pair(strFileName, strFilePath));
 }
 
-void ProjectFileSet::addFiles(const QStringList &files, int language) {
+void ProjectFileSet::addFiles(const QStringList &commands,
+                              const QStringList &libs, const QStringList &files,
+                              int language) {
   m_langMap.push_back(std::make_pair(language, files));
+  m_commandsLibs.push_back(std::make_pair(commands, libs));
 }
 
 QString ProjectFileSet::getFilePath(const QString &strFileName) {
@@ -57,7 +60,11 @@ void ProjectFileSet::deleteFile(const QString &strFileName) {
     for (auto it = m_langMap.begin(); it != m_langMap.end(); ++it) {
       if (it->second.contains(file)) {
         it->second.removeOne(file);
-        if (it->second.isEmpty()) m_langMap.erase(it);
+        if (it->second.isEmpty()) {
+          auto dst = std::distance(m_langMap.begin(), it);
+          m_langMap.erase(it);
+          m_commandsLibs.erase(m_commandsLibs.begin() + dst);
+        }
         break;
       }
     }
@@ -85,4 +92,9 @@ const std::vector<std::pair<QString, QString>> &ProjectFileSet::getMapFiles()
 
 const std::vector<std::pair<int, QStringList>> &ProjectFileSet::Files() const {
   return m_langMap;
+}
+
+std::vector<std::pair<QStringList, QStringList>> ProjectFileSet::getLibraries()
+    const {
+  return m_commandsLibs;
 }

--- a/src/NewProject/ProjectManager/project_fileset.cpp
+++ b/src/NewProject/ProjectManager/project_fileset.cpp
@@ -94,7 +94,7 @@ const std::vector<std::pair<int, QStringList>> &ProjectFileSet::Files() const {
   return m_langMap;
 }
 
-std::vector<std::pair<QStringList, QStringList>> ProjectFileSet::getLibraries()
-    const {
+const std::vector<std::pair<QStringList, QStringList>>
+    &ProjectFileSet::getLibraries() const {
   return m_commandsLibs;
 }

--- a/src/NewProject/ProjectManager/project_fileset.h
+++ b/src/NewProject/ProjectManager/project_fileset.h
@@ -31,7 +31,7 @@ class ProjectFileSet : public ProjectOption {
   const std::vector<std::pair<QString, QString>> &getMapFiles() const;
   const std::vector<std::pair<int, QStringList>> &Files() const;
 
-  std::vector<std::pair<QStringList, QStringList>> getLibraries() const;
+  const std::vector<std::pair<QStringList, QStringList>> &getLibraries() const;
 
  private:
   QString m_setName;

--- a/src/NewProject/ProjectManager/project_fileset.h
+++ b/src/NewProject/ProjectManager/project_fileset.h
@@ -14,7 +14,8 @@ class ProjectFileSet : public ProjectOption {
   ProjectFileSet &operator=(const ProjectFileSet &other);
 
   void addFile(const QString &strFileName, const QString &strFilePath);
-  void addFiles(const QStringList &files, int language);
+  void addFiles(const QStringList &commands, const QStringList &libs,
+                const QStringList &files, int language);
   QString getFilePath(const QString &strFileName);
   void deleteFile(const QString &strFileName);
 
@@ -30,12 +31,17 @@ class ProjectFileSet : public ProjectOption {
   const std::vector<std::pair<QString, QString>> &getMapFiles() const;
   const std::vector<std::pair<int, QStringList>> &Files() const;
 
+  std::vector<std::pair<QStringList, QStringList>> getLibraries() const;
+
  private:
   QString m_setName;
   QString m_setType;
   QString m_relSrcDir;
   std::vector<std::pair<QString, QString>> m_mapFiles;
   std::vector<std::pair<int, QStringList>> m_langMap;
+  std::vector<std::pair<QStringList, QStringList>>
+      m_commandsLibs;  // Collection of commands with corresponding libraries.
+                       // Synchronized with m_langMap.
 };
 }  // namespace FOEDAG
 #endif  // PROJECTFILESET_H

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -151,7 +151,8 @@ class ProjectManager : public QObject {
 
   int setProjectType(const QString &strType);
 
-  ErrorInfo addDesignFiles(const QString &fileNames, int lang,
+  ErrorInfo addDesignFiles(const QString &commands, const QString &libs,
+                           const QString &fileNames, int lang,
                            bool isFileCopy = true, bool localToProject = true);
   int setDesignFiles(const QString &fileNames, int lang, bool isFileCopy = true,
                      bool localToProject = true);
@@ -177,6 +178,8 @@ class ProjectManager : public QObject {
   int setDesignActive(const QString &strSetName);
   QStringList getDesignFiles(const QString &strFileSet) const;
   QStringList getDesignFiles() const;
+  std::vector<std::pair<std::vector<std::string>, std::vector<std::string>>>
+  DesignLibraries() const;
   std::vector<std::pair<int, std::string>> DesignFiles() const;
   std::vector<std::pair<int, std::vector<std::string>>> DesignFileList() const;
   QString getDesignTopModule(const QString &strFileSet) const;

--- a/src/ProjNavigator/tcl_command_integration.cpp
+++ b/src/ProjNavigator/tcl_command_integration.cpp
@@ -126,7 +126,9 @@ bool TclCommandIntegration::TclAddOrCreateDesignFiles(const QString &files,
   return true;
 }
 
-bool TclCommandIntegration::TclAddDesignFiles(const QString &files, int lang,
+bool TclCommandIntegration::TclAddDesignFiles(const QString &commands,
+                                              const QString &libs,
+                                              const QString &files, int lang,
                                               std::ostream &out) {
   if (!validate()) {
     out << "Command validation fail: internal error" << std::endl;
@@ -135,7 +137,8 @@ bool TclCommandIntegration::TclAddDesignFiles(const QString &files, int lang,
 
   const QString strSetName = m_projManager->getDesignActiveFileSet();
   m_projManager->setCurrentFileSet(strSetName);
-  const auto ret = m_projManager->addDesignFiles(files, lang, false, false);
+  const auto ret =
+      m_projManager->addDesignFiles(commands, libs, files, lang, false, false);
   if (ProjectManager::EC_Success != ret.code) {
     error(ret.code, ret.message, out);
     return false;

--- a/src/ProjNavigator/tcl_command_integration.h
+++ b/src/ProjNavigator/tcl_command_integration.h
@@ -38,7 +38,8 @@ class TclCommandIntegration : public QObject {
                                  std::ostream &out);
   bool TclAddOrCreateDesignFiles(const QString &files, int lang,
                                  std::ostream &out);
-  bool TclAddDesignFiles(const QString &files, int lang, std::ostream &out);
+  bool TclAddDesignFiles(const QString &commands, const QString &libs,
+                         const QString &files, int lang, std::ostream &out);
   bool TclAddOrCreateConstrFiles(const QString &file, std::ostream &out);
   bool TclAddConstrFiles(const QString &file, std::ostream &out);
   bool TclSetActive(int argc, const char *argv[], std::ostream &out);


### PR DESCRIPTION
Given PR extends 'add_Design_files ' TCL command with '-work' and '-L' arguments.
It also makes sure they are passed to Yosys script. So far only Verific parser is supported, as default Yosys one puts all the files from the script into one pile.
UI is also not included here.

By default, empty strings will be used and previous behavior kept.

To make its behavior more clear, here is the example: Input (test.tcl)
...
add_design_file -work lib1 test.v -SV_2012
add_design_file -L lib1 -L lib2 bottom.v -SV_2012
...

Output (test.ys):
...
verific -work lib1  -sv2012 /home/work/Work/FOEDAG-Taras/tests/Testcases/trivial/test.v
verific -L lib1 -L lib2  -sv2012 /home/work/Work/FOEDAG-Taras/tests/Testcases/trivial/bottom.v
...

Tested on FOEDAG application with following cmdline commands:
--verific --compiler openfpga --script /home/work/Work/FOEDAG-Taras/tests/Testcases/trivial/test.tcl