### PR TITLE
Revert changes keeping welcome page open after unchecking show flag

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -514,8 +514,12 @@ void MainWindow::showWelcomePage() {
     centralWidget->addRecentProject(*it->first);
   }
 
-  connect(centralWidget, &WelcomePageWidget::welcomePageClosed, this,
-          &MainWindow::slotWelcomePageCloseRequested);
+  connect(centralWidget, &WelcomePageWidget::welcomePageClosed,
+          [&](bool permanently) {
+            m_showWelcomePage = !permanently;
+            if (permanently) saveWelcomePageConfig();
+            ReShowWindow({});
+          });
 
   setCentralWidget(centralWidget);
 
@@ -799,23 +803,7 @@ void MainWindow::saveWelcomePageConfig() {
   // should we shown. To store it we just save a file in a working directory -
   // if it's there, we don't show the welcome page.
   QFile file(WELCOME_PAGE_CONFIG_FILE);
-  if (file.open(QIODevice::WriteOnly)) {
-    if (m_showWelcomePage)
-      file.remove();
-    else
-      file.close();
-  }
-}
-
-void MainWindow::slotWelcomePageCloseRequested(bool permanently) {
-  // TODO: This code will have to be reworked as soon as we have global settings
-  // storage.
-  if (permanently) {
-    m_showWelcomePage = !m_showWelcomePage;
-    saveWelcomePageConfig();
-  } else {
-    ReShowWindow({});
-  }
+  if (file.open(QIODevice::WriteOnly)) file.close();
 }
 
 void MainWindow::recentProjectOpen() {

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -67,9 +67,6 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void recentProjectOpen();
 
   void slotTabChanged(int index);
-  // Either closes welcome page immediately or saves the configuration to not
-  // show it after closing the project
-  void slotWelcomePageCloseRequested(bool permanently);
 
  public slots:
   void updateSourceTree();


### PR DESCRIPTION
> ### Motivate of the pull request
Current PR reverts changes of following PR:
https://github.com/os-fpga/FOEDAG/pull/657

Change is caused by updated requirements.
Now welcome page will immediately disappear after unchecking "Show welcome page" flag.
