### PR TITLE
[RG-71] - Use Module Name instead of IP Name for IP Instances in Source Tree

### DIFF
--- a/src/IpConfigurator/IpConfigDlg.cpp
+++ b/src/IpConfigurator/IpConfigDlg.cpp
@@ -63,6 +63,7 @@ QString getUserProjectPath(const QString& suffix) {
 
 IpConfigDlg::IpConfigDlg(QWidget* parent /*nullptr*/,
                          QString requestedIpName /* "" */,
+                         QString moduleName /* "" */,
                          QStringList instanceValueArgs /*{}*/)
     : m_requestedIpName(requestedIpName),
       m_instanceValueArgs(instanceValueArgs) {
@@ -90,6 +91,11 @@ IpConfigDlg::IpConfigDlg(QWidget* parent /*nullptr*/,
   // Add Output Box
   CreateOutputFields();
   topLayout->addWidget(&outputBox);
+  // Update the module name if one was passed (this occurs during a
+  // re-configure)
+  if (!moduleName.isEmpty()) {
+    moduleEdit.setText(moduleName);
+  }
 
   // Add Dialog Buttons
   topLayout->addStretch();

--- a/src/IpConfigurator/IpConfigDlg.h
+++ b/src/IpConfigurator/IpConfigDlg.h
@@ -35,6 +35,7 @@ class IpConfigDlg : public QDialog {
 
  public:
   explicit IpConfigDlg(QWidget* parent = nullptr, QString requestedIpName = "",
+                       QString moduleName = "",
                        QStringList instanceValueArgs = {});
 
  public slots:

--- a/src/ProjNavigator/sources_form.cpp
+++ b/src/ProjNavigator/sources_form.cpp
@@ -439,23 +439,23 @@ void SourcesForm::CreateActions() {
     if (item == nullptr) {
       return;
     }
-    std::string ipName = item->text(0).toStdString();
+    std::string moduleName = item->text(0).toStdString();
 
     auto instances =
         GlobalSession->GetCompiler()->GetIPGenerator()->IPInstances();
 
-    // Find the ip instance with a matching name
-    // This assumes the IPInstances() interface stores unique IPName's
-    // Additional qualifiers can be added to this search if IPName becomes
-    // non-unique
-    auto isMatch = [ipName](IPInstance *instance) {
-      return instance->IPName() == ipName;
+    // Find the ip instance with a matching module name
+    auto isMatch = [moduleName](IPInstance *instance) {
+      return instance->ModuleName() == moduleName;
     };
     auto result =
         std::find_if(std::begin(instances), std::end(instances), isMatch);
 
+    std::string ipName{};
     QStringList args{};
     if (result != std::end(instances)) {
+      ipName = (*result)->IPName();
+
       // Step through this instance's paremeters
       for (auto param : (*result)->Parameters()) {
         // Create a list of parameter value pairs in the format of
@@ -468,7 +468,8 @@ void SourcesForm::CreateActions() {
 
     // Load IP Config dialog with the previously configured values
     FOEDAG::IpConfigDlg *dlg =
-        new FOEDAG::IpConfigDlg(this, QString::fromStdString(ipName), args);
+        new FOEDAG::IpConfigDlg(this, QString::fromStdString(ipName),
+                                QString::fromStdString(moduleName), args);
     dlg->show();
   });
 }
@@ -618,12 +619,14 @@ void SourcesForm::CreateFolderHierachyTree() {
     iFileSum = 0;
     QTreeWidgetItem *ipParentItem{topitemIpInstances};
     for (auto instance : ipGen->IPInstances()) {
-      QString str = QString::fromStdString(instance->IPName());
+      QString ipName = QString::fromStdString(instance->IPName());
+      QString moduleName = QString::fromStdString(instance->ModuleName());
 
       QTreeWidgetItem *itemf = new QTreeWidgetItem(ipParentItem);
-      itemf->setText(0, str);
+      itemf->setText(0, moduleName);
+      itemf->setData(0, Qt::UserRole, ipName);
       itemf->setData(0, Qt::WhatsThisPropertyRole, SRC_TREE_IP_FILE_ITEM);
-      itemf->setData(0, SetFileDataRole, str);
+      itemf->setData(0, SetFileDataRole, ipName);
 
       iFileSum += 1;
     }


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-71

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Currently the source tree lists IP instances by IPName_Version which limits the user to only 1 unique instance of each IP version

> #### What does this pull request change?
> - This PR updates the Ip Instances listing in the source tree to show the user specified Module Name instead of IPName_Version  
> ![image](https://user-images.githubusercontent.com/103447061/191280953-2d14dc76-14f9-4e65-8b09-2b3082a93bba.png)
> - Configure dialog has been updated to handle both configure and re-configure operations as expected

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IpConfigurator, ProjNavigator (source tree)
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
> - This is a gui only change so only manual testing has been done
> - Manually integration tested in raptor
