### PR TITLE
[RG-83] Recognize *.VHD and *.SV files in case insensitive manner

### DIFF
--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -376,12 +376,12 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     }
     std::string actualType = "VERILOG_2001";
     Design::Language language = Design::Language::VERILOG_2001;
-    const std::string file = argv[1];
-    if (strstr(file.c_str(), ".vhd")) {
+    auto file = QString(argv[1]).toLower();
+    if (file.contains(".vhd")) {
       language = Design::Language::VHDL_2008;
       actualType = "VHDL_2008";
     }
-    if (strstr(file.c_str(), ".sv")) {
+    if (file.contains(".sv")) {
       language = Design::Language::SYSTEMVERILOG_2017;
       actualType = "SV_2017";
     }

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -56,6 +56,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "TaskManager.h"
 #include "Utils/FileUtils.h"
 #include "Utils/ProcessUtils.h"
+#include "Utils/StringUtils.h"
 
 extern FOEDAG::Session* GlobalSession;
 using namespace FOEDAG;
@@ -376,12 +377,12 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     }
     std::string actualType = "VERILOG_2001";
     Design::Language language = Design::Language::VERILOG_2001;
-    auto file = QString(argv[1]).toLower();
-    if (file.contains(".vhd")) {
+    auto file = StringUtils::toLower(argv[1]);
+    if (strstr(file.c_str(), ".vhd")) {
       language = Design::Language::VHDL_2008;
       actualType = "VHDL_2008";
     }
-    if (file.contains(".sv")) {
+    if (strstr(file.c_str(), ".sv")) {
       language = Design::Language::SYSTEMVERILOG_2017;
       actualType = "SV_2017";
     }
@@ -487,12 +488,13 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     }
 
     const std::string file = argv[1];
+    const std::string fileLowerCase = StringUtils::toLower(file);
     std::string actualType = "VERILOG";
     Design::Language language = Design::Language::VERILOG_NETLIST;
-    if (strstr(file.c_str(), ".blif")) {
+    if (strstr(fileLowerCase.c_str(), ".blif")) {
       language = Design::Language::BLIF;
       actualType = "BLIF";
-    } else if (strstr(file.c_str(), ".eblif")) {
+    } else if (strstr(fileLowerCase.c_str(), ".eblif")) {
       language = Design::Language::EBLIF;
       actualType = "EBLIF";
     }

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -238,4 +238,18 @@ bool StringUtils::endsWith(const std::string& fullString,
   }
 }
 
+std::string StringUtils::toLower(const std::string& text) {
+  auto result = text;
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](auto c) { return std::tolower(c); });
+  return result;
+}
+
+std::string StringUtils::toUpper(const std::string& text) {
+  auto result = text;
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](auto c) { return std::toupper(c); });
+  return result;
+}
+
 }  // namespace FOEDAG

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -99,6 +99,11 @@ class StringUtils final {
   // Returns bool indicating if `text` ends with `ending`
   static bool endsWith(const std::string& text, const std::string& ending);
 
+  // Converts the input text to lower case
+  static std::string toLower(const std::string& text);
+  // Converts the input text to upper case
+  static std::string toUpper(const std::string& text);
+
  private:
   StringUtils() = delete;
   StringUtils(const StringUtils& orig) = delete;

--- a/tests/unittest/Utils/StringUtils_test.cpp
+++ b/tests/unittest/Utils/StringUtils_test.cpp
@@ -111,5 +111,13 @@ TEST(StringUtilsTest, endsWithTest) {
   EXPECT_EQ(StringUtils::endsWith("string123", "12"), false);
 }
 
+TEST(StringUtilsTest, toLowerTest) {
+    EXPECT_EQ(StringUtils::toLower("LOWERCASE"), std::string("lowercase"));
+}
+
+TEST(StringUtilsTest, toUpperTest) {
+    EXPECT_EQ(StringUtils::toUpper("upperCase"), std::string("UPPERCASE"));
+}
+
 }  // namespace
 }  // namespace FOEDAG


### PR DESCRIPTION
> ### Motivate of the pull request
This PR fixes first part of RG-83 issue: make sure *.VHD and *.SV files, passed to add_design_files TCL function, are recognized in case insensitive manner.

> ### Describe the technical details
There are two ways of detecting which language to use: 
- explicitly indicate it as a parameter of add_design_files():
      add_design_file aes_decrypt128.sv aes_decrypt256.sv  -SV_2012

- Or the application automatically deduces the language. Currently only two formats are handled explicitly:
    VHDL_2008 (*.vhd)
    SYSTEMVERILOG_2017 (*.sv)

> #### What is currently done? (Provide issue link if applicable)
Automatic language detection was case sensitive: if the file had *.VHD type, it wasn't recognized as VHDL_2008.
This PR makes sure type is recognized in case insensitive manner. We don't override any files or introduce new types.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [+ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
Now following input:  add_design_file aes_decrypt128.SV aes_decrypt256.SV
Results in:                 verific -sv aes_decrypt128.SV aes_decrypt256.SV