### PR TITLE
[RG-70] Auto load IP Catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ test/batch: run-cmake-release
 	grep "Found IP: axis_converter_V1_1" foedag.log
 	./build/bin/foedag --batch --script tests/Testcases/IPGenerate/test_ipgenerate_instances.tcl
 	./build/bin/foedag --batch --script tests/Testcases/project_file/test.tcl
-
+	./build/bin/foedag --batch --script tests/TestBatch/test_ip_configure_load.tcl
 	
 lib-only: run-cmake-release
 	cmake --build build --target foedag -j $(CPU_CORES)

--- a/ip_load/axis_converter_V1_0_axis_converter.json
+++ b/ip_load/axis_converter_V1_0_axis_converter.json
@@ -3,7 +3,7 @@
    "core_out_width": 64,
    "core_user_width": 0,
    "core_reverse": 0,
-   "build_dir": "/home/skyler/code/forks/FOEDAG/ipTest/ipTest.IPs/RapidSilicon/IP/axis_converter/V1_1/axis_converter/src",
+   "build_dir": "./ip_load/ip_load.IPs/RapidSilicon/IP/axis_converter/V1_1/axis_converter/src",
    "build_name": "axis_converter.v",
    "build": true,
    "json": "axis_converter_V1_0_axis_converter.json",

--- a/ip_load/axis_converter_V1_0_axis_converter.json
+++ b/ip_load/axis_converter_V1_0_axis_converter.json
@@ -1,0 +1,11 @@
+{
+   "core_in_width": 128,
+   "core_out_width": 64,
+   "core_user_width": 0,
+   "core_reverse": 0,
+   "build_dir": "/home/skyler/code/forks/FOEDAG/ipTest/ipTest.IPs/RapidSilicon/IP/axis_converter/V1_1/axis_converter/src",
+   "build_name": "axis_converter.v",
+   "build": true,
+   "json": "axis_converter_V1_0_axis_converter.json",
+   "json_template": false
+}

--- a/ip_load/axis_converter_V1_0_axis_converter2.json
+++ b/ip_load/axis_converter_V1_0_axis_converter2.json
@@ -3,7 +3,7 @@
    "core_out_width": 64,
    "core_user_width": 0,
    "core_reverse": 0,
-   "build_dir": "/home/skyler/code/forks/FOEDAG/ipTest/ipTest.IPs/RapidSilicon/IP/axis_converter/V1_1/axis_converter/src",
+   "build_dir": "./ipTest/ipTest.IPs/RapidSilicon/IP/axis_converter/V1_1/axis_converter/src",
    "build_name": "axis_converter.v",
    "build": true,
    "json": "axis_converter_V1_0_axis_converter2.json",

--- a/ip_load/axis_converter_V1_0_axis_converter2.json
+++ b/ip_load/axis_converter_V1_0_axis_converter2.json
@@ -1,0 +1,11 @@
+{
+   "core_in_width": 128,
+   "core_out_width": 64,
+   "core_user_width": 0,
+   "core_reverse": 0,
+   "build_dir": "/home/skyler/code/forks/FOEDAG/ipTest/ipTest.IPs/RapidSilicon/IP/axis_converter/V1_1/axis_converter/src",
+   "build_name": "axis_converter.v",
+   "build": true,
+   "json": "axis_converter_V1_0_axis_converter2.json",
+   "json_template": false
+}

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -1639,7 +1639,16 @@ bool Compiler::HasIPInstances() {
   bool result = false;
   auto ipGen = GetIPGenerator();
   if (ipGen) {
-    result = (ipGen->IPInstances().size() > 0);
+    result = !ipGen->IPInstances().empty();
+  }
+  return result;
+}
+
+bool Compiler::HasIPDefinitions() {
+  bool result = false;
+  auto ipGen = GetIPGenerator();
+  if (ipGen && ipGen->Catalog()) {
+    result = !ipGen->Catalog()->Definitions().empty();
   }
   return result;
 }

--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -123,6 +123,8 @@ class Compiler {
   void SetIPGenerator(IPGenerator* generator) { m_IPGenerator = generator; }
   IPGenerator* GetIPGenerator() { return m_IPGenerator; }
   bool BuildLiteXIPCatalog(std::filesystem::path litexPath);
+  bool HasIPInstances();
+  bool HasIPDefinitions();
 
   // VPR, Yosys generic opt
   void ChannelWidth(uint32_t width) { m_channel_width = width; }
@@ -194,7 +196,6 @@ class Compiler {
    */
   virtual bool VerifyTargetDevice() const;
   bool HasTargetDevice();
-  bool HasIPInstances();
 
   bool CreateDesign(const std::string& name);
   static void PrintVersion(std::ostream* out);

--- a/src/IPGenerate/IPCatalogBuilder.cpp
+++ b/src/IPGenerate/IPCatalogBuilder.cpp
@@ -126,9 +126,6 @@ bool IPCatalogBuilder::buildLiteXIPFromGenerator(
                              help.str());
     return false;
   }
-  std::cout << "python3Path: " << python3Path.string() << std::endl;
-  std::cout << "Python Command: " << command << std::endl;
-  std::cout << "Python Result: " << help.str() << std::endl;
   std::stringstream buffer;
   buffer << help.str();
   json jopts;

--- a/src/IPGenerate/IPCatalogBuilder.cpp
+++ b/src/IPGenerate/IPCatalogBuilder.cpp
@@ -126,6 +126,9 @@ bool IPCatalogBuilder::buildLiteXIPFromGenerator(
                              help.str());
     return false;
   }
+
+  std::cout << "Python Command: " << command << std::endl;
+  std::cout << "Python Result: " << help.str() << std::endl;
   std::stringstream buffer;
   buffer << help.str();
   json jopts;
@@ -134,7 +137,7 @@ bool IPCatalogBuilder::buildLiteXIPFromGenerator(
   } catch (json::parse_error& e) {
     std::string msg = "Json Parse Error: " + std::string(e.what()) + "\n" +
                       "filePath: " + pythonConverterScript.string() + "\n" +
-                      "json: " + buffer.str();
+                      "genCmd: " + command + "\n" + "json: " + buffer.str();
     m_compiler->ErrorMessage(msg);
   }
 

--- a/src/IPGenerate/IPCatalogBuilder.cpp
+++ b/src/IPGenerate/IPCatalogBuilder.cpp
@@ -133,7 +133,8 @@ bool IPCatalogBuilder::buildLiteXIPFromGenerator(
     jopts = json::parse(buffer);
   } catch (json::parse_error& e) {
     std::string msg = "Json Parse Error: " + std::string(e.what()) + "\n" +
-                      "filePath: " + pythonConverterScript.string() + "\n";
+                      "filePath: " + pythonConverterScript.string() + "\n" +
+                      "json: " + buffer.str();
     m_compiler->ErrorMessage(msg);
   }
 

--- a/src/IPGenerate/IPCatalogBuilder.cpp
+++ b/src/IPGenerate/IPCatalogBuilder.cpp
@@ -126,7 +126,7 @@ bool IPCatalogBuilder::buildLiteXIPFromGenerator(
                              help.str());
     return false;
   }
-
+  std::cout << "python3Path: " << python3Path.string() << std::endl;
   std::cout << "Python Command: " << command << std::endl;
   std::cout << "Python Result: " << help.str() << std::endl;
   std::stringstream buffer;

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -66,9 +66,10 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       compiler->ErrorMessage(
           "Missing directory path for LiteX ip generator(s)");
     }
-    const std::string file = argv[1];
+    // const std::string file = argv[1];
+    const std::filesystem::path file = argv[1];
     std::cout << "add_litex_ip_catalog " << file << std::endl;
-    std::string expandedFile = file;
+    std::filesystem::path expandedFile = file;
     bool use_orig_path = false;
     if (FileUtils::FileExists(expandedFile) && expandedFile != "./") {
       use_orig_path = true;
@@ -80,15 +81,15 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
           compiler->GetSession()->CmdLine()->Script();
       std::filesystem::path scriptPath = script.parent_path();
       std::filesystem::path fullPath = scriptPath;
-      fullPath.append(file);
-      expandedFile = fullPath.string();
+      fullPath = fullPath / file;
+      expandedFile = fullPath;
       std::cout << "add_litex_ip_catalog2 " << fullPath << " " << scriptPath
                 << std::endl;
     }
     std::filesystem::path the_path = expandedFile;
     if (!the_path.is_absolute()) {
       const auto& path = std::filesystem::current_path();
-      expandedFile = std::filesystem::path(path / expandedFile).string();
+      expandedFile = path / expandedFile;
       std::cout << "add_litex_ip_catalog3 " << expandedFile << std::endl;
     }
     bool status = compiler->BuildLiteXIPCatalog(expandedFile);

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -109,8 +109,8 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       std::filesystem::path path =
           GlobalSession->Context()->DataPath() / "IP_Catalog";
       std::cout << "auto load " << path << std::endl;
-      compiler->TclInterp()->evalCmd("add_litex_ip_catalog " +
-                                     path.lexically_normal().string());
+      compiler->TclInterp()->evalCmd("add_litex_ip_catalog {" +
+                                     path.lexically_normal().string() + "}");
     }
 
     bool status = true;
@@ -168,8 +168,8 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     if (!compiler->HasIPDefinitions()) {
       std::filesystem::path path =
           GlobalSession->Context()->DataPath() / "IP_Catalog";
-      compiler->TclInterp()->evalCmd("add_litex_ip_catalog " +
-                                     path.lexically_normal().string());
+      compiler->TclInterp()->evalCmd("add_litex_ip_catalog {" +
+                                     path.lexically_normal().string() + "}");
     }
 
     std::string ip_name;

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -108,7 +108,8 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     if (!compiler->HasIPDefinitions()) {
       std::filesystem::path path =
           GlobalSession->Context()->DataPath() / "IP_Catalog";
-      compiler->TclInterp()->evalCmd("add_litex_ip_catalog " + path.string());
+      compiler->TclInterp()->evalCmd("add_litex_ip_catalog " +
+                                     path.lexically_normal().string());
     }
 
     bool status = true;
@@ -166,7 +167,8 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     if (!compiler->HasIPDefinitions()) {
       std::filesystem::path path =
           GlobalSession->Context()->DataPath() / "IP_Catalog";
-      compiler->TclInterp()->evalCmd("add_litex_ip_catalog " + path.string());
+      compiler->TclInterp()->evalCmd("add_litex_ip_catalog " +
+                                     path.lexically_normal().string());
     }
 
     std::string ip_name;
