### PR TITLE
RG-14: Populating IP Configurator UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,8 +178,9 @@ test/batch: run-cmake-release
 	./build/bin/foedag --batch --script tests/TestBatch/test_compiler_batch.tcl
 	./build/bin/foedag --batch --script tests/TestBatch/test_task_clean.tcl
 	./build/bin/foedag --batch --script tests/Testcases/IPGenerate/test_recursive_load.tcl
-	grep "Found IP: dummy_1_gen" foedag.log
-	grep "Found IP: dummy_2_gen" foedag.log
+	grep "Found IP: axis_converter_V1_0" foedag.log
+	grep "Found IP: axis_converter_V1_1" foedag.log
+
 	
 lib-only: run-cmake-release
 	cmake --build build --target foedag -j $(CPU_CORES)

--- a/src/IPGenerate/IPCatalog.cpp
+++ b/src/IPGenerate/IPCatalog.cpp
@@ -46,6 +46,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "IPGenerate/IPCatalog.h"
 #include "MainWindow/Session.h"
 #include "Utils/ProcessUtils.h"
+#include "Utils/StringUtils.h"
 
 extern FOEDAG::Session* GlobalSession;
 using namespace FOEDAG;
@@ -78,4 +79,37 @@ void IPCatalog::WriteCatalog(std::ostream& out) {
   for (auto def : m_definitions) {
     out << "IP Name: " << def->Name() << std::endl;
   }
+}
+
+// This takes a path to an IP and parses the vendor, library, name, and version
+// info from the parent directories. This assumes that the directory format is
+// Vendor/Library/Name/Version
+VLNV FOEDAG::getIpInfoFromPath(std::filesystem::path path) {
+  std::string vendor, library, name, version;
+
+  std::string separator =
+      std::string(1, std::filesystem::path::preferred_separator);
+
+  // Specify our container variables in the order we will read into them
+  // Note we will read from the back of the path first
+  std::vector<std::string*> values = {&version, &name, &library, &vendor};
+
+  // split the path into tokens
+  std::vector<std::string> tokens;
+  StringUtils::tokenize(path.string(), separator, tokens);
+
+  // Take off the child node if it is a python file
+  if (StringUtils::endsWith(tokens.back(), ".py")) {
+    tokens.pop_back();
+  }
+
+  // Read each path section into a variable, starting from the back of the path
+  for (std::string* value : values) {
+    if (!tokens.empty()) {
+      *value = tokens.back();
+      tokens.pop_back();
+    }
+  }
+
+  return VLNV{vendor, library, name, version};
 }

--- a/src/IPGenerate/IPCatalog.h
+++ b/src/IPGenerate/IPCatalog.h
@@ -245,6 +245,15 @@ class IPCatalog {
   std::map<std::string, IPDefinition*> m_definitionMap;
 };
 
+struct VLNV {
+  std::string vendor;
+  std::string library;
+  std::string name;
+  std::string version;
+};
+
+VLNV getIpInfoFromPath(std::filesystem::path path);
+
 }  // namespace FOEDAG
 
 #endif

