### PR TITLE
Fixed empty target device

### DIFF
--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -1624,7 +1624,7 @@ void ProjectManager::setTargetDevice(const std::string& deviceName) {
   auto result = setSynthesisOption(
       {{PROJECT_PART_DEVICE, QString::fromStdString(deviceName)}});
   if (result != 0)
-    std::cerr << "setSynthesisOption(): something goes wrong, return value is: "
+    std::cerr << "setSynthesisOption(): something went wrong, return value is: "
               << result
               << std::endl;  // TODO @volodymyrk backlog,logging improve
   emit saveFile();

--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -7,6 +7,7 @@
 #include <QTime>
 #include <QXmlStreamWriter>
 #include <filesystem>
+#include <iostream>
 
 #include "Compiler/CompilerDefines.h"
 
@@ -1619,12 +1620,18 @@ ProjectManager::macroList() const {
 }
 
 void ProjectManager::setTargetDevice(const std::string& deviceName) {
-  setSynthesisOption(
+  setCurrentRun(getActiveSynthRunName());
+  auto result = setSynthesisOption(
       {{PROJECT_PART_DEVICE, QString::fromStdString(deviceName)}});
+  if (result != 0)
+    std::cerr << "setSynthesisOption(): something goes wrong, return value is: "
+              << result
+              << std::endl;  // TODO @volodymyrk backlog,logging improve
   emit saveFile();
 }
 
-std::string ProjectManager::getTargetDevice() const {
+std::string ProjectManager::getTargetDevice() {
+  setCurrentRun(getActiveSynthRunName());
   return getSynthOption(PROJECT_PART_DEVICE).toStdString();
 }
 

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -262,7 +262,7 @@ class ProjectManager : public QObject {
   const std::vector<std::pair<std::string, std::string>> &macroList() const;
 
   void setTargetDevice(const std::string &deviceName);
-  std::string getTargetDevice() const;
+  std::string getTargetDevice();
   static QStringList StringSplit(const QString &str, const QString &sep);
 
  private:


### PR DESCRIPTION
### Motivate of the pull request
When start new project - no target device in the project manager.

### Describe the technical details
After new project is created - project manager doesn't provide target device. E.g. 
qDebug() << projectManager->targetDevice(); will show empty string.
