### PR TITLE
Fixed task table, expanding rows issue

### DIFF
--- a/src/Compiler/TaskModel.cpp
+++ b/src/Compiler/TaskModel.cpp
@@ -55,6 +55,14 @@ uint TaskModel::ToTaskId(const QModelIndex &index) const {
   return m_taskOrder[index.row()].second;
 }
 
+int TaskModel::ToRowIndex(uint taskId) const {
+  auto it = std::find_if(
+      m_taskOrder.cbegin(), m_taskOrder.cend(),
+      [=](const std::pair<int, uint> &p) { return p.second == taskId; });
+  if (it != m_taskOrder.cend()) return it->first;
+  return -1;
+}
+
 int TaskModel::rowCount(const QModelIndex &parent) const {
   return m_taskManager ? m_taskManager->tasks().count() : 0;
 }
@@ -101,7 +109,8 @@ QVariant TaskModel::data(const QModelIndex &index, int role) const {
     if (auto p = task->parentTask()) {
       uint id = m_taskManager->taskId(p);
       if (id != TaskManager::invalid_id) {
-        return m_expanded.value(createIndex(id, index.column()), true);
+        return m_expanded.value(createIndex(ToRowIndex(id), index.column()),
+                                true);
       }
     }
     return false;

--- a/src/Compiler/TaskModel.h
+++ b/src/Compiler/TaskModel.h
@@ -56,6 +56,7 @@ class TaskModel : public QAbstractTableModel {
   bool hasChildren(const QModelIndex &parent) const override;
   Qt::ItemFlags flags(const QModelIndex &index) const override;
   uint ToTaskId(const QModelIndex &index) const;
+  int ToRowIndex(uint taskId) const;
 
  private:
   TaskManager *m_taskManager{nullptr};


### PR DESCRIPTION
### Motivate of the pull request
Issue: task table will not expand row when new rows arrived.

### Describe the technical details
There is wrong conversion between task id and row index.

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/187387675-3bb11306-7d70-4609-a5ab-267cc432fa18.png)