--- a/src/IPGenerate/IPCatalogBuilder.cpp
+++ b/src/IPGenerate/IPCatalogBuilder.cpp
@@ -140,6 +140,17 @@ bool IPCatalogBuilder::buildLiteXIPFromGenerator(
   std::filesystem::path basepath = FileUtils::Basename(pythonConverterScript);
   std::string basename = basepath.string();
   std::string IPName = rtrim(basename, '.');
+
+  // Remove _gen from IPName
+  std::string suffix = "_gen";
+  if (StringUtils::endsWith(IPName, suffix)) {
+    IPName.erase(IPName.length() - suffix.length());
+  }
+
+  // Add version number to IPName
+  auto info = FOEDAG::getIpInfoFromPath(pythonConverterScript);
+  IPName += "_" + info.version;
+
   std::vector<Value*> parameters;
   std::vector<Connector*> connections;
   for (auto& el : jopts.items()) {

--- a/src/IpConfigurator/IpCatalogTree.cpp
+++ b/src/IpConfigurator/IpCatalogTree.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QTreeWidgetItem>
 
+#include "IpConfigurator/IpConfigDlg.h"
 #include "MainWindow/Session.h"
 #include "Utils/FileUtils.h"
 
@@ -48,6 +49,15 @@ bool tclCmdExists(const QString& cmdName) {
 IpCatalogTree::IpCatalogTree(QWidget* parent /*nullptr*/)
     : QTreeWidget(parent) {
   this->setHeaderLabel("Available IPs");
+
+  QObject::connect(this, &QTreeWidget::itemDoubleClicked,
+                   [this](QTreeWidgetItem* item, int column) {
+                     FOEDAG::IpConfigDlg* dlg =
+                         new IpConfigDlg(this, item->text(0));
+                     dlg->setAttribute(Qt::WA_DeleteOnClose);
+                     dlg->show();
+                   });
+
   refresh();
 }
 

--- a/src/IpConfigurator/IpConfigDlg.cpp
+++ b/src/IpConfigurator/IpConfigDlg.cpp
@@ -21,23 +21,288 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "IpConfigurator/IpConfigDlg.h"
 
 #include <QDialogButtonBox>
+#include <QLabel>
 #include <QPushButton>
-#include <QVBoxLayout>
+#include <QWidget>
+
+#include "Main/WidgetFactory.h"
+#include "MainWindow/Session.h"
+#include "NewProject/ProjectManager/project_manager.h"
 
 using namespace FOEDAG;
+extern FOEDAG::Session* GlobalSession;
 
-IpConfigDlg::IpConfigDlg(QWidget* parent /*nullptr*/) {
+#include "nlohmann_json/json.hpp"
+using json = nlohmann::ordered_json;
+
+static QString SEPARATOR = QString::fromStdString(
+    std::string(1, std::filesystem::path::preferred_separator));
+
+QString getUserProjectPath(const QString& suffix) {
+  QString path;
+  QString projPath =
+      GlobalSession->GetCompiler()->ProjManager()->getProjectPath();
+  QString projName =
+      GlobalSession->GetCompiler()->ProjManager()->getProjectName();
+
+  // Only format for a suffix if one was provided
+  QString suffixStr = "";
+  if (!suffix.isEmpty()) {
+    suffixStr = "." + suffix;
+  }
+
+  if (!projPath.isEmpty() && !projName.isEmpty()) {
+    path = projPath + SEPARATOR + projName + suffixStr;
+  } else {
+    path = "." + SEPARATOR + "noProject" + suffixStr;
+  }
+
+  return path;
+}
+
+IpConfigDlg::IpConfigDlg(QWidget* parent /*nullptr*/,
+                         QString requestedIpName /* "" */)
+    : requestedIpName(requestedIpName) {
   this->setWindowTitle("Configure IP");
   this->setObjectName("IpConfigDlg");
+  baseDirDefault = getUserProjectPath("IPs");
+
+  // Set the path related widgets' tooltips to whatever their text is so long
+  // paths are easier to view
+  QObject::connect(
+      &outputPath, &QLineEdit::textChanged,
+      [this](const QString& text) { outputPath.setToolTip(text); });
+
+  // Main Layout
   QVBoxLayout* topLayout = new QVBoxLayout();
   this->setLayout(topLayout);
 
-  topLayout->addStretch();
+  // Add VLNV meta text description
+  topLayout->addWidget(&metaLabel);
 
+  // Fill and add Parameters box
+  CreateParamFields();
+  topLayout->addWidget(&paramsBox);
+
+  // Add Output Box
+  CreateOutputFields();
+  topLayout->addWidget(&outputBox);
+
+  // Add Dialog Buttons
+  topLayout->addStretch();
+  AddDialogControls(topLayout);
+
+  // Update output path now that meta data has been loaded
+  updateOutputPath();
+}
+
+void IpConfigDlg::AddDialogControls(QBoxLayout* layout) {
   // Dialog Buttons
   QDialogButtonBox* btns = new QDialogButtonBox(QDialogButtonBox::Cancel);
   btns->setObjectName("IpConfigDlg_QDialogButtonBox");
-  topLayout->addWidget(btns);
-  QPushButton* instantiateBtn = new QPushButton("Instantiate IP", this);
-  btns->addButton(instantiateBtn, QDialogButtonBox::ButtonRole::ActionRole);
+  layout->addWidget(btns);
+  QPushButton* generateBtn = new QPushButton("Generate IP", this);
+  btns->addButton(generateBtn, QDialogButtonBox::ButtonRole::ActionRole);
+
+  // Create our tcl command to generate the IP when the Generate IP button
+  // is clicked
+  QObject::connect(generateBtn, &QPushButton::clicked, this, [this]() {
+    // Find settings fields in the parameter box layout
+    QLayout* fieldsLayout = paramsBox.layout();
+    QList<QObject*> settingsObjs =
+        FOEDAG::getTargetObjectsFromLayout(fieldsLayout);
+
+    // Build up a parameter string based off the current UI fields
+    QString params = "";
+    for (QObject* obj : settingsObjs) {
+      // Add a space before each param except the first
+      if (!params.isEmpty()) {
+        params += " ";
+      }
+
+      // convert tclArg property from "name value" to "name=value"
+      params += obj->property("tclArg").toString().replace(" ", "=");
+    }
+
+    // Build up a cmd string to generate the IP
+    QString cmd = "configure_ip " + this->requestedIpName + " -mod_name " +
+                  moduleEdit.text() + " -version " +
+                  QString::fromStdString(meta.version) + " " + params +
+                  " -out_file " + outputPath.text();
+
+    // TODO @skyler-rs Sept2022 configure_ip command execution code will be
+    // added in a future update
+    std::cout << cmd.toStdString() << std::endl;
+  });
+
+  // Forward standard QDialogButtonBox signals to the parent dialog
+  QObject::connect(btns, &QDialogButtonBox::rejected, this, &QDialog::reject);
+  QObject::connect(btns, &QDialogButtonBox::accepted, this, &QDialog::accept);
+}
+
+void IpConfigDlg::CreateParamFields() {
+  QVBoxLayout* vLayout = new QVBoxLayout();
+  paramsBox.setLayout(vLayout);
+
+  QStringList tclArgList;
+  json parentJson;
+  // Loop through IPDefinitions stored in IPCatalog
+  for (auto def : getDefinitions()) {
+    // if this definition is for the requested IP
+    if (requestedIpName.toStdString() == def->Name()) {
+      // Store VLNV meta data for the requested IP
+      meta = FOEDAG::getIpInfoFromPath(def->FilePath());
+      updateMetaLabel(meta);
+
+      // set default module name to the VLNV name
+      moduleEdit.setText(QString::fromStdString(meta.name));
+
+      // Build widget factory json for each parameter
+      for (auto param : def->Parameters()) {
+        json childJson;
+        // Add P to the arg as the configure_ip format is -P{ARG_NAME}
+        childJson["arg"] = "P" + param->Name();
+        // Convert label's underscores to spaces
+        childJson["label"] = QString::fromStdString(param->Name())
+                                 .replace('_', ' ')
+                                 .toStdString();
+        std::string defaultValue;
+
+        // Currently all fields are input/linedit
+        childJson["widgetType"] = "input";
+
+        switch (param->GetType()) {
+          case Value::Type::ParamInt:
+            defaultValue = std::to_string(param->GetValue());
+            // set validator so this field only accepts integer values
+            childJson["validator"] = "int";
+            // Note: Do not set "default" as the value will be passed in
+            // tclArgList and passing default as well a tclArg will result in
+            // the value not registering as a diff when set and the tclArg
+            // property won't be set in widgetFactory
+            break;
+          case Value::Type::ParamString:
+            defaultValue = param->GetSValue();
+            break;
+          case Value::Type::ConstInt:
+            // set validator so this field only accepts integer values
+            childJson["validator"] = "int";
+            defaultValue = std::to_string(param->GetValue());
+            break;
+          default:
+            defaultValue = std::to_string(param->GetValue());
+            break;
+        }
+        parentJson[param->Name()] = childJson;
+
+        // Create a list of tcl defaults that will be passed to createWidget
+        tclArgList << QString("-P%1 %2")
+                          .arg(QString::fromStdString(param->Name()))
+                          .arg(QString::fromStdString(defaultValue));
+      }
+    }
+  }
+
+  // Create and add the child widget to our parent container
+  for (auto [widgetId, widgetJson] : parentJson.items()) {
+    QWidget* subWidget = FOEDAG::createWidget(
+        widgetJson, QString::fromStdString(widgetId), tclArgList);
+    if (subWidget != nullptr) {
+      vLayout->addWidget(subWidget);
+    }
+  }
+}
+
+void IpConfigDlg::CreateOutputFields() {
+  // Using grid for easy right justification of label fields
+  QGridLayout* grid = new QGridLayout(&outputBox);
+
+  // Set objectNames for future testing targets
+  moduleEdit.setObjectName("IpConfigurator_moduleLineEdit");
+  outputPath.setObjectName("IpConfigurator_outputPathLineEdit");
+
+  // Make the output directory field read only
+  outputPath.setReadOnly(true);
+  outputPath.setStyleSheet(
+      QString("QLineEdit{ background-color: %1; }")
+          .arg(QWidget::palette()
+                   .color(QPalette::Disabled, QPalette::Base)
+                   .name()));
+
+  // Create a list of label/widget pairs
+  std::vector<std::pair<std::string, QWidget*>> pairs = {
+      {"Module Name", &moduleEdit}, {"Output Dir", &outputPath}};
+
+  // Loop through pairs and add them to layout
+  int count = 0;
+  for (auto [labelName, widget] : pairs) {
+    grid->addWidget(new QLabel(QString::fromStdString(labelName)), count, 0,
+                    Qt::AlignRight);
+
+    // Add to a layout so the widget grows w/ the dialog
+    QHBoxLayout* hLayout = new QHBoxLayout();
+    hLayout->addWidget(widget);
+    grid->addLayout(hLayout, count, 1, Qt::AlignLeft);
+    count++;
+  }
+
+  // Update the output dir when module name changes
+  QObject::connect(&moduleEdit, &QLineEdit::textChanged, this,
+                   &IpConfigDlg::updateOutputPath);
+
+  // add the layout to the output group box
+  outputBox.setLayout(grid);
+}
+
+void IpConfigDlg::updateMetaLabel(VLNV info) {
+  // Create a descriptive sentence that lists all the VLNV info
+  QString verStr = QString::fromStdString(info.version).replace("_", ".");
+  std::string text = "<em>Configuring " + info.name + " (" +
+                     verStr.toStdString() + ")" + " from " + info.vendor +
+                     "'s " + info.library + " library</em>";
+  metaLabel.setTextFormat(Qt::RichText);
+  metaLabel.setText(QString::fromStdString(text));
+  metaLabel.setWordWrap(true);
+}
+
+// Returns the IPDefinitions stored in the current IPGenerator's IPCatalog
+std::vector<FOEDAG::IPDefinition*> IpConfigDlg::getDefinitions() {
+  FOEDAG::Compiler* compiler = nullptr;
+  FOEDAG::IPGenerator* ipgen = nullptr;
+  FOEDAG::IPCatalog* ipcatalog = nullptr;
+  std::vector<FOEDAG::IPDefinition*> defs;
+
+  // This just checks at each getter step to make sure no nulls are returned
+  if (GlobalSession && (compiler = GlobalSession->GetCompiler()) &&
+      (ipgen = compiler->GetIPGenerator()) && (ipcatalog = ipgen->Catalog())) {
+    defs = ipcatalog->Definitions();
+  }
+
+  return defs;
+}
+
+void IpConfigDlg::updateOutputPath() {
+  // Strip end separator from baseDir if there is one
+  QString baseDir = baseDirDefault;
+  if (baseDir.endsWith(SEPARATOR)) {
+    baseDir.chop(SEPARATOR.length());
+  }
+
+  // add .v to module  name if it doesn't exist
+  QString fileName = moduleEdit.text();
+  if (!fileName.endsWith(".v")) {
+    fileName += ".v";
+  }
+
+  QString vendor = QString::fromStdString(meta.vendor);
+  QString library = QString::fromStdString(meta.library);
+  QString version = QString::fromStdString(meta.version);
+  QString name = QString::fromStdString(meta.name);
+
+  // Create and set new path.
+  // This follows VLNV order (Vendor/Library/Name/Version)
+  QStringList orderedPieces = {baseDir, vendor,  library,
+                               name,    version, fileName};
+  QString path = orderedPieces.join(SEPARATOR);
+  outputPath.setText(path);
 }

--- a/src/IpConfigurator/IpConfigDlg.h
+++ b/src/IpConfigurator/IpConfigDlg.h
@@ -20,7 +20,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
 
+#include <QBoxLayout>
 #include <QDialog>
+#include <QGroupBox>
+#include <QLabel>
+#include <QLineEdit>
+
+#include "IPGenerate/IPCatalog.h"
 
 namespace FOEDAG {
 
@@ -28,9 +34,27 @@ class IpConfigDlg : public QDialog {
   Q_OBJECT
 
  public:
-  explicit IpConfigDlg(QWidget* parent = nullptr);
+  explicit IpConfigDlg(QWidget* parent = nullptr, QString requestedIpName = "");
+
+ public slots:
+  void updateOutputPath();
 
  private:
+  void AddDialogControls(QBoxLayout* layout);
+  void CreateParamFields();
+  void CreateOutputFields();
+  void updateMetaLabel(VLNV info);
+  std::vector<FOEDAG::IPDefinition*> getDefinitions();
+
+  QGroupBox paramsBox{"Parameters", this};
+  QGroupBox outputBox{"Output", this};
+  QLabel metaLabel;
+  QLineEdit moduleEdit;
+  QLineEdit outputPath;
+
+  QString baseDirDefault;
+  QString requestedIpName;
+  VLNV meta;
 };
 
 }  // namespace FOEDAG

--- a/src/IpConfigurator/IpConfigurator.cpp
+++ b/src/IpConfigurator/IpConfigurator.cpp
@@ -100,9 +100,9 @@ void FOEDAG::registerIpConfiguratorCommands(QWidget* widget,
 
   auto show_dlg = [](void* clientData, Tcl_Interp* interp, int argc,
                      const char* argv[]) -> int {
-    IpConfigDlg* dlg = new IpConfigDlg();
-    dlg->setAttribute(Qt::WA_DeleteOnClose);
-    dlg->exec();
+    QWidget* w = static_cast<QWidget*>(clientData);
+    IpConfigDlg* dlg = new IpConfigDlg(w);
+    dlg->show();
     return 0;
   };
   session->TclInterp()->registerCmd("ipconfigurator_show_dlg", show_dlg, widget,

--- a/src/IpConfigurator/IpConfiguratorCreator.cpp
+++ b/src/IpConfigurator/IpConfiguratorCreator.cpp
@@ -23,7 +23,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QBoxLayout>
 
 #include "IpCatalogTree.h"
-// #include "IpConfigurator.h"
 
 namespace FOEDAG {
 
@@ -39,6 +38,7 @@ QWidget *IpConfiguratorCreator::GetAvailableIpsWidget() {
 QWidget *IpConfiguratorCreator::CreateLayoutedWidget(QWidget *main) {
   QWidget *w = new QWidget;
   w->setLayout(new QVBoxLayout);
+  w->layout()->setContentsMargins(0, 0, 0, 0);
   w->layout()->addWidget(main);
   return w;
 }

--- a/src/Main/WidgetFactory.h
+++ b/src/Main/WidgetFactory.h
@@ -85,6 +85,7 @@ QButtonGroup* createRadioButtons(
 QCheckBox* createCheckBox(
     const QString& objectName, const QString& text, Qt::CheckState checked,
     std::function<void(QCheckBox*, const int&)> onChange = nullptr);
+QList<QObject*> getTargetObjectsFromLayout(QLayout* layout);
 
 }  // namespace FOEDAG
 

--- a/src/Main/registerTclCommands.cpp
+++ b/src/Main/registerTclCommands.cpp
@@ -45,7 +45,7 @@ extern "C" {
 #include "CommandLine.h"
 #include "Compiler/Log.h"
 #include "Foedag.h"
-#include "IpConfigurator/IpConfigurator.h"
+#include "IpConfigurator/IpConfigDlg.h"
 #include "Main/Tasks.h"
 #include "Main/WidgetFactory.h"
 #include "MainWindow/Session.h"
@@ -295,6 +295,27 @@ void registerAllFoedagCommands(QWidget* widget, FOEDAG::Session* session) {
       };
       session->TclInterp()->registerCmd("EditTaskSettings", EditTaskSettingsFn,
                                         0, 0);
+
+      auto ipconfiguratorDlgFn = [](void* clientData, Tcl_Interp* interp,
+                                    int argc, const char* argv[]) -> int {
+        QWidget* w = static_cast<QWidget*>(clientData);
+
+        if (argc == 2) {
+          FOEDAG::IpConfigDlg* dlg = new FOEDAG::IpConfigDlg(w, argv[1]);
+          dlg->setAttribute(Qt::WA_DeleteOnClose);
+          dlg->show();
+
+          return TCL_OK;
+        } else {
+          Tcl_AppendResult(
+              interp,
+              qPrintable("Expected Syntax: ipconfigurator_show_dlg IpName"),
+              nullptr);
+          return TCL_ERROR;
+        }
+      };
+      session->TclInterp()->registerCmd("ipconfigurator_show_dlg",
+                                        ipconfiguratorDlgFn, 0, 0);
     }
   }
 }

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -228,4 +228,14 @@ std::string StringUtils::unquoted(const std::string& text) {
   return text;
 }
 
+bool StringUtils::endsWith(const std::string& fullString,
+                           const std::string& ending) {
+  if (fullString.length() >= ending.length()) {
+    return (0 == fullString.compare(fullString.length() - ending.length(),
+                                    ending.length(), ending));
+  } else {
+    return false;
+  }
+}
+
 }  // namespace FOEDAG

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -96,6 +96,9 @@ class StringUtils final {
 
   static std::string unquoted(const std::string& text);
 
+  // Returns bool indicating if `text` ends with `ending`
+  static bool endsWith(const std::string& text, const std::string& ending);
+
  private:
   StringUtils() = delete;
   StringUtils(const StringUtils& orig) = delete;

--- a/tests/TestGui/gui_ipconfigurator.tcl
+++ b/tests/TestGui/gui_ipconfigurator.tcl
@@ -18,6 +18,7 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 puts "IP CONFIGURATOR GUI SHOW" ; flush stdout ; ipconfigurator_show
+puts "IP CONFIGURATOR DLG SHOW" ; flush stdout ; ipconfigurator_show_dlg
 puts "IP CONFIGURATOR GUI STOP"  ; flush stdout ; ipconfigurator_hide
 
 

--- a/tests/Testcases/IPGenerate/IP_Catalog/dummy_generators/RapidSilicon/IP/axis_converter/V1_0/axis_converter_gen.py
+++ b/tests/Testcases/IPGenerate/IP_Catalog/dummy_generators/RapidSilicon/IP/axis_converter/V1_0/axis_converter_gen.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+# The following is the captured output of `python3 axis_converter_gen.py --json-template`
+# Which is what the IPCatalog calls when first reading in IPs
+# Foedag currently doesn't have the dependencies(litex/migen) to run that command
+# on the fly so this file is a temporary solution
+print('''{
+    "core_in_width": 128,
+    "core_out_width": 64,
+    "core_user_width": 0,
+    "core_reverse": false,
+    "build": false,
+    "build_dir": "build",
+    "build_name": "axis_converter_128b_to_64b",
+    "json": null,
+    "json_template": true
+}''')

--- a/tests/Testcases/IPGenerate/IP_Catalog/dummy_generators/RapidSilicon/IP/axis_converter/V1_1/axis_converter_gen.py
+++ b/tests/Testcases/IPGenerate/IP_Catalog/dummy_generators/RapidSilicon/IP/axis_converter/V1_1/axis_converter_gen.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+# The following is the captured output of `python3 axis_converter_gen.py --json-template`
+# Which is what the IPCatalog calls when first reading in IPs
+# Foedag currently doesn't have the dependencies(litex/migen) to run that command
+# on the fly so this file is a temporary solution
+print('''{
+    "core_in_width": 128,
+    "core_out_width": 64,
+    "core_user_width": 0,
+    "core_reverse": false,
+    "build": false,
+    "build_dir": "build",
+    "build_name": "axis_converter_128b_to_64b",
+    "json": null,
+    "json_template": true
+}''')

--- a/tests/Testcases/IPGenerate/IP_Catalog/nested/folder/dummy_1_gen.py
+++ b/tests/Testcases/IPGenerate/IP_Catalog/nested/folder/dummy_1_gen.py
@@ -1,2 +1,0 @@
-# Return empty json
-print( "{}")

--- a/tests/Testcases/IPGenerate/IP_Catalog/nested/folder/further/nested/dummy_2_gen.py
+++ b/tests/Testcases/IPGenerate/IP_Catalog/nested/folder/further/nested/dummy_2_gen.py
@@ -1,2 +1,0 @@
-# Return empty json
-print( "{}" )


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-14
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> IP Configurator dialog was empty
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, FOEDAG has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->
> Ip Configurator dialog now looks up and displays an IP's VLNV meta data, parameters, and the generated output path.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IPGenerate, IpConfigurator
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.

> ### Testing
> - IpConfigurator dialog already has a smoke test in the system
> - FOEDAG test IP_Catalog has been updated to remove empty json dummies and instead use captured json output from actual litex commands that FOEDAG currently can't do at runtime due to dependencies. This also updates the test folder structure to match Raptor's Vendor/Library/Name/Version format
> - Recursive IP loading test has been updated to use new IP_Catalog format
> - Full gui testing is not possible with out current test harness
> - This has been manually tested with Raptor

> ### UI Changes
Ip Configurator Dialog now populates based off which IP you double click in the Available IPs tree
![image](https://user-images.githubusercontent.com/103447061/187941541-a67688cb-bf7e-4cc8-8a6d-dfe266a95bef.png)
