### PR TITLE
foedag main window title fixed

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -177,7 +177,13 @@ void MainWindow::openFileSlot() {
 }
 
 void MainWindow::newDesignCreated(const QString& design) {
-  setWindowTitle(m_projectInfo.name + " - " + design);
+  const QFileInfo path(design);
+  if (design.isEmpty()) {
+    setWindowTitle(m_projectInfo.name);
+  } else {
+    setWindowTitle(path.fileName() + " - " + path.baseName() + " - " +
+                   m_projectInfo.name);
+  }
   pinAssignmentAction->setEnabled(!design.isEmpty());
   pinAssignmentAction->setChecked(false);
 }


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
Foedag's Main Window title was showed in this pattern:  "FOEDAG - current opened file path".
![image](https://user-images.githubusercontent.com/109368108/189113251-da8afed2-902d-4c88-81f8-6e3f8208b27d.png)


> #### What is currently done? (Provide issue link if applicable)
Now main window title is changed to following consistent pattern:  "current-file-open-in-editor" - "project-name" - FOEDAG.
>
> #### What does this pull request change?
It will change the title pattern of main window. 

> #### Testing Steps:
Run the Gui and create or open new project.
Check the title on the window after creating or opening project
Main title shows in the following format shows in the image below
![image](https://user-images.githubusercontent.com/109368108/189112925-cd1073be-c1a5-4cc6-b015-c47f72bb812b.png)


> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [x] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
