### PR TITLE
Continue showing welcome page after user unchecked "Show WelcomePage" checkbox

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -730,7 +730,8 @@ void MainWindow::saveWelcomePageConfig() {
 }
 
 void MainWindow::slotWelcomePageCloseRequested(bool permanently) {
-    // TODO: This code will have to be reworked as soon as we have global settings storage.
+  // TODO: This code will have to be reworked as soon as we have global settings
+  // storage.
   if (permanently) {
     m_showWelcomePage = !m_showWelcomePage;
     saveWelcomePageConfig();

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -440,12 +440,9 @@ void MainWindow::showWelcomePage() {
   centralWidget->addAction(*openProjectAction);
   centralWidget->addAction(*openExampleAction);
 
-  connect(centralWidget, &WelcomePageWidget::welcomePageClosed,
-          [&](bool permanently) {
-            m_showWelcomePage = !permanently;
-            if (permanently) saveWelcomePageConfig();
-            ReShowWindow({});
-          });
+  connect(centralWidget, &WelcomePageWidget::welcomePageClosed, this,
+          &MainWindow::slotWelcomePageCloseRequested);
+
   setCentralWidget(centralWidget);
 
   centralWidget->show();
@@ -724,5 +721,20 @@ void MainWindow::saveWelcomePageConfig() {
   // should we shown. To store it we just save a file in a working directory -
   // if it's there, we don't show the welcome page.
   QFile file(WELCOME_PAGE_CONFIG_FILE);
-  if (file.open(QIODevice::WriteOnly)) file.close();
+  if (file.open(QIODevice::WriteOnly)) {
+    if (m_showWelcomePage)
+      file.remove();
+    else
+      file.close();
+  }
+}
+
+void MainWindow::slotWelcomePageCloseRequested(bool permanently) {
+    // TODO: This code will have to be reworked as soon as we have global settings storage.
+  if (permanently) {
+    m_showWelcomePage = !m_showWelcomePage;
+    saveWelcomePageConfig();
+  } else {
+    ReShowWindow({});
+  }
 }

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -64,7 +64,8 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void newDialogAccepted();
 
   void slotTabChanged(int index);
-  // Either closes welcome page immediately or saves the configuration to not show it after closing the project
+  // Either closes welcome page immediately or saves the configuration to not
+  // show it after closing the project
   void slotWelcomePageCloseRequested(bool permanently);
 
  private: /* Menu bar builders */

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -64,6 +64,8 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void newDialogAccepted();
 
   void slotTabChanged(int index);
+  // Either closes welcome page immediately or saves the configuration to not show it after closing the project
+  void slotWelcomePageCloseRequested(bool permanently);
 
  private: /* Menu bar builders */
   void createMenus();


### PR DESCRIPTION
> ### Motivate of the pull request
The goal of this PR is to fix RG-64 issue: welcome page immediately disappears after unchecking "Show WelcomePage" checkbox. The user should still be able to execute one of proposed actions.

> ### Describe the technical details
Not hiding the page immediately opens another opportunity for the user: he may change his mind and check the flag again.
In this case the file has to be removed. Still, all this will have to be reworked after we get QSettings working and decide on configuration panel for this.

![image](https://user-images.githubusercontent.com/109239890/190641967-1c44bad1-2e3d-4a1d-a99e-905da32758ac.png)

