### PR TITLE
[RG-88] Remove Raptor specific synthesis settings

### DIFF
--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -152,49 +152,6 @@
                 ],
                 "arg": "_SynthOpt_"
             },
-            "effort_dropdown": {
-                "label": "Effort",
-                "widgetType": "dropdown",
-                "options": [
-                    "High",
-                    "Medium",
-                    "Low"
-                ],
-                "optionsLookup": [
-                    "high",
-                    "medium",
-                    "low"
-                ],
-                "arg": "effort"
-            },
-            "fsm_encoding_dropdown": {
-                "label": "FSM Encoding",
-                "widgetType": "dropdown",
-                "options": [
-                    "Binary",
-                    "One Hot"
-                ],
-                "optionsLookup": [
-                    "binary",
-                    "onehot"
-                ],
-                "arg": "fsm_encoding"
-            },
-            "carry_dropdown": {
-                "label": "Carry",
-                "widgetType": "dropdown",
-                "options": [
-                    "All",
-                    "No Const",
-                    "None"
-                ],
-                "optionsLookup": [
-                    "all",
-                    "no_const",
-                    "none"
-                ],
-                "arg": "carry"
-            },
             "no_dsp_checkbox": {
                 "label": "No DSP Blocks",
                 "widgetType": "checkbox",
@@ -205,11 +162,6 @@
                 "widgetType": "checkbox",
                 "arg": "no_bram"
             },
-            "fast_checkbox": {
-                "label": "Fast Synthesis",
-                "widgetType": "checkbox",
-                "arg": "fast"
-            },
             "_META_": {
                 "hidden": false,
                 "isSetting": true,
@@ -217,14 +169,14 @@
             }
         },
         "Placement": {
-        "pin_selection_radiobtn": {
+            "pin_selection_radiobtn": {
                 "label": "Pin Location Assign Method:",
                 "widgetType": "radiobuttons",
                 "options": [
                     "Random",
                     "In Define Order"
                 ],
-                "optionsLookup":[
+                "optionsLookup": [
                     "random",
                     "in_define_order"
                 ],


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-88

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Foedag's settings file has settings specific to Raptor
>
> #### What does this pull request change?
> Effort, FSM Encoding, Carry, and Fast Synthesis options have been removed from the Synthesis settings
![image](https://user-images.githubusercontent.com/103447061/191610877-4ea8f891-8c94-41f1-af19-cc7c4f7394a8.png)



> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: Main
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> Testing
> - This is a meta file change only, no actual code has changed and the file is only used by foedag (Foedag_rs and Raptor have their own copies of the file). No testing has been done other than manually verifying that the requested fields have been removed from foedag.
