### PR TITLE
Reducing dummy compiler delay from 1s to 100ms

### DIFF
--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -1270,7 +1270,7 @@ bool Compiler::Synthesize() {
       it++;
     }
     (*m_out) << std::endl;
-    std::chrono::milliseconds dura(1000);
+    std::chrono::milliseconds dura(100);
     std::this_thread::sleep_for(dura);
     if (m_stop) return false;
   }
@@ -1300,7 +1300,7 @@ bool Compiler::GlobalPlacement() {
            << "..." << std::endl;
   for (int i = 0; i < 100; i = i + 10) {
     (*m_out) << i << "%" << std::endl;
-    std::chrono::milliseconds dura(1000);
+    std::chrono::milliseconds dura(100);
     std::this_thread::sleep_for(dura);
     if (m_stop) return false;
   }


### PR DESCRIPTION
> ### Motivate of the pull request
> This speeds up any test that runs the Sythensize or Global Placement tasks in the Foedag dummy compiler

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Currently the dummy compiler prints a percentage increase every second to simulate a task running.
>
> #### What does this pull request change?
> The delay between updates has been reduced to 100ms to speed up test runs

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> Dummy compiler tasks will finish faster
