### PR TITLE
[RG-74] Improve WidgetFactory field alignment

### DIFF
--- a/src/IpConfigurator/IpConfigDlg.cpp
+++ b/src/IpConfigurator/IpConfigDlg.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "IpConfigurator/IpConfigDlg.h"
 
 #include <QDialogButtonBox>
+#include <QFormLayout>
 #include <QLabel>
 #include <QPushButton>
 #include <QWidget>
@@ -160,9 +161,6 @@ void IpConfigDlg::AddDialogControls(QBoxLayout* layout) {
 }
 
 void IpConfigDlg::CreateParamFields() {
-  QVBoxLayout* vLayout = new QVBoxLayout();
-  paramsBox.setLayout(vLayout);
-
   QStringList tclArgList;
   json parentJson;
   // Loop through IPDefinitions stored in IPCatalog
@@ -227,18 +225,14 @@ void IpConfigDlg::CreateParamFields() {
   }
 
   // Create and add the child widget to our parent container
-  for (auto [widgetId, widgetJson] : parentJson.items()) {
-    QWidget* subWidget = FOEDAG::createWidget(
-        widgetJson, QString::fromStdString(widgetId), tclArgList);
-    if (subWidget != nullptr) {
-      vLayout->addWidget(subWidget);
-    }
-  }
+
+  auto form = createWidgetFormLayout(parentJson, tclArgList);
+  paramsBox.setLayout(form);
 }
 
 void IpConfigDlg::CreateOutputFields() {
-  // Using grid for easy right justification of label fields
-  QGridLayout* grid = new QGridLayout(&outputBox);
+  QFormLayout* form = new QFormLayout(&outputBox);
+  form->setLabelAlignment(Qt::AlignRight);
 
   // Set objectNames for future testing targets
   moduleEdit.setObjectName("IpConfigurator_moduleLineEdit");
@@ -259,13 +253,7 @@ void IpConfigDlg::CreateOutputFields() {
   // Loop through pairs and add them to layout
   int count = 0;
   for (auto [labelName, widget] : pairs) {
-    grid->addWidget(new QLabel(QString::fromStdString(labelName)), count, 0,
-                    Qt::AlignRight);
-
-    // Add to a layout so the widget grows w/ the dialog
-    QHBoxLayout* hLayout = new QHBoxLayout();
-    hLayout->addWidget(widget);
-    grid->addLayout(hLayout, count, 1, Qt::AlignLeft);
+    form->addRow(QString::fromStdString(labelName), widget);
     count++;
   }
 
@@ -274,7 +262,7 @@ void IpConfigDlg::CreateOutputFields() {
                    &IpConfigDlg::updateOutputPath);
 
   // add the layout to the output group box
-  outputBox.setLayout(grid);
+  outputBox.setLayout(form);
 }
 
 void IpConfigDlg::updateMetaLabel(VLNV info) {

--- a/src/Main/WidgetFactory.cpp
+++ b/src/Main/WidgetFactory.cpp
@@ -555,6 +555,7 @@ QWidget* FOEDAG::createSettingsWidget(json& widgetsJson,
   QVBoxLayout* VLayout = new QVBoxLayout();
   widget->setLayout(VLayout);
 
+  // Create a QFormLayout containing the requested fields
   QFormLayout* form = createWidgetFormLayout(widgetsJson, tclArgs.split("-"));
   VLayout->addLayout(form);
   VLayout->addStretch();
@@ -575,7 +576,8 @@ QWidget* FOEDAG::createSettingsWidget(json& widgetsJson,
     QHash<QString, QString> patchHash;
     QString argsStr = "";
     for (int i = 0; i < form->rowCount(); i++) {
-      QWidget* settingsWidget = form->itemAt(i)->widget();
+      QWidget* settingsWidget =
+          form->itemAt(i, QFormLayout::FieldRole)->widget();
       if (settingsWidget) {
         QObject* targetObject =
             qvariant_cast<QObject*>(settingsWidget->property("targetObject"));
@@ -669,7 +671,7 @@ QFormLayout* FOEDAG::createWidgetFormLayout(
   QFormLayout* form = new QFormLayout();
   form->setLabelAlignment(Qt::AlignRight);
 
-  // Create and add the child widget to our parent container
+  // Create and add the child widget to the form layout
   for (auto [widgetId, widgetJson] : widgetsJson.items()) {
     QWidget* subWidget = FOEDAG::createWidget(
         widgetJson, QString::fromStdString(widgetId), tclArgList);

--- a/src/Main/WidgetFactory.cpp
+++ b/src/Main/WidgetFactory.cpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QDialogButtonBox>
 #include <QDir>
 #include <QFileInfo>
+#include <QFormLayout>
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QMetaEnum>
@@ -77,6 +78,12 @@ tclArgFns FOEDAG::getTclArgFns(const QString& tclArgKey) {
 
   return retVal;
 }
+
+QString getStr(const json& jsonObj, const QString& key,
+               const QString& defaultStr = "") {
+  std::string val = jsonObj.value(key.toStdString(), defaultStr.toStdString());
+  return QString::fromStdString(val);
+};
 
 static constexpr uint JsonPathRole = Qt::UserRole + 1;
 
@@ -548,15 +555,8 @@ QWidget* FOEDAG::createSettingsWidget(json& widgetsJson,
   QVBoxLayout* VLayout = new QVBoxLayout();
   widget->setLayout(VLayout);
 
-  // Create and add the child widget to our parent container
-  QStringList tclArgList = tclArgs.split("-");
-  for (auto [widgetId, widgetJson] : widgetsJson.items()) {
-    QWidget* subWidget = FOEDAG::createWidget(
-        widgetJson, QString::fromStdString(widgetId), tclArgList);
-    if (subWidget != nullptr) {
-      VLayout->addWidget(subWidget);
-    }
-  }
+  QFormLayout* form = createWidgetFormLayout(widgetsJson, tclArgs.split("-"));
+  VLayout->addLayout(form);
   VLayout->addStretch();
 
   // Add ok/cancel/apply buttons
@@ -570,12 +570,12 @@ QWidget* FOEDAG::createSettingsWidget(json& widgetsJson,
   // settings to a user file and add the changes to the passed in settings
   // This will also build up and store a tcl arg list for these
   // settings if the widgets have "arg" fields defined
-  auto checkVals = [VLayout, &widgetsJson, widget]() {
+  auto checkVals = [form, &widgetsJson, widget]() {
     bool save = false;
     QHash<QString, QString> patchHash;
     QString argsStr = "";
-    for (int i = 0; i < VLayout->count(); i++) {
-      QWidget* settingsWidget = VLayout->itemAt(i)->widget();
+    for (int i = 0; i < form->rowCount(); i++) {
+      QWidget* settingsWidget = form->itemAt(i)->widget();
       if (settingsWidget) {
         QObject* targetObject =
             qvariant_cast<QObject*>(settingsWidget->property("targetObject"));
@@ -664,15 +664,26 @@ QWidget* FOEDAG::createSettingsWidget(json& widgetsJson,
   return widget;
 }
 
+QFormLayout* FOEDAG::createWidgetFormLayout(
+    json& widgetsJson, const QStringList& tclArgList /* {} */) {
+  QFormLayout* form = new QFormLayout();
+  form->setLabelAlignment(Qt::AlignRight);
+
+  // Create and add the child widget to our parent container
+  for (auto [widgetId, widgetJson] : widgetsJson.items()) {
+    QWidget* subWidget = FOEDAG::createWidget(
+        widgetJson, QString::fromStdString(widgetId), tclArgList);
+    QString label = getStr(widgetJson, "label");
+
+    if (subWidget != nullptr) {
+      form->addRow(label, subWidget);
+    }
+  }
+  return form;
+}
+
 QWidget* FOEDAG::createWidget(const json& widgetJsonObj, const QString& objName,
                               const QStringList& args) {
-  auto getStr = [](const json& jsonObj, const QString& key,
-                   const QString& defaultStr = "") {
-    std::string val =
-        jsonObj.value(key.toStdString(), defaultStr.toStdString());
-    return QString::fromStdString(val);
-  };
-
   auto lookupStr = [](const QStringList& options, const QStringList& lookup,
                       const QString& option) -> QString {
     // Find the given option in the options array
@@ -1037,9 +1048,10 @@ QWidget* FOEDAG::createWidget(const json& widgetJsonObj, const QString& objName,
     }
 
     if (createdWidget) {
-      // Add a containing widget and label if "label" property was provided
-      QString label = getStr(widgetJsonObj, "label");
-      retVal = FOEDAG::createContainerWidget(createdWidget, label);
+      // Only calling this for the container which will allow the widget to
+      // stretch, label is no longer provided here as labels are now added via
+      // QFormLayout at a different time
+      retVal = FOEDAG::createContainerWidget(createdWidget);
 
       // Store a pointer to the primary widget incase we wrapped it in a
       // container widget with a label

--- a/src/Main/WidgetFactory.h
+++ b/src/Main/WidgetFactory.h
@@ -26,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDoubleSpinBox>
+#include <QFormLayout>
 #include <QLineEdit>
 #include <QRadioButton>
 
@@ -55,6 +56,8 @@ QWidget* createSettingsWidget(json& widgetsJson,
                               const QString& objNamePrefix = "",
                               const QString& tclArgs = "");
 
+QFormLayout* createWidgetFormLayout(json& widgetsJson,
+                                    const QStringList& tclArgList = {});
 QWidget* createWidget(const json& widgetJsonObj, const QString& objName = "",
                       const QStringList& args = QStringList());
 QWidget* createWidget(const QString& widgetJsonStr, const QString& objName = "",


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-74

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> QWidgetFactory currently places widgets and labels in 1 QHBoxLayout per entry. This can result in labels that don't line up.
>
> #### What does this pull request change?
> WidgetFactory and the IP Configuration dialog have been updated to use [QFormLayout](https://doc.qt.io/qt-5/qformlayout.html) which provides better field alignment when labels are involved.
> Per the concerns in the Jira description, extra care was taken to ensure as little of the underlying widget structure was changed as these are GUI related changes and we don't have a GUI test suite to ensure changes are safe.
Settings Dialog Changes:
![image](https://user-images.githubusercontent.com/103447061/191535184-e80e8695-9db4-4a1e-9035-b7b655a09377.png)
IP Config Dialog Changes:
![image](https://user-images.githubusercontent.com/103447061/191543183-e9b3d19d-0120-4597-9f92-a18f23577408.png)

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [X] Library: IpConfigurator, Main
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Testing
> - These are gui related changes and we don't have a test harness to support gui testing currently
> - Manual testing was done on the settings and ip configuration dialog to ensure that the underlying structures still work after the layout changes.
> - Integration testing has been done manually in Raptor
