### PR TITLE
Enable Remove action for top level files; introduce delete shortcut and remove question.

### DIFF
--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -607,9 +607,8 @@ int ProjectManager::deleteFile(const QString& strFileName) {
   if (nullptr == proFileSet) {
     return -1;
   }
-  // target or top file cannot be deleted
-  if (strFileName == proFileSet->getOption(PROJECT_FILE_CONFIG_TOP) ||
-      strFileName == proFileSet->getOption(PROJECT_FILE_CONFIG_TARGET)) {
+  // target file cannot be deleted
+  if (strFileName == proFileSet->getOption(PROJECT_FILE_CONFIG_TARGET)) {
     return -1;
   }
 

--- a/src/ProjNavigator/sources_form.cpp
+++ b/src/ProjNavigator/sources_form.cpp
@@ -112,6 +112,7 @@ void SourcesForm::SlotItempressed(QTreeWidgetItem *item, int column) {
                SRC_TREE_SIM_FILE_ITEM == strPropertyRole) {
       if (strName.contains(SRC_TREE_FLG_TOP)) {
         menu->addAction(m_actOpenFile);
+        menu->addAction(m_actRemoveFile);
         menu->addAction(m_actRefresh);
         menu->addSeparator();
         menu->addAction(m_actEditConstrsSets);
@@ -280,9 +281,15 @@ void SourcesForm::SlotRemoveFile() {
   QTreeWidgetItem *item = m_treeSrcHierachy->currentItem();
   if (item == nullptr) return;
 
+  auto strFileName = item->text(0);
+  if (strFileName.contains(SRC_TREE_FLG_TOP))
+    strFileName.remove(SRC_TREE_FLG_TOP);
   auto fileSet = item->data(0, SetFileDataRole);
   if (!fileSet.isNull()) {
-    QString strFileName = item->text(0);
+    auto questionStr = tr("Should %1 file be removed?").arg(strFileName);
+    if (QMessageBox::question(this, tr("Remove file"), questionStr) ==
+        QMessageBox::No)
+      return;
     m_projManager->setCurrentFileSet(fileSet.toString());
     int ret = m_projManager->deleteFile(strFileName);
     if (0 == ret) {
@@ -394,6 +401,8 @@ void SourcesForm::CreateActions() {
           SLOT(SlotRemoveFileSet()));
 
   m_actRemoveFile = new QAction(tr("Remove File"), m_treeSrcHierachy);
+  m_actRemoveFile->setShortcut(Qt::Key_Delete);
+  m_treeSrcHierachy->addAction(m_actRemoveFile);
   connect(m_actRemoveFile, SIGNAL(triggered()), this, SLOT(SlotRemoveFile()));
 
   m_actSetAsTop = new QAction(tr("Set As TopModule"), m_treeSrcHierachy);
@@ -455,6 +464,7 @@ void SourcesForm::CreateFolderHierachyTree() {
           itemf->setIcon(0, QIcon(":/img/file.png"));
           itemf->setData(0, Qt::WhatsThisPropertyRole,
                          SRC_TREE_DESIGN_FILE_ITEM);
+          itemf->setData(0, SetFileDataRole, str);
           parentItem = itemf;
         }
         break;


### PR DESCRIPTION
> ### Motivate of the pull request
The goal of this PR is to solve GEMINIEDA-350 issue.

The changes are:
- Enabled Remove action for top level design file;
- Added a shortcut (Delete) for Remove action;
![image](https://user-images.githubusercontent.com/109239890/190001985-90fce506-01e1-4f53-bb2d-7fa1c6bf6d2c.png)

- Ask the user whether he really wants to delete the file.
![image](https://user-images.githubusercontent.com/109239890/190002065-eae56322-6fca-43d6-b27c-9873ac3f5eae.png)

Multi-selection, mentioned in GEMINIEDA-350, was discussed on a meeting and agreed to log it separately, as it's an extra feature that requires some functional analysis.
