### PR TITLE
RG-27: Supporting recursive search for IP Gen Python script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,6 +499,9 @@ install(
 
 install(
   FILES etc/device.xml DESTINATION  ${CMAKE_INSTALL_DATAROOTDIR}/foedag/etc/)
+
+install(
+  DIRECTORY tests/Testcases/IPGenerate/IP_Catalog DESTINATION  ${CMAKE_INSTALL_DATAROOTDIR}/foedag)
   
 install(
   FILES etc/settings/settings_test.json DESTINATION  ${CMAKE_INSTALL_DATAROOTDIR}/foedag/etc/settings/)
@@ -523,6 +526,12 @@ add_custom_command(TARGET foedag-bin POST_BUILD
                   COMMAND ${CMAKE_COMMAND} -E copy 
                   ${PROJECT_SOURCE_DIR}/etc/device.xml        
                           ${CMAKE_CURRENT_BINARY_DIR}/share/foedag/etc/)
+                          
+add_custom_command(TARGET foedag-bin POST_BUILD
+                  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/share/foedag/IP_Catalog/
+                  COMMAND ${CMAKE_COMMAND} -E copy_directory
+                  ${PROJECT_SOURCE_DIR}/tests/Testcases/IPGenerate/IP_Catalog
+                  ${CMAKE_CURRENT_BINARY_DIR}/share/foedag/IP_Catalog)
                           
 add_custom_command(TARGET foedag-bin POST_BUILD
                   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/share/foedag/etc/settings/

--- a/Makefile
+++ b/Makefile
@@ -177,8 +177,10 @@ test/batch: run-cmake-release
 	./build/bin/foedag --batch --script tests/TestBatch/test_compiler_stop.tcl
 	./build/bin/foedag --batch --script tests/TestBatch/test_compiler_batch.tcl
 	./build/bin/foedag --batch --script tests/TestBatch/test_task_clean.tcl
-
-
+	./build/bin/foedag --batch --script tests/Testcases/IPGenerate/test_recursive_load.tcl
+	grep "Found IP: dummy_1_gen" foedag.log
+	grep "Found IP: dummy_2_gen" foedag.log
+	
 lib-only: run-cmake-release
 	cmake --build build --target foedag -j $(CPU_CORES)
 

--- a/src/Console/TclConsoleWidget.cpp
+++ b/src/Console/TclConsoleWidget.cpp
@@ -65,6 +65,8 @@ void TclConsoleWidget::clearText() {
   displayPrompt();
 }
 
+void TclConsoleWidget::showPrompt() { displayPrompt(); }
+
 QString TclConsoleWidget::interpretCommand(const QString &command, int *res) {
   if (!command.isEmpty()) {
     setUndoRedoEnabled(false);

--- a/src/Console/TclConsoleWidget.h
+++ b/src/Console/TclConsoleWidget.h
@@ -49,6 +49,7 @@ class TclConsoleWidget : public QConsole {
 
  public slots:
   void clearText();
+  void showPrompt();
 
  signals:
   void searchEnable();

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -69,7 +69,7 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     const std::string file = argv[1];
     std::string expandedFile = file;
     bool use_orig_path = false;
-    if (FileUtils::FileExists(expandedFile)) {
+    if (FileUtils::FileExists(expandedFile) && expandedFile != "./") {
       use_orig_path = true;
     }
 

--- a/src/IpConfigurator/IpCatalogTree.cpp
+++ b/src/IpConfigurator/IpCatalogTree.cpp
@@ -56,7 +56,7 @@ void IpCatalogTree::refresh() {
   // catalog path. This path should be loaded in addition to the default
   QString UserCatalogPath = "";
   QString IpCatalogPath =
-      QString::fromStdString(GlobalSession->Context()->DataPath()) +
+      QString::fromStdString(GlobalSession->Context()->DataPath().string()) +
       "/IP_Catalog";
   QStringList IpPaths{IpCatalogPath, UserCatalogPath};
 

--- a/src/IpConfigurator/IpCatalogTree.h
+++ b/src/IpConfigurator/IpCatalogTree.h
@@ -35,8 +35,8 @@ class IpCatalogTree : public QTreeWidget {
   QStringList prevIpCatalogResults;
   bool ipsLoaded = false;
 
-  QStringList getAvailableIPs(QString path);
-  void loadIps(QString path);
+  QStringList getAvailableIPs(const QStringList& paths);
+  void loadIps(const QStringList& paths);
 };
 
 }  // namespace FOEDAG

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -372,6 +372,7 @@ void MainWindow::createActions() {
           tr("IPs"), "availableIpsWidget", creator.GetAvailableIpsWidget(),
           nullptr, Qt::RightDockWidgetArea);
       m_ipConfiguratorDocks = {availableIpsDockWidget};
+      m_console->showPrompt();
     } else {
       cleanUpDockWidgets(m_ipConfiguratorDocks);
     }

--- a/tests/Testcases/IPGenerate/IP_Catalog/nested/folder/dummy_1_gen.py
+++ b/tests/Testcases/IPGenerate/IP_Catalog/nested/folder/dummy_1_gen.py
@@ -1,0 +1,2 @@
+# Return empty json
+print( "{}")

--- a/tests/Testcases/IPGenerate/IP_Catalog/nested/folder/further/nested/dummy_2_gen.py
+++ b/tests/Testcases/IPGenerate/IP_Catalog/nested/folder/further/nested/dummy_2_gen.py
@@ -1,0 +1,2 @@
+# Return empty json
+print( "{}" )

--- a/tests/Testcases/IPGenerate/test_recursive_load.tcl
+++ b/tests/Testcases/IPGenerate/test_recursive_load.tcl
@@ -1,0 +1,6 @@
+create_design ip_test
+architecture ../../Arch/k6_frac_N10_tileable_40nm.xml ../../Arch/k6_N10_40nm_openfpga.xml
+add_litex_ip_catalog ./IP_Catalog
+foreach ip [ip_catalog] {
+    puts "Found IP: $ip"
+}


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-27
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, FOEDAG has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
> buildLiteXCatalog only searches the single directory passed to it
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->
> - Updates buildLiteXCatalog to use `std::filesystem::recursive_directory_iterator` instead of `std::filesystem::directory_iterator`
> - Updates CMakelists.txt to install IP_Catalog at share/foedag/IP_Catalog and include a nested dummy ips
> - Updates call to display the Available Ips dock widget so that the console prompt works as expected after loading IPs and the compiler prints a message to the console

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IPGenerate
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - Available IPs tree now loads from the proper raptor/foedag IP_Catalog share directories
> - IP Loading is now done recursively in the folder provided
> - Updated IP Loader to only load files ending in _gen.py
> - Fixed potential json parse crash in IPCatalogBuilder

> ### Testing
> - Manually tested in raptor.
> - Added new test to confirm recursive loading