### PR TITLE
[RG-81] Copy files project checkbox option is set unchecked by default (PART1 & PART 2)

### DIFF
--- a/src/NewProject/add_constraints_form.cpp
+++ b/src/NewProject/add_constraints_form.cpp
@@ -25,7 +25,7 @@ addConstraintsForm::addConstraintsForm(QWidget *parent)
   ui->m_frame->setLayout(box);
 
   ui->m_ckkBoxCopy->setText(tr("Copy sources into project."));
-  ui->m_ckkBoxCopy->setCheckState(Qt::CheckState::Checked);
+  ui->m_ckkBoxCopy->setCheckState(Qt::CheckState::Unchecked);
 
   Compiler *compiler = GlobalSession->GetCompiler();
   if (compiler->PinAssignOpts() == Compiler::PinAssignOpt::Random)

--- a/src/NewProject/add_source_form.cpp
+++ b/src/NewProject/add_source_form.cpp
@@ -22,7 +22,7 @@ addSourceForm::addSourceForm(QWidget *parent)
   ui->m_frame->setLayout(box);
 
   ui->m_ckkBoxCopy->setText(tr("Copy sources into project. "));
-  ui->m_ckkBoxCopy->setCheckState(Qt::CheckState::Checked);
+  ui->m_ckkBoxCopy->setCheckState(Qt::CheckState::Unchecked);
 }
 
 addSourceForm::~addSourceForm() { delete ui; }

--- a/src/ProjNavigator/add_file_form.cpp
+++ b/src/ProjNavigator/add_file_form.cpp
@@ -69,7 +69,7 @@ void AddFileForm::InitForm(int itype) {
     ui->m_ckkBoxCopy->setText(tr("Copy sources into project. "));
   }
 
-  ui->m_ckkBoxCopy->setCheckState(Qt::CheckState::Checked);
+  ui->m_ckkBoxCopy->setCheckState(Qt::CheckState::Unchecked);
 
   initSetComboBox(itype);
 }


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] **Copy files to project option in design creation wizard doesn't actually copy anything**

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
"Copy sources into project" checkbox was checked by default. Now default option is changed to unchecked.
Screenshot: 
![image](https://user-images.githubusercontent.com/109368108/191448684-5ba9ea10-a87c-4a85-a4f5-2ab4d1ace275.png)
**Test Steps:**

-     Create a new project
-     move next to add source window
-     Verify "Copy sources into project" option is unchecked by default. 
-     Now checked “copy file sources into project”  checkbox 
-     finished the project
-     Open the project folder project_x/project_x.srcs/sources_1 
-     Source file “.v” is copied there. C
![image](https://user-images.githubusercontent.com/109368108/191449736-697f2830-85f9-49c5-89fa-7b4c00c51a58.png)

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [x] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
