### PR TITLE
Align welcome page controls

### DIFF
--- a/src/MainWindow/WelcomePageWidget.cpp
+++ b/src/MainWindow/WelcomePageWidget.cpp
@@ -59,16 +59,14 @@ WelcomePageWidget::WelcomePageWidget(const QString &header,
   auto headerFont = headerLabel->font();
   headerFont.setPointSize(HEADER_POINTSIZE);
   headerLabel->setFont(headerFont);
-  headerLabel->setContentsMargins(HEADER_MARGIN, HEADER_MARGIN, HEADER_MARGIN,
-                                  0);
+  headerLabel->setContentsMargins(0, HEADER_MARGIN, HEADER_MARGIN, 0);
 
   // Description label
   auto descLabel = new QLabel(getDescription(srcDir), this);
   auto descFont = descLabel->font();
   descFont.setPointSize(DESCRIPTION_POINTSIZE);
   descLabel->setFont(descFont);
-  descLabel->setContentsMargins(HEADER_MARGIN, 0, HEADER_MARGIN,
-                                HEADER_MARGIN * 2);
+  descLabel->setContentsMargins(0, 0, HEADER_MARGIN, HEADER_MARGIN * 2);
 
   // Group box with start actions
   auto quickStartGroupBox = new QGroupBox(this);
@@ -94,7 +92,7 @@ WelcomePageWidget::WelcomePageWidget(const QString &header,
   showPageCheckBox->setCheckState(Qt::Checked);
   connect(showPageCheckBox, &QAbstractButton::clicked,
           [this]() { emit welcomePageClosed(true); });
-  mainLayout->addWidget(showPageCheckBox);
+  mainLayout->addWidget(showPageCheckBox, 0, Qt::AlignHCenter);
   mainLayout->addStretch(1);
   m_mainLayout = mainLayout;
 
@@ -155,8 +153,7 @@ void WelcomePageWidget::initRecentProjects() {
   auto recentFont = recentLabel->font();
   recentFont.setPointSize(DESCRIPTION_POINTSIZE);
   recentLabel->setFont(recentFont);
-  recentLabel->setContentsMargins(HEADER_MARGIN, 0, HEADER_MARGIN,
-                                  HEADER_MARGIN * 2);
+  recentLabel->setContentsMargins(0, 0, HEADER_MARGIN, HEADER_MARGIN * 2);
   m_recentProjectsLayout->addWidget(recentLabel);
   auto recentProjectsGroupBox = new QGroupBox(this);
   recentProjectsGroupBox->setLayout(m_recentProjectsLayout);


### PR DESCRIPTION
> ### Motivate of the pull request
The goal of this PR is to fix RG-63 issue: labels alignment on the welcome page.

> ### Describe the technical details
Left margin of description and application name was set to 0, which is similar to actions and recent projects margin.
Show Welcome Page checkbox was moved to the center, as suggested in RG-63.
![image](https://user-images.githubusercontent.com/109239890/190730454-12dddfd7-9432-4f18-b8b4-2f27a15852f2.png)