@@ -285,10 +287,11 @@ bool IPGenerator::Generate() {
   for (IPInstance* inst : m_instances) {
     // Create output directory
     const std::filesystem::path& out_path = inst->OutputFile();
-
+    std::cout << "IPGenerator::Generate path: " << out_path << std::endl;
     if (!std::filesystem::exists(out_path)) {
       std::filesystem::create_directories(out_path.parent_path());
     }
+    std::cout << "IPGenerator::Generate POST-CREATE" << std::endl;
 
     const IPDefinition* def = inst->Definition();
     switch (def->Type()) {

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -66,9 +66,7 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       compiler->ErrorMessage(
           "Missing directory path for LiteX ip generator(s)");
     }
-    // const std::string file = argv[1];
     const std::filesystem::path file = argv[1];
-    std::cout << "add_litex_ip_catalog " << file << std::endl;
     std::filesystem::path expandedFile = file;
     bool use_orig_path = false;
     if (FileUtils::FileExists(expandedFile) && expandedFile != "./") {
@@ -83,16 +81,12 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       std::filesystem::path fullPath = scriptPath;
       fullPath = fullPath / file;
       expandedFile = fullPath;
-      std::cout << "add_litex_ip_catalog2 " << fullPath << " " << scriptPath
-                << std::endl;
     }
     std::filesystem::path the_path = expandedFile;
     if (!the_path.is_absolute()) {
       const auto& path = std::filesystem::current_path();
       expandedFile = path / expandedFile;
-      std::cout << "add_litex_ip_catalog3 " << expandedFile << std::endl;
     }
-    std::cout << "PATH: " << expandedFile.lexically_normal() << std::endl;
     bool status =
         compiler->BuildLiteXIPCatalog(expandedFile.lexically_normal());
     return (status) ? TCL_OK : TCL_ERROR;
@@ -108,7 +102,6 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     if (!compiler->HasIPDefinitions()) {
       std::filesystem::path path =
           GlobalSession->Context()->DataPath() / "IP_Catalog";
-      std::cout << "auto load " << path << std::endl;
       compiler->TclInterp()->evalCmd("add_litex_ip_catalog {" +
                                      path.lexically_normal().string() + "}");
     }
@@ -296,11 +289,9 @@ bool IPGenerator::Generate() {
   for (IPInstance* inst : m_instances) {
     // Create output directory
     const std::filesystem::path& out_path = inst->OutputFile();
-    std::cout << "IPGenerator::Generate path: " << out_path << std::endl;
     if (!std::filesystem::exists(out_path)) {
       std::filesystem::create_directories(out_path.parent_path());
     }
-    std::cout << "IPGenerator::Generate POST-CREATE" << std::endl;
 
     const IPDefinition* def = inst->Definition();
     switch (def->Type()) {

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -96,6 +96,15 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
                        const char* argv[]) -> int {
     IPGenerator* generator = (IPGenerator*)clientData;
     Compiler* compiler = generator->GetCompiler();
+
+    // Load IPs if no definitions are available
+    if (!compiler->HasIPDefinitions()) {
+      std::filesystem::path path =
+          std::filesystem::path(GlobalSession->Context()->DataPath().string()) /
+          "IP_Catalog";
+      compiler->TclInterp()->evalCmd("add_litex_ip_catalog " + path.string());
+    }
+
     bool status = true;
     if (argc == 1) {
       // List all IPs
@@ -146,6 +155,15 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
           "-out_file <filename> -version <ver_name> -P<param>=\"<value>\"...");
       return TCL_ERROR;
     }
+
+    // Load IPs if no definitions are available
+    if (!compiler->HasIPDefinitions()) {
+      std::filesystem::path path =
+          std::filesystem::path(GlobalSession->Context()->DataPath().string()) /
+          "IP_Catalog";
+      compiler->TclInterp()->evalCmd("add_litex_ip_catalog " + path.string());
+    }
+
     std::string ip_name;
     std::string mod_name;
     std::string out_file;

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -108,6 +108,7 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     if (!compiler->HasIPDefinitions()) {
       std::filesystem::path path =
           GlobalSession->Context()->DataPath() / "IP_Catalog";
+      std::cout << "auto load " << path << std::endl;
       compiler->TclInterp()->evalCmd("add_litex_ip_catalog " +
                                      path.lexically_normal().string());
     }

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -92,7 +92,9 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       expandedFile = path / expandedFile;
       std::cout << "add_litex_ip_catalog3 " << expandedFile << std::endl;
     }
-    bool status = compiler->BuildLiteXIPCatalog(expandedFile);
+    std::cout << "PATH: " << expandedFile.lexically_normal() << std::endl;
+    bool status =
+        compiler->BuildLiteXIPCatalog(expandedFile.lexically_normal());
     return (status) ? TCL_OK : TCL_ERROR;
   };
   interp->registerCmd("add_litex_ip_catalog", add_litex_ip_catalog, this, 0);

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -100,8 +100,7 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     // Load IPs if no definitions are available
     if (!compiler->HasIPDefinitions()) {
       std::filesystem::path path =
-          std::filesystem::path(GlobalSession->Context()->DataPath().string()) /
-          "IP_Catalog";
+          GlobalSession->Context()->DataPath() / "IP_Catalog";
       compiler->TclInterp()->evalCmd("add_litex_ip_catalog " + path.string());
     }
 
@@ -159,8 +158,7 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     // Load IPs if no definitions are available
     if (!compiler->HasIPDefinitions()) {
       std::filesystem::path path =
-          std::filesystem::path(GlobalSession->Context()->DataPath().string()) /
-          "IP_Catalog";
+          GlobalSession->Context()->DataPath() / "IP_Catalog";
       compiler->TclInterp()->evalCmd("add_litex_ip_catalog " + path.string());
     }
 

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -67,6 +67,7 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
           "Missing directory path for LiteX ip generator(s)");
     }
     const std::string file = argv[1];
+    std::cout << "add_litex_ip_catalog " << file << std::endl;
     std::string expandedFile = file;
     bool use_orig_path = false;
     if (FileUtils::FileExists(expandedFile) && expandedFile != "./") {
@@ -81,11 +82,14 @@ bool IPGenerator::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       std::filesystem::path fullPath = scriptPath;
       fullPath.append(file);
       expandedFile = fullPath.string();
+      std::cout << "add_litex_ip_catalog2 " << fullPath << " " << scriptPath
+                << std::endl;
     }
     std::filesystem::path the_path = expandedFile;
     if (!the_path.is_absolute()) {
       const auto& path = std::filesystem::current_path();
       expandedFile = std::filesystem::path(path / expandedFile).string();
+      std::cout << "add_litex_ip_catalog3 " << expandedFile << std::endl;
     }
     bool status = compiler->BuildLiteXIPCatalog(expandedFile);
     return (status) ? TCL_OK : TCL_ERROR;

--- a/src/IpConfigurator/IpCatalogTree.cpp
+++ b/src/IpConfigurator/IpCatalogTree.cpp
@@ -106,7 +106,7 @@ void IpCatalogTree::loadIps(const std::vector<std::filesystem::path>& paths) {
     for (auto path : paths) {
       if (std::filesystem::exists(path)) {
         QString cmd = QString("add_litex_ip_catalog %1")
-                          .arg(QString::fromStdString(path.string()));
+                          .arg(QString::fromStdString(path.lexically_normal()));
         int ok = TCL_ERROR;
         GlobalSession->TclInterp()->evalCmd(cmd.toStdString(), &ok);
       }

--- a/src/IpConfigurator/IpCatalogTree.cpp
+++ b/src/IpConfigurator/IpCatalogTree.cpp
@@ -106,7 +106,7 @@ void IpCatalogTree::loadIps(const std::vector<std::filesystem::path>& paths) {
     for (auto path : paths) {
       if (std::filesystem::exists(path)) {
         QString cmd =
-            QString("add_litex_ip_catalog %1")
+            QString("add_litex_ip_catalog {%1}")
                 .arg(QString::fromStdString(path.lexically_normal().string()));
         int ok = TCL_ERROR;
         GlobalSession->TclInterp()->evalCmd(cmd.toStdString(), &ok);

--- a/src/IpConfigurator/IpCatalogTree.cpp
+++ b/src/IpConfigurator/IpCatalogTree.cpp
@@ -66,8 +66,7 @@ void IpCatalogTree::refresh() {
   // catalog path. This path should be loaded in addition to the default
   std::filesystem::path UserCatalogPath = std::filesystem::path("");
   std::filesystem::path IpCatalogPath =
-      std::filesystem::path(GlobalSession->Context()->DataPath().string()) /
-      "IP_Catalog";
+      GlobalSession->Context()->DataPath() / "IP_Catalog";
   std::vector<std::filesystem::path> IpPaths{IpCatalogPath, UserCatalogPath};
 
   QStringList ips;

--- a/src/IpConfigurator/IpCatalogTree.cpp
+++ b/src/IpConfigurator/IpCatalogTree.cpp
@@ -105,8 +105,9 @@ void IpCatalogTree::loadIps(const std::vector<std::filesystem::path>& paths) {
   if (tclCmdExists("add_litex_ip_catalog")) {
     for (auto path : paths) {
       if (std::filesystem::exists(path)) {
-        QString cmd = QString("add_litex_ip_catalog %1")
-                          .arg(QString::fromStdString(path.lexically_normal()));
+        QString cmd =
+            QString("add_litex_ip_catalog %1")
+                .arg(QString::fromStdString(path.lexically_normal().string()));
         int ok = TCL_ERROR;
         GlobalSession->TclInterp()->evalCmd(cmd.toStdString(), &ok);
       }

--- a/src/Main/Foedag.cpp
+++ b/src/Main/Foedag.cpp
@@ -144,10 +144,8 @@ Foedag::Foedag(FOEDAG::CommandLine* cmdLine, MainWindowBuilder* mainWinBuilder,
     std::filesystem::path exeDirPath = exePath.parent_path();
     m_context->BinaryPath(exeDirPath);
     std::filesystem::path installDir = exeDirPath.parent_path();
-    const std::string separator(1, std::filesystem::path::preferred_separator);
-    std::filesystem::path dataDir = installDir.string() + separator +
-                                    std::string("share") + separator +
-                                    m_context->ExecutableName();
+    std::filesystem::path dataDir =
+        installDir / "share" / m_context->ExecutableName();
     m_context->DataPath(dataDir);
   }
 }

--- a/tests/TestBatch/test_ip_configure_load.tcl
+++ b/tests/TestBatch/test_ip_configure_load.tcl
@@ -24,6 +24,7 @@
 
 set platform $::tcl_platform(platform)
 if { $platform == "windows" } {
+    # TODO @skyler-rs Sept2022 Enable in windows once GH-661 is resolved
     puts "SKIPPING ON WINDOWS: This test requires python which FileUtils::ExecuteSystemCommand() currently fails to find on Windows. Disabling windows run of test until python issues on windows are resolved.\n"
     # returning a pass condition because this is an expected failure for now
     exit 0

--- a/tests/TestBatch/test_ip_configure_load.tcl
+++ b/tests/TestBatch/test_ip_configure_load.tcl
@@ -1,0 +1,49 @@
+#Copyright 2022 The Foedag team
+
+#GPL License
+
+#Copyright (c) 2022 The Open-Source FPGA Foundation
+
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+######################################################################
+
+# This is a test for GEMINIEDA-352
+# This test ensures that the IP_Catalog is automatically loaded when a user
+# runs a script with configure_ip, but doesn't bother to call add_litex_ip_catalog
+
+create_design ip_load
+architecture ../../Arch/k6_frac_N10_tileable_40nm.xml ../../Arch/k6_N10_40nm_openfpga.xml
+
+# Typically you should load your IP_Catalog via add_litex_ip_catalog, but GEMINIEDA-352
+# requests new functionality to auto load the ip library before a configure_ip
+
+configure_ip axis_converter_V1_0 -mod_name axis_converter -version V1_1 -Pcore_in_width=128 -Pcore_out_width=64 -Pcore_user_width=0 -Pcore_reverse=0 -out_file /home/skyler/code/forks/FOEDAG/ipTest/ipTest.IPs/RapidSilicon/IP/axis_converter/V1_1/axis_converter/src/axis_converter.v
+ipgenerate
+
+# If the IP fails to generate, it means that axis_converter_V1_0 never got
+# automatically loaded into the IP_Catalog
+
+# Error out if "IPs are generated" wasn't printed
+set fp [open "foedag.log" r]
+set file_data [read $fp]
+close $fp
+set failed [regexp "IPs are generated" $file_data]
+# invert the return value so it the script will error properly
+set failed [expr {!$failed}]
+if { $failed == 1 } {
+    puts "ERROR: configure_ip command failed to generate ip"
+}
+exit $failed
+
+

--- a/tests/TestBatch/test_ip_configure_load.tcl
+++ b/tests/TestBatch/test_ip_configure_load.tcl
@@ -22,28 +22,35 @@
 # This test ensures that the IP_Catalog is automatically loaded when a user
 # runs a script with configure_ip, but doesn't bother to call add_litex_ip_catalog
 
-create_design ip_load
-architecture ../../Arch/k6_frac_N10_tileable_40nm.xml ../../Arch/k6_N10_40nm_openfpga.xml
+set platform $::tcl_platform(platform)
+if { $platform == "windows" } {
+    puts "SKIPPING ON WINDOWS: This test requires python which FileUtils::ExecuteSystemCommand() currently fails to find on Windows. Disabling windows run of test until python issues on windows are resolved.\n"
+    # returning a pass condition because this is an expected failure for now
+    exit 0
+} else {
+    create_design ip_load
+    architecture ../../Arch/k6_frac_N10_tileable_40nm.xml ../../Arch/k6_N10_40nm_openfpga.xml
 
-# Typically you should load your IP_Catalog via add_litex_ip_catalog, but GEMINIEDA-352
-# requests new functionality to auto load the ip library before a configure_ip
+    # Typically you should load your IP_Catalog via add_litex_ip_catalog, but GEMINIEDA-352
+    # requests new functionality to auto load the ip library before a configure_ip
 
-configure_ip axis_converter_V1_0 -mod_name axis_converter -version V1_1 -Pcore_in_width=128 -Pcore_out_width=64 -Pcore_user_width=0 -Pcore_reverse=0 -out_file ./ip_load/ip_load.IPs/RapidSilicon/IP/axis_converter/V1_1/axis_converter/src/axis_converter.v
-ipgenerate
+    configure_ip axis_converter_V1_0 -mod_name axis_converter -version V1_1 -Pcore_in_width=128 -Pcore_out_width=64 -Pcore_user_width=0 -Pcore_reverse=0 -out_file ./ip_load/ip_load.IPs/RapidSilicon/IP/axis_converter/V1_1/axis_converter/src/axis_converter.v
+    ipgenerate
 
-# If the IP fails to generate, it means that axis_converter_V1_0 never got
-# automatically loaded into the IP_Catalog
+    # If the IP fails to generate, it means that axis_converter_V1_0 never got
+    # automatically loaded into the IP_Catalog
 
-# Error out if "IPs are generated" wasn't printed
-set fp [open "foedag.log" r]
-set file_data [read $fp]
-close $fp
-set failed [regexp "IPs are generated" $file_data]
-# invert the return value so it the script will error properly
-set failed [expr {!$failed}]
-if { $failed == 1 } {
-    puts "ERROR: configure_ip command failed to generate ip"
+    # Error out if "IPs are generated" wasn't printed
+    set fp [open "foedag.log" r]
+    set file_data [read $fp]
+    close $fp
+    set failed [regexp "IPs are generated" $file_data]
+    # invert the return value so it the script will error properly
+    set failed [expr {!$failed}]
+    if { $failed == 1 } {
+        puts "ERROR: configure_ip command failed to generate ip"
+    }
+    exit $failed
 }
-exit $failed
 
 

--- a/tests/TestBatch/test_ip_configure_load.tcl
+++ b/tests/TestBatch/test_ip_configure_load.tcl
@@ -28,7 +28,7 @@ architecture ../../Arch/k6_frac_N10_tileable_40nm.xml ../../Arch/k6_N10_40nm_ope
 # Typically you should load your IP_Catalog via add_litex_ip_catalog, but GEMINIEDA-352
 # requests new functionality to auto load the ip library before a configure_ip
 
-configure_ip axis_converter_V1_0 -mod_name axis_converter -version V1_1 -Pcore_in_width=128 -Pcore_out_width=64 -Pcore_user_width=0 -Pcore_reverse=0 -out_file /home/skyler/code/forks/FOEDAG/ipTest/ipTest.IPs/RapidSilicon/IP/axis_converter/V1_1/axis_converter/src/axis_converter.v
+configure_ip axis_converter_V1_0 -mod_name axis_converter -version V1_1 -Pcore_in_width=128 -Pcore_out_width=64 -Pcore_user_width=0 -Pcore_reverse=0 -out_file ./ip_load/ip_load.IPs/RapidSilicon/IP/axis_converter/V1_1/axis_converter/src/axis_converter.v
 ipgenerate
 
 # If the IP fails to generate, it means that axis_converter_V1_0 never got

--- a/tests/Testcases/IPGenerate/IP_Catalog/dummy_generators/RapidSilicon/IP/axis_converter/V1_0/axis_converter_gen.py
+++ b/tests/Testcases/IPGenerate/IP_Catalog/dummy_generators/RapidSilicon/IP/axis_converter/V1_0/axis_converter_gen.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python3
+import json
 
 # The following is the captured output of `python3 axis_converter_gen.py --json-template`
 # Which is what the IPCatalog calls when first reading in IPs
 # Foedag currently doesn't have the dependencies(litex/migen) to run that command
 # on the fly so this file is a temporary solution
-print('''{
+
+obj = {
     "core_in_width": 128,
     "core_out_width": 64,
     "core_user_width": 0,
-    "core_reverse": false,
-    "build": false,
+    "core_reverse": False,
+    "build": False,
     "build_dir": "build",
     "build_name": "axis_converter_128b_to_64b",
-    "json": null,
-    "json_template": true
-}''')
+    "json": None,
+    "json_template": True
+}
+
+print( json.dumps(obj) )

--- a/tests/Testcases/IPGenerate/IP_Catalog/dummy_generators/RapidSilicon/IP/axis_converter/V1_1/axis_converter_gen.py
+++ b/tests/Testcases/IPGenerate/IP_Catalog/dummy_generators/RapidSilicon/IP/axis_converter/V1_1/axis_converter_gen.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python3
+import json
 
 # The following is the captured output of `python3 axis_converter_gen.py --json-template`
 # Which is what the IPCatalog calls when first reading in IPs
 # Foedag currently doesn't have the dependencies(litex/migen) to run that command
 # on the fly so this file is a temporary solution
-print('''{
+
+obj = {
     "core_in_width": 128,
     "core_out_width": 64,
     "core_user_width": 0,
-    "core_reverse": false,
-    "build": false,
+    "core_reverse": False,
+    "build": False,
     "build_dir": "build",
     "build_name": "axis_converter_128b_to_64b",
-    "json": null,
-    "json_template": true
-}''')
+    "json": None,
+    "json_template": True
+}
+
+print( json.dumps(obj) )


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-70

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Currently the IP_Catalog needs to be manually loaded by calling add_litex_ip_catalog

> #### What does this pull request change?
> add_litex_ip_catalog is now called when ip_catalog and configure_ip are fired and the IP Catalog is empty.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IPGenerate, Compiler
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
> - tests/TestBatch/test_ip_configure_load.tcl has been added to ensure that an ip can be generated w/o an explicit call to add_litex_ip_catalog
> - Manually integration tested in raptor