### PR TITLE
fix logo pixelitation issue; update welcome page actions shortcuts

### DIFF
--- a/src/MainWindow/WelcomePageWidget.cpp
+++ b/src/MainWindow/WelcomePageWidget.cpp
@@ -39,7 +39,6 @@ static constexpr auto HEADER_POINTSIZE = 24;
 static constexpr auto DESCRIPTION_POINTSIZE = 14;
 static constexpr auto PAGE_MARGIN = 30;
 static constexpr auto PAGE_SPACING = 20;
-static constexpr auto LOGO_SIZE = 400;
 
 static const auto ETC_DIR = "etc";
 static const auto WELCOME_PAGE_DIR = "Welcome_Page";
@@ -80,8 +79,7 @@ WelcomePageWidget::WelcomePageWidget(const QString &header,
   std::filesystem::path labelPath = srcDir / LOGO_FILENAME;
   auto logoPixmap = QPixmap(QString::fromStdString(labelPath.string()));
   if (!logoPixmap.isNull())
-    logoLabel->setPixmap(
-        logoPixmap.scaled(QSize(LOGO_SIZE, LOGO_SIZE), Qt::KeepAspectRatio));
+    logoLabel->setPixmap(logoPixmap);
 
   // Main layout
   auto mainLayout = new QVBoxLayout(this);

--- a/src/MainWindow/WelcomePageWidget.cpp
+++ b/src/MainWindow/WelcomePageWidget.cpp
@@ -78,8 +78,7 @@ WelcomePageWidget::WelcomePageWidget(const QString &header,
   auto logoLabel = new QLabel(this);
   std::filesystem::path labelPath = srcDir / LOGO_FILENAME;
   auto logoPixmap = QPixmap(QString::fromStdString(labelPath.string()));
-  if (!logoPixmap.isNull())
-    logoLabel->setPixmap(logoPixmap);
+  if (!logoPixmap.isNull()) logoLabel->setPixmap(logoPixmap);
 
   // Main layout
   auto mainLayout = new QVBoxLayout(this);

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -322,11 +322,11 @@ void MainWindow::createActions() {
   newAction->setStatusTip(tr("Create a new source file"));
   connect(newAction, SIGNAL(triggered()), this, SLOT(newFile()));
 
-  openProjectAction = new QAction(tr("&Open Project..."), this);
+  openProjectAction = new QAction(tr("Open &Project..."), this);
   openProjectAction->setStatusTip(tr("Open a new project"));
   connect(openProjectAction, SIGNAL(triggered()), this, SLOT(openProject()));
 
-  openExampleAction = new QAction(tr("&Open Example Design..."), this);
+  openExampleAction = new QAction(tr("Open &Example Design..."), this);
   openExampleAction->setStatusTip(tr("Open example design"));
   connect(openExampleAction, SIGNAL(triggered()), this,
           SLOT(openExampleProject()));


### PR DESCRIPTION
Motivate of the pull request:
- #RG-49
- #RG-51

As a result of logo pixelation improvement, it changes from upper to lower:
![image](https://user-images.githubusercontent.com/109239890/188211386-662d7b8a-ba37-4b4a-a606-a9debd89c552.png)

The second change makes sure shortcuts of welcome page actions aren't overlapped:
![image](https://user-images.githubusercontent.com/109239890/188211530-55f60d42-dfe1-4352-87db-ff08a2e82c94.png)
