### PR TITLE
hide menu bar on welcome page

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -304,7 +304,8 @@ void MainWindow::createToolBars() {
   debugToolBar->addAction(stopAction);
 }
 
-void MainWindow::showToolbars(bool show) {
+void MainWindow::showMenus(bool show) {
+  menuBar()->setVisible(show);
   fileToolBar->setVisible(show);
   debugToolBar->setVisible(show);
 }
@@ -411,7 +412,7 @@ void MainWindow::showWelcomePage() {
   takeCentralWidget()->hide();  // we can't delete it because of singleton
 
   newDesignCreated({});
-  showToolbars(false);
+  showMenus(false);
 
   auto exeName =
       QString::fromStdString(GlobalSession->Context()->ExecutableName());
@@ -436,7 +437,7 @@ void MainWindow::ReShowWindow(QString strProject) {
 
   newDesignCreated(strProject);
 
-  showToolbars(true);
+  showMenus(true);
 
   QDockWidget* sourceDockWidget = new QDockWidget(tr("Source"), this);
   sourceDockWidget->setObjectName("sourcedockwidget");

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -81,7 +81,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void cleanUpDockWidgets(std::vector<QDockWidget*>& dockWidgets);
   void openProject(const QString& dir);
 
-  void showToolbars(bool show);
+  void showMenus(bool show);
   void showWelcomePage();
 
   bool saveConstraintFile();


### PR DESCRIPTION
> ### Motivate of the pull request
The motivation of this PR is RG-52 issue, which is caused by some actions not making sense on a welcome page.
As a quick solution we'll just hide entire menu bar. In the future we might want to implement more intelligent mechanism on managing views on a menu bar.

> ### Describe the technical details
As long the code hiding toolbars for the welcome page already exists, I extended it with hiding the menu bar as well.
>
> #### What does this pull request change?
Menu bar will no longer be visible when welcome page is on.
![image](https://user-images.githubusercontent.com/109239890/188711060-dacf1ae0-07ba-4d9a-b8f7-119acf435aae.png)


