### PR TITLE
Fixed wrong window title after new project has started

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -139,14 +139,8 @@ void MainWindow::newFile() {
 }
 
 void MainWindow::newProjectDlg() {
-  int ret = newProjdialog->exec();
   newProjdialog->Reset();
-  newProjdialog->close();
-  if (ret) {
-    QString strproject = newProjdialog->getProject();
-    newProjectAction->setEnabled(false);
-    ReShowWindow(strproject);
-  }
+  newProjdialog->open();
 }
 
 void MainWindow::openProject() { openProject(QString{}); }
@@ -336,6 +330,7 @@ void MainWindow::createActions() {
   connect(closeProjectAction, SIGNAL(triggered()), this, SLOT(closeProject()));
 
   newProjdialog = new newProjectDialog(this);
+  connect(newProjdialog, SIGNAL(accepted()), this, SLOT(newDialogAccepted()));
   newProjectAction = new QAction(tr("&New Project..."), this);
   newProjectAction->setStatusTip(tr("Create a new project"));
   connect(newProjectAction, SIGNAL(triggered()), this, SLOT(newProjectDlg()));
@@ -676,4 +671,10 @@ void MainWindow::pinAssignmentActionTriggered() {
     }
   }
   saveToolBar->setHidden(!pinAssignmentAction->isChecked());
+}
+
+void MainWindow::newDialogAccepted() {
+  const QString strproject = newProjdialog->getProject();
+  newProjectAction->setEnabled(false);
+  ReShowWindow(strproject);
 }

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -60,6 +60,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void updatePRViewButton(int state);
   void saveActionTriggered();
   void pinAssignmentActionTriggered();
+  void newDialogAccepted();
 
  private: /* Menu bar builders */
   void createMenus();

--- a/src/NewProject/new_project_dialog.cpp
+++ b/src/NewProject/new_project_dialog.cpp
@@ -111,14 +111,10 @@ void newProjectDialog::on_buttonBox_accepted() {
   } else
     compiler->PinAssignOpts(Compiler::PinAssignOpt::In_Define_Order);
   m_projectManager->CreateProject(opt);
-  this->setResult(1);
-  this->hide();
+  accept();
 }
 
-void newProjectDialog::on_buttonBox_rejected() {
-  this->setResult(0);
-  this->hide();
-}
+void newProjectDialog::on_buttonBox_rejected() { reject(); }
 
 void newProjectDialog::on_next() {
   if (INDEX_LOCATION == m_index) {


### PR DESCRIPTION
### Motivate of the pull request
When create new project - window title doesn't reflect the project name (see screenshot)

### Describe the technical details
When get text for window title - it is wrong calculation of existing folder.

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/188150574-ee9a7a5c-3bd6-4aa3-8790-901d22ece704.png)

### Other impact
Show/hide new project title was updated according to the documentation.
