### PR TITLE
Fix potential empty Available IP tree scenario in Raptor

### DIFF
--- a/src/IpConfigurator/IpCatalogTree.cpp
+++ b/src/IpConfigurator/IpCatalogTree.cpp
@@ -94,7 +94,7 @@ QStringList IpCatalogTree::getAvailableIPs(
   loadIps(paths);
 
   // Request loaded IPs
-  if (ipsLoaded && tclCmdExists("ip_catalog")) {
+  if (tclCmdExists("ip_catalog")) {
     std::string result = GlobalSession->TclInterp()->evalCmd("ip_catalog");
     ips = QString::fromStdString(result).trimmed().split(" ");
   }
@@ -103,14 +103,13 @@ QStringList IpCatalogTree::getAvailableIPs(
 }
 
 void IpCatalogTree::loadIps(const std::vector<std::filesystem::path>& paths) {
-  if (!ipsLoaded && tclCmdExists("add_litex_ip_catalog")) {
+  if (tclCmdExists("add_litex_ip_catalog")) {
     for (auto path : paths) {
       if (std::filesystem::exists(path)) {
         QString cmd = QString("add_litex_ip_catalog %1")
                           .arg(QString::fromStdString(path.string()));
         int ok = TCL_ERROR;
         GlobalSession->TclInterp()->evalCmd(cmd.toStdString(), &ok);
-        ipsLoaded |= (ok == TCL_OK);
       }
     }
   }

--- a/src/IpConfigurator/IpCatalogTree.h
+++ b/src/IpConfigurator/IpCatalogTree.h
@@ -34,7 +34,6 @@ class IpCatalogTree : public QTreeWidget {
 
  private:
   QStringList prevIpCatalogResults;
-  bool ipsLoaded = false;
 
   QStringList getAvailableIPs(const std::vector<std::filesystem::path>& paths);
   void loadIps(const std::vector<std::filesystem::path>& paths);


### PR DESCRIPTION
> ### Motivate of the pull request
> Discovered an oversight in original Available IP Logic that could result in Raptor displaying an empty IP tree even after a semi successful load of IPs.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> It was assumed that return value of IPCatalogBuilder::buildLiteXCatalog (which loads all IPs at once) would return true if any of the IPs succeeded to load (assuming the return result was OR'd with loop results), but its logic works out such that it returns false if any of the IPs failed to load. My code was overprotectively skipping displaying of any IPs when the return value was false.
>
> #### What does this pull request change?
> The return value is no longer checked and instead the system is always introspected to accurately report what was loaded.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [X] Library: IpConfigurator
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Testing
> - This is a gui only change which can't be tested with our current test harness
> - Manual testing was done in Raptor to ensure that IPs are shown even if one of the IPs fails to load.
