### PR TITLE
Only disable tasks table viewport and leave scrollbars working

### DIFF
--- a/src/Compiler/TaskTableView.cpp
+++ b/src/Compiler/TaskTableView.cpp
@@ -26,7 +26,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QHeaderView>
 #include <QMenu>
 #include <QPushButton>
-#include <QScrollBar>
 
 #include "TaskManager.h"
 

--- a/src/Compiler/TaskTableView.h
+++ b/src/Compiler/TaskTableView.h
@@ -71,7 +71,7 @@ class TaskTableView : public QTableView {
  private:
   TaskManager *m_taskManager{nullptr};
   static constexpr uint TitleCol{1};
-  bool m_viewDisabled{
-      false};  // Indicates that view is disabled and shouldn't be interactive
+  // Indicates that view is disabled and shouldn't be interactive
+  bool m_viewDisabled{false};
 };
 }  // namespace FOEDAG

--- a/src/Compiler/TaskTableView.h
+++ b/src/Compiler/TaskTableView.h
@@ -71,5 +71,7 @@ class TaskTableView : public QTableView {
  private:
   TaskManager *m_taskManager{nullptr};
   static constexpr uint TitleCol{1};
+  bool m_viewDisabled{
+      false};  // Indicates that view is disabled and shouldn't be interactive
 };
 }  // namespace FOEDAG


### PR DESCRIPTION
> ### Motivate of the pull request
This PR aims to solve rg-58 issue: enable scrollbars while compilations is is progress.

> ### Describe the technical details
I couldn't activate only the scrollbar and leave all the rest as is. It is part of the view which was disabled automatically.
Still, there is an API to retrieve the widget holding only the data part: viewport().
Disabling only that one leaves scrollbars working - exactly what we want.

By doing so other things got enabled either:
- Selection;
- parent tasks collapse/expand;
- column resize.

Those only affect visual representation and, I hope, are acceptible:

![image](https://user-images.githubusercontent.com/109239890/190417431-bf1f093a-5c57-41ad-94cc-68f8f828ebe5.png)

Note: mouse press events got activated as well, so I had to manually catch them while compilation is in progress. Not the best approach, but it avoids extra complexity and effort to enable scrollbars in another way.
