### PR TITLE
Add dock widget actions into View menu

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -660,6 +660,7 @@ void MainWindow::ReShowWindow(QString strProject) {
   sourcesForm->InitSourcesForm();
   // runForm->InitRunsForm();
   updatePRViewButton(static_cast<int>(m_compiler->CompilerState()));
+  updateViewMenu();
 }
 
 void MainWindow::clearDockWidgets() {
@@ -785,6 +786,21 @@ void MainWindow::newDialogAccepted() {
 void MainWindow::updateSourceTree() {
   if (sourcesForm) {
     sourcesForm->InitSourcesForm();
+  }
+}
+
+void MainWindow::updateViewMenu() {
+  viewMenu->clear();
+  viewMenu->addAction(ipConfiguratorAction);
+  viewMenu->addAction(pinAssignmentAction);
+  const QList<QDockWidget*> dockwidgets = findChildren<QDockWidget*>();
+  if (!dockwidgets.empty()) {
+    viewMenu->addSeparator();
+    for (int i = 0; i < dockwidgets.size(); ++i) {
+      QDockWidget* dockWidget = dockwidgets.at(i);
+      if (layout()->indexOf(dockWidget) == -1) continue;
+      viewMenu->addAction(dockWidget->toggleViewAction());
+    }
   }
 }
 

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -75,6 +75,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void updateSourceTree();
 
  private: /* Menu bar builders */
+  void updateViewMenu();
   void createMenus();
   void createToolBars();
   void createActions();


### PR DESCRIPTION
### Motivate of the pull request
Add dock widgets actions into View menu. This will improve usability.

### Describe the technical details
Every dock widget has it's own action show/hide it. Just added this actions into View menu.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/191251301-027b9a5c-6316-4759-bf0a-fc97cca6518e.png)