### PR TITLE
Fixed crash when welcome page is open

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -407,15 +407,14 @@ void MainWindow::createActions() {
 }
 
 void MainWindow::gui_start(bool showWP) {
+  ReShowWindow({});
   if (showWP)
     showWelcomePage();
-  else
-    ReShowWindow({});
 }
 
 void MainWindow::showWelcomePage() {
   clearDockWidgets();
-  takeCentralWidget();
+  takeCentralWidget()->hide(); // we can't delete it because of singleton
 
   newDesignCreated({});
   showToolbars(false);


### PR DESCRIPTION
### Motivate of the pull request
There is crash when welcome page started and user try to create new project.

### Describe the technical details
Before welcome page started we need to initialize everything which is done by ReShowWindow method. Not calling it leads to many problems.