### PR TITLE
GEMINIEDA-338: Fix new project dialog not showing multiple devices

### DIFF
--- a/src/NewProject/ProjectManager/config.cpp
+++ b/src/NewProject/ProjectManager/config.cpp
@@ -60,7 +60,8 @@ int Config::InitConfig(const QString &devicexml) {
       QDomElement e = node.toElement();
 
       QStringList devlist;
-      devlist.append(e.attribute("name"));
+      QString name = e.attribute("name");
+      devlist.append(name);
       devlist.append(e.attribute("pin_count"));
       devlist.append(e.attribute("speedgrade"));
       devlist.append(e.attribute("core_voltage"));
@@ -79,7 +80,11 @@ int Config::InitConfig(const QString &devicexml) {
       devlist.append(series);
       devlist.append(family);
       devlist.append(package);
-      m_map_device_info.insert(series + family + package, devlist);
+
+      // adding name to avoid key collisions when there are multiple devices
+      // with the same series/family/package
+      QString key = series + family + package + "_" + name;
+      m_map_device_info.insert(key, devlist);
       MakeDeviceMap(series, family, package);
     }
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: GEMINIEDA-338
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> A device table is filled based off a key compare in a QMap. The existing code gave the same key to sibling devices with the same device/series/family. This resulted in the table only ever showing 1 device because whichever device was read in last overwrote the previous entry with the same key.
>
> #### What does this pull request change?
> The devices names is added to the key to provide a unique entry in the QMap

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: New Project
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> New project dialog now correctly shows multiple devices if any are present
> <img width="935" alt="image" src="https://user-images.githubusercontent.com/103447061/189236655-0944ac7a-ea6b-41d6-811d-8f36c043c5dc.png">

> ### Testing
> - This is a gui feature/fix and cannot be verified with our current test harness
> - Loading was manually tested by loading the raptor devices.xml file in Foedag and confirming the list showed multiple devices.
> - Integration has been manually tested in Raptor
