### PR TITLE
[GEMINIEDA-371] Add new fields into project wizard - top level module and library for top level

### DIFF
--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -69,15 +69,8 @@ void ProjectManager::CreateProject(const ProjectOptions& opt) {
     }
   }
 
-  if (!strDefaultSrc.isEmpty()) {
-    QString module = strDefaultSrc.left(strDefaultSrc.lastIndexOf("."));
-    setTopModule(module);
-
-    // set default simulation source
-    setCurrentFileSet(DEFAULT_FOLDER_SIM);
-    setDesignFile("sim_" + strDefaultSrc, false);
-    setTopModule("sim_" + module);
-  }
+  setTopModule(opt.topModule);
+  setTopModuleLibrary(opt.topModuleLib);
 
   setCurrentFileSet(DEFAULT_FOLDER_CONSTRS);
   QString strDefaultCts;
@@ -628,6 +621,17 @@ int ProjectManager::setTopModule(const QString& strModuleName) {
   return ret;
 }
 
+int ProjectManager::setTopModuleLibrary(const QString& strModuleNameLib) {
+  ProjectFileSet* proFileSet =
+      Project::Instance()->getProjectFileset(m_currentFileSet);
+  if (nullptr == proFileSet) {
+    return EC_FileSetNotExist;
+  }
+
+  proFileSet->setOption(PROJECT_FILE_CONFIG_TOP_LIB, strModuleNameLib);
+  return EC_Success;
+}
+
 int ProjectManager::setTargetConstrs(const QString& strFileName) {
   int ret = 0;
   ProjectFileSet* proFileSet =
@@ -814,6 +818,26 @@ QString ProjectManager::getDesignTopModule() const {
 
 std::string ProjectManager::DesignTopModule() const {
   return getDesignTopModule().toStdString();
+}
+
+QString ProjectManager::getDesignTopModuleLib(const QString& strFileSet) const {
+  QString strTopModuleLib;
+
+  ProjectFileSet* tmpFileSet =
+      Project::Instance()->getProjectFileset(strFileSet);
+
+  if (tmpFileSet && PROJECT_FILE_TYPE_DS == tmpFileSet->getSetType()) {
+    strTopModuleLib = tmpFileSet->getOption(PROJECT_FILE_CONFIG_TOP_LIB);
+  }
+  return strTopModuleLib;
+}
+
+QString ProjectManager::getDesignTopModuleLib() const {
+  return getDesignTopModuleLib(getDesignActiveFileSet());
+}
+
+std::string ProjectManager::DesignTopModuleLib() const {
+  return getDesignTopModuleLib().toStdString();
 }
 
 int ProjectManager::setConstrFileSet(const QString& strSetName) {

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -73,6 +73,7 @@ project object is singleton mode.
 #define PROJECT_FILE_TYPE_SS "SimulationSrcs"
 
 #define PROJECT_FILE_CONFIG_TOP "TopModule"
+#define PROJECT_FILE_CONFIG_TOP_LIB "TopModuleLib"
 #define PROJECT_FILE_CONFIG_TARGET "TargetConstrsFile"
 
 #define PROJECT_RUN_OPTION_FLOW "Compilation Flow"
@@ -109,6 +110,8 @@ struct ProjectOptions {
   QStringList device;
   bool rewriteProject;
   QString currentFileSet;
+  QString topModule;
+  QString topModuleLib;
 };
 
 struct Suffixes {
@@ -178,6 +181,7 @@ class ProjectManager : public QObject {
 
   // Please set currentfileset before using this function
   int setTopModule(const QString &strModuleName);
+  int setTopModuleLibrary(const QString &strModuleNameLib);
   // Please set currentfileset before using this function
   int setTargetConstrs(const QString &strFileName);
 
@@ -194,6 +198,10 @@ class ProjectManager : public QObject {
   QString getDesignTopModule(const QString &strFileSet) const;
   QString getDesignTopModule() const;
   std::string DesignTopModule() const;
+
+  QString getDesignTopModuleLib(const QString &strFileSet) const;
+  QString getDesignTopModuleLib() const;
+  std::string DesignTopModuleLib() const;
 
   int setConstrFileSet(const QString &strSetName);
   QStringList getConstrFileSets() const;

--- a/src/NewProject/add_source_form.cpp
+++ b/src/NewProject/add_source_form.cpp
@@ -35,3 +35,11 @@ bool addSourceForm::IsCopySource() {
   return ui->m_ckkBoxCopy->checkState() == Qt::CheckState::Checked ? true
                                                                    : false;
 }
+
+QString addSourceForm::TopModule() const {
+  return ui->lineEditTopModule->text().trimmed();
+}
+
+QString addSourceForm::LibraryForTopModule() const {
+  return ui->lineEditTopModuleLib->text().trimmed();
+}

--- a/src/NewProject/add_source_form.h
+++ b/src/NewProject/add_source_form.h
@@ -20,6 +20,8 @@ class addSourceForm : public QWidget {
 
   QList<filedata> getFileData();
   bool IsCopySource();
+  QString TopModule() const;
+  QString LibraryForTopModule() const;
 
  private:
   Ui::addSourceForm *ui;

--- a/src/NewProject/add_source_form.ui
+++ b/src/NewProject/add_source_form.ui
@@ -62,7 +62,7 @@
       <number>30</number>
      </property>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout" stretch="90,10">
+      <layout class="QVBoxLayout" name="verticalLayout" stretch="90,0,10">
        <property name="spacing">
         <number>10</number>
        </property>
@@ -81,6 +81,33 @@
           <enum>QFrame::Raised</enum>
          </property>
         </widget>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Top level module:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="lineEditTopModule"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Library for top-level :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="lineEditTopModuleLib"/>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QCheckBox" name="m_ckkBoxCopy">

--- a/src/NewProject/new_project_dialog.cpp
+++ b/src/NewProject/new_project_dialog.cpp
@@ -104,7 +104,9 @@ void newProjectDialog::on_buttonBox_accepted() {
       {m_addConstrsForm->getFileData(), m_addConstrsForm->IsCopySource()},
       m_devicePlanForm->getSelectedDevice(),
       false /*rewrite*/,
-      DEFAULT_FOLDER_SOURCE};
+      DEFAULT_FOLDER_SOURCE,
+      m_addSrcForm->TopModule(),
+      m_addSrcForm->LibraryForTopModule()};
   Compiler *compiler = GlobalSession->GetCompiler();
   if (m_addConstrsForm->IsRandom()) {
     compiler->PinAssignOpts(Compiler::PinAssignOpt::Random);

--- a/src/ProjNavigator/sources_form.cpp
+++ b/src/ProjNavigator/sources_form.cpp
@@ -113,26 +113,14 @@ void SourcesForm::SlotItempressed(QTreeWidgetItem *item, int column) {
       }
     } else if (SRC_TREE_DESIGN_FILE_ITEM == strPropertyRole ||
                SRC_TREE_SIM_FILE_ITEM == strPropertyRole) {
-      if (strName.contains(SRC_TREE_FLG_TOP)) {
-        menu->addAction(m_actOpenFile);
-        menu->addAction(m_actRemoveFile);
-        menu->addAction(m_actRefresh);
-        menu->addSeparator();
-        menu->addAction(m_actEditConstrsSets);
-        menu->addAction(m_actEditSimulSets);
-        menu->addSeparator();
-        menu->addAction(m_actAddFile);
-      } else {
-        menu->addAction(m_actOpenFile);
-        menu->addAction(m_actRemoveFile);
-        menu->addAction(m_actRefresh);
-        menu->addSeparator();
-        menu->addAction(m_actEditConstrsSets);
-        menu->addAction(m_actEditSimulSets);
-        menu->addSeparator();
-        menu->addAction(m_actAddFile);
-        menu->addAction(m_actSetAsTop);
-      }
+      menu->addAction(m_actOpenFile);
+      menu->addAction(m_actRemoveFile);
+      menu->addAction(m_actRefresh);
+      menu->addSeparator();
+      menu->addAction(m_actEditConstrsSets);
+      menu->addAction(m_actEditSimulSets);
+      menu->addSeparator();
+      menu->addAction(m_actAddFile);
     } else if (SRC_TREE_CONSTR_FILE_ITEM == strPropertyRole) {
       if (strName.contains(SRC_TREE_FLG_TARGET)) {
         menu->addAction(m_actOpenFile);
@@ -292,8 +280,6 @@ void SourcesForm::SlotRemoveFile() {
   if (item == nullptr) return;
 
   auto strFileName = item->text(0);
-  if (strFileName.contains(SRC_TREE_FLG_TOP))
-    strFileName.remove(SRC_TREE_FLG_TOP);
   auto fileSet = item->data(0, SetFileDataRole);
   if (!fileSet.isNull()) {
     auto questionStr =
@@ -307,22 +293,6 @@ void SourcesForm::SlotRemoveFile() {
       UpdateSrcHierachyTree();
       m_projManager->FinishedProject();
     }
-  }
-}
-
-void SourcesForm::SlotSetAsTop() {
-  QTreeWidgetItem *item = m_treeSrcHierachy->currentItem();
-  if (item == nullptr) {
-    return;
-  }
-  QString strFileName = item->text(0);
-
-  m_projManager->setCurrentFileSet(m_projManager->getDesignActiveFileSet());
-  QString module = strFileName.left(strFileName.lastIndexOf("."));
-  int ret = m_projManager->setTopModule(module);
-  if (0 == ret) {
-    UpdateSrcHierachyTree();
-    m_projManager->FinishedProject();
   }
 }
 
@@ -416,9 +386,6 @@ void SourcesForm::CreateActions() {
   m_treeSrcHierachy->addAction(m_actRemoveFile);
   connect(m_actRemoveFile, SIGNAL(triggered()), this, SLOT(SlotRemoveFile()));
 
-  m_actSetAsTop = new QAction(tr("Set As TopModule"), m_treeSrcHierachy);
-  connect(m_actSetAsTop, SIGNAL(triggered()), this, SLOT(SlotSetAsTop()));
-
   m_actSetAsTarget =
       new QAction(tr("Set as Target Constraint File"), m_treeSrcHierachy);
   connect(m_actSetAsTarget, SIGNAL(triggered()), this, SLOT(SlotSetAsTarget()));
@@ -502,26 +469,6 @@ void SourcesForm::CreateFolderHierachyTree() {
 
     QTreeWidgetItem *parentItem{topitemDS};
     for (auto &strfile : listDesFile) {
-      QString filename =
-          strfile.right(strfile.size() - (strfile.lastIndexOf("/") + 1));
-      QString module = filename.left(filename.lastIndexOf("."));
-      if (module == strTop) {
-        if (parentItem) {
-          QString filename =
-              strfile.right(strfile.size() - (strfile.lastIndexOf("/") + 1));
-          QTreeWidgetItem *itemf = new QTreeWidgetItem(parentItem);
-          itemf->setText(0, filename + SRC_TREE_FLG_TOP);
-          itemf->setData(0, Qt::UserRole, strfile);
-          itemf->setIcon(0, QIcon(":/img/file.png"));
-          itemf->setData(0, Qt::WhatsThisPropertyRole,
-                         SRC_TREE_DESIGN_FILE_ITEM);
-          itemf->setData(0, SetFileDataRole, str);
-          parentItem = itemf;
-        }
-        break;
-      }
-    }
-    for (auto &strfile : listDesFile) {
       if (parentItem) {
         QString filename =
             strfile.right(strfile.size() - (strfile.lastIndexOf("/") + 1));
@@ -581,20 +528,13 @@ void SourcesForm::CreateFolderHierachyTree() {
   iFileSum = 0;
   for (const auto &str : listSimFset) {
     QStringList listSimFile = m_projManager->getSimulationFiles(str);
-    QString strTop = m_projManager->getSimulationTopModule(str);
-
     QTreeWidgetItem *parentItem{topitemSS};
     for (auto &strfile : listSimFile) {
       if (parentItem) {
         QString filename =
             strfile.right(strfile.size() - (strfile.lastIndexOf("/") + 1));
         QTreeWidgetItem *itemf = new QTreeWidgetItem(parentItem);
-        QString module = filename.left(filename.lastIndexOf("."));
-        if (module == strTop) {
-          itemf->setText(0, filename + SRC_TREE_FLG_TOP);
-        } else {
-          itemf->setText(0, filename);
-        }
+        itemf->setText(0, filename);
         itemf->setData(0, Qt::UserRole, strfile);
         itemf->setIcon(0, QIcon(":/img/file.png"));
         itemf->setData(0, Qt::WhatsThisPropertyRole, SRC_TREE_SIM_FILE_ITEM);

--- a/src/ProjNavigator/sources_form.h
+++ b/src/ProjNavigator/sources_form.h
@@ -22,7 +22,6 @@
 #define SRC_TREE_IP_FILE_ITEM "ipfileitem"
 
 #define SRC_TREE_FLG_ACTIVE tr(" (Active)")
-#define SRC_TREE_FLG_TOP tr(" (Top)")
 #define SRC_TREE_FLG_TARGET tr(" (Target)")
 
 namespace Ui {
@@ -64,7 +63,6 @@ class SourcesForm : public QWidget {
   void SlotOpenFile();
   void SlotRemoveFileSet();
   void SlotRemoveFile();
-  void SlotSetAsTop();
   void SlotSetAsTarget();
   void SlotSetActive();
   void SlotProperties();
@@ -81,7 +79,6 @@ class SourcesForm : public QWidget {
   QAction* m_actOpenFile;
   QAction* m_actRemoveFileset;
   QAction* m_actRemoveFile;
-  QAction* m_actSetAsTop;
   QAction* m_actSetAsTarget;
   QAction* m_actMakeActive;
   QAction* m_actProperties;

--- a/src/ProjNavigator/tcl_command_integration.cpp
+++ b/src/ProjNavigator/tcl_command_integration.cpp
@@ -41,10 +41,9 @@ bool TclCommandIntegration::TclSetTopModule(int argc, const char *argv[],
     return false;
   }
 
-  QString strFileName = QString(argv[1]);
+  const QString topModule = QString(argv[1]);
   m_projManager->setCurrentFileSet(m_projManager->getDesignActiveFileSet());
-  QString module = strFileName.left(strFileName.lastIndexOf("."));
-  int ret = m_projManager->setTopModule(module);
+  int ret = m_projManager->setTopModule(topModule);
   if (0 == ret) update();
   return true;
 }
@@ -254,7 +253,9 @@ void TclCommandIntegration::createNewDesign(const QString &projName) {
                      {{}, false},
                      {},
                      true /*rewrite*/,
-                     DEFAULT_FOLDER_SOURCE};
+                     DEFAULT_FOLDER_SOURCE,
+                     {},
+                     {}};
   m_projManager->CreateProject(opt);
   QString newDesignStr{m_projManager->getProjectPath() + "/" +
                        m_projManager->getProjectName() + PROJECT_FILE_FORMAT};


### PR DESCRIPTION
### Motivate of the pull request
Add possibility for users to setup top level module in project wizard. And remove relation to the filename. 
Update Hierarchy view:
* Remove top level item
* Remove action from context menu

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: newproject, projnavigator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/191532351-36b74878-9b4f-43ec-bda8-94b194bcdc39.png)
![image](https://user-images.githubusercontent.com/95262932/191534349-15c03e2f-53ae-4cb7-839a-8629773dd966.png)


