### PR TITLE
make “Show Welcome Page” checkbox persistent between runs

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -436,6 +436,9 @@ void MainWindow::showWelcomePage() {
             ReShowWindow({});
           });
   setCentralWidget(centralWidget);
+
+  centralWidget->show();
+  centralWidget->setFocus();
 }
 
 void MainWindow::ReShowWindow(QString strProject) {

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -85,6 +85,12 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void showWelcomePage();
 
   bool saveConstraintFile();
+  // Creates the new file in a working directory holding welcome page
+  // configuration
+  void saveWelcomePageConfig();
+
+  // Welcome page config file name
+  static const QString WELCOME_PAGE_CONFIG_FILE;
 
  private: /* Objects/Widgets under the main window */
   bool m_showWelcomePage{true};


### PR DESCRIPTION
> ### Motivate of the pull request
The motivation of this change is RG-52 issue, logged on “Show Welcome Page” flag value not stored between runs.
This leads to welcome page appearance after each GUI restart, which might be annoying.

> ### Describe the technical details
The idea is rather simple: we store an empty file in a working directory. During startup initialization we check whether it's there and don't show the welcome page, if it's not. The file is created when we uncheck "Show Welcome Page" checkbox.
The only way to see the welcome page again is to delete the file from working directory.