### PR TITLE
Fixed issue with target device when no target saved to project file

### DIFF
--- a/src/NewProject/ProjectManager/compiler_configuration.cpp
+++ b/src/NewProject/ProjectManager/compiler_configuration.cpp
@@ -71,12 +71,4 @@ const std::vector<std::pair<std::string, std::string> >
     &CompilerConfiguration::macroList() const {
   return m_macroList;
 }
-
-void CompilerConfiguration::setTargetDevice(const std::string &deviceName) {
-  m_deviceName = deviceName;
-}
-
-const std::string &CompilerConfiguration::getTargetDevice() const {
-  return m_deviceName;
-}
 }  // namespace FOEDAG

--- a/src/NewProject/ProjectManager/compiler_configuration.h
+++ b/src/NewProject/ProjectManager/compiler_configuration.h
@@ -44,15 +44,11 @@ class CompilerConfiguration {
   void addMacro(const std::string &macroName, const std::string &macroValue);
   const std::vector<std::pair<std::string, std::string>> &macroList() const;
 
-  void setTargetDevice(const std::string &deviceName);
-  const std::string &getTargetDevice() const;
-
  private:
   std::vector<std::string> m_includePathList;
   std::vector<std::string> m_libraryPathList;
   std::vector<std::string> m_libraryExtList;
   std::vector<std::pair<std::string, std::string>> m_macroList;
-  std::string m_deviceName;
 };
 
 }  // namespace FOEDAG

--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -1597,11 +1597,13 @@ ProjectManager::macroList() const {
 }
 
 void ProjectManager::setTargetDevice(const std::string& deviceName) {
-  Project::Instance()->compilerConfig()->setTargetDevice(deviceName);
+  setSynthesisOption(
+      {{PROJECT_PART_DEVICE, QString::fromStdString(deviceName)}});
+  emit saveFile();
 }
 
-const std::string& ProjectManager::getTargetDevice() const {
-  return Project::Instance()->compilerConfig()->getTargetDevice();
+std::string ProjectManager::getTargetDevice() const {
+  return getSynthOption(PROJECT_PART_DEVICE).toStdString();
 }
 
 const std::vector<std::string>& ProjectManager::includePathList() const {

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -259,7 +259,7 @@ class ProjectManager : public QObject {
   const std::vector<std::pair<std::string, std::string>> &macroList() const;
 
   void setTargetDevice(const std::string &deviceName);
-  const std::string &getTargetDevice() const;
+  std::string getTargetDevice() const;
   static QStringList StringSplit(const QString &str, const QString &sep);
 
  private:


### PR DESCRIPTION
### Motivate of the pull request
Fixed command **target_device** when device name isn't save to project file.

### Steps to reproduce:
1. Open GUI
2. run command: create_device <any name>
3. run command target_device <device name>
4. Close.
5. Open project file.

*Expected results:* project file contains device name.
*Actual results:* no target device in project file.

### Describe the technical details
Hold target device name to the right place.