### PR TITLE
[RG-72] Convert Ip Config Dialog to a Dock Widget

### DIFF
--- a/src/IpConfigurator/CMakeLists.txt
+++ b/src/IpConfigurator/CMakeLists.txt
@@ -46,7 +46,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../lib)
 set (SRC_CPP_LIST
   IpConfiguratorCreator.cpp
   IpCatalogTree.cpp
-  IpConfigDlg.cpp
+  IpConfigWidget.cpp
   IpConfigurator.cpp
   IpInstancesTree.cpp
   IpTreesWidget.cpp
@@ -59,7 +59,7 @@ set (SRC_H_INSTALL_LIST
 set (SRC_H_LIST
   ${SRC_H_INSTALL_LIST}
   IpCatalogTree.h
-  IpConfigDlg.h
+  IpConfigWidget.h
   IpConfigurator.h
   IpInstancesTree.h
   IpTreesWidget.h

--- a/src/IpConfigurator/IpCatalogTree.cpp
+++ b/src/IpConfigurator/IpCatalogTree.cpp
@@ -22,7 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QTreeWidgetItem>
 
-#include "IpConfigurator/IpConfigDlg.h"
 #include "MainWindow/Session.h"
 #include "Utils/FileUtils.h"
 
@@ -49,15 +48,6 @@ bool tclCmdExists(const QString& cmdName) {
 IpCatalogTree::IpCatalogTree(QWidget* parent /*nullptr*/)
     : QTreeWidget(parent) {
   this->setHeaderLabel("Available IPs");
-
-  QObject::connect(this, &QTreeWidget::itemDoubleClicked,
-                   [this](QTreeWidgetItem* item, int column) {
-                     FOEDAG::IpConfigDlg* dlg =
-                         new IpConfigDlg(this, item->text(0));
-                     dlg->setAttribute(Qt::WA_DeleteOnClose);
-                     dlg->show();
-                   });
-
   refresh();
 }
 

--- a/src/IpConfigurator/IpConfigWidget.h
+++ b/src/IpConfigurator/IpConfigWidget.h
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include <QBoxLayout>
-#include <QDialog>
 #include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
@@ -30,13 +29,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FOEDAG {
 
-class IpConfigDlg : public QDialog {
+class IpConfigWidget : public QWidget {
   Q_OBJECT
 
  public:
-  explicit IpConfigDlg(QWidget* parent = nullptr, QString requestedIpName = "",
-                       QString moduleName = "",
-                       QStringList instanceValueArgs = {});
+  explicit IpConfigWidget(QWidget* parent = nullptr,
+                          const QString& requestedIpName = "",
+                          const QString& moduleName = "",
+                          const QStringList& instanceValueArgs = {});
+
+ signals:
+  void ipInstancesUpdated();
 
  public slots:
   void updateOutputPath();

--- a/src/IpConfigurator/IpConfigurator.cpp
+++ b/src/IpConfigurator/IpConfigurator.cpp
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QDockWidget>
 
-#include "IpConfigurator/IpConfigDlg.h"
+#include "IpConfigurator/IpConfigWidget.h"
 #include "IpConfigurator/IpTreesWidget.h"
 #include "MainWindow/Session.h"
 
@@ -72,8 +72,8 @@ void IpConfigurator::HideIpTrees() {
 }
 
 void IpConfigurator::ShowConfigDlg() {
-  IpConfigDlg dlg;
-  dlg.exec();
+  IpConfigWidget widget;
+  widget.show();
 }
 
 QWidget* IpConfigurator::GetIpTreesWidget() {
@@ -101,8 +101,8 @@ void FOEDAG::registerIpConfiguratorCommands(QWidget* widget,
   auto show_dlg = [](void* clientData, Tcl_Interp* interp, int argc,
                      const char* argv[]) -> int {
     QWidget* w = static_cast<QWidget*>(clientData);
-    IpConfigDlg* dlg = new IpConfigDlg(w);
-    dlg->show();
+    IpConfigWidget* widget = new IpConfigWidget(w);
+    widget->show();
     return 0;
   };
   session->TclInterp()->registerCmd("ipconfigurator_show_dlg", show_dlg, widget,

--- a/src/Main/registerTclCommands.cpp
+++ b/src/Main/registerTclCommands.cpp
@@ -45,7 +45,7 @@ extern "C" {
 #include "CommandLine.h"
 #include "Compiler/Log.h"
 #include "Foedag.h"
-#include "IpConfigurator/IpConfigDlg.h"
+#include "IpConfigurator/IpConfigWidget.h"
 #include "Main/Tasks.h"
 #include "Main/WidgetFactory.h"
 #include "MainWindow/Session.h"
@@ -302,9 +302,9 @@ void registerAllFoedagCommands(QWidget* widget, FOEDAG::Session* session) {
         QWidget* w = static_cast<QWidget*>(clientData);
 
         if (argc == 2) {
-          FOEDAG::IpConfigDlg* dlg = new FOEDAG::IpConfigDlg(w, argv[1]);
-          dlg->setAttribute(Qt::WA_DeleteOnClose);
-          dlg->show();
+          FOEDAG::IpConfigWidget* widget =
+              new FOEDAG::IpConfigWidget(w, argv[1]);
+          widget->show();
 
           return TCL_OK;
         } else {

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -64,6 +64,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void updatePRViewButton(int state);
   void saveActionTriggered();
   void pinAssignmentActionTriggered();
+  void ipConfiguratorActionTriggered();
   void newDialogAccepted();
   void recentProjectOpen();
 
@@ -71,6 +72,10 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
 
  public slots:
   void updateSourceTree();
+  void handleIpTreeSelectionChanged();
+  void handleIpReConfigRequested(const QString& ipName,
+                                 const QString& moduleName,
+                                 const QStringList& paramList);
 
  private: /* Menu bar builders */
   void updateViewMenu();
@@ -101,6 +106,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   // Creates the new file in a working directory holding welcome page
   // configuration
   void saveWelcomePageConfig();
+  void replaceIpConfigDockWidget(QWidget* widget);
 
   // Welcome page config file name
   static const QString WELCOME_PAGE_CONFIG_FILE;
@@ -141,10 +147,12 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   class ProjectManager* m_projectManager{nullptr};
   class ProjectFileLoader* m_projectFileLoader{nullptr};
   class SourcesForm* sourcesForm{nullptr};
+  class IpCatalogTree* m_ipCatalogTree{nullptr};
   QWidget* m_progressWidget{nullptr};
   QDockWidget* m_dockConsole{nullptr};
   std::vector<QDockWidget*> m_pinAssignmentDocks;
-  std::vector<QDockWidget*> m_ipConfiguratorDocks;
+  QDockWidget* m_ipConfigDockWidget{nullptr};
+  QDockWidget* m_availableIpsgDockWidget{nullptr};
   QSettings m_settings;
 };
 

--- a/src/ProjNavigator/sources_form.cpp
+++ b/src/ProjNavigator/sources_form.cpp
@@ -8,7 +8,6 @@
 #include <QTextStream>
 #include <algorithm>
 
-#include "IpConfigurator/IpConfigDlg.h"
 #include "Main/Foedag.h"
 #include "tcl_command_integration.h"
 #include "ui_sources_form.h"
@@ -355,6 +354,42 @@ void SourcesForm::SlotPropertiesTriggered() {
   SlotProperties();
 }
 
+void SourcesForm::SlotReConfigureIp() {
+  QTreeWidgetItem *item = m_treeSrcHierachy->currentItem();
+  if (item == nullptr) {
+    return;
+  }
+  std::string moduleName = item->text(0).toStdString();
+
+  auto instances =
+      GlobalSession->GetCompiler()->GetIPGenerator()->IPInstances();
+
+  // Find the ip instance with a matching module name
+  auto isMatch = [moduleName](IPInstance *instance) {
+    return instance->ModuleName() == moduleName;
+  };
+  auto result =
+      std::find_if(std::begin(instances), std::end(instances), isMatch);
+
+  std::string ipName{};
+  QStringList args{};
+  if (result != std::end(instances)) {
+    ipName = (*result)->IPName();
+
+    // Step through this instance's paremeters
+    for (auto param : (*result)->Parameters()) {
+      // Create a list of parameter value pairs in the format of
+      // -P<param_name> <value>
+      args.append(QString("-P%1 %2")
+                      .arg(QString::fromStdString(param.Name()))
+                      .arg(QString::number(param.GetValue())));
+    }
+  }
+
+  emit IpReconfigRequested(QString::fromStdString(ipName),
+                           QString::fromStdString(moduleName), args);
+}
+
 void SourcesForm::CreateActions() {
   m_actRefresh = new QAction(tr("Refresh Hierarchy"), m_treeSrcHierachy);
   connect(m_actRefresh, SIGNAL(triggered()), this,
@@ -401,44 +436,8 @@ void SourcesForm::CreateActions() {
   connect(m_actCloseProject, SIGNAL(triggered()), this, SIGNAL(CloseProject()));
 
   m_actReconfigureIp = new QAction(tr("Re-Configure IP"), m_treeSrcHierachy);
-  connect(m_actReconfigureIp, &QAction::triggered, this, [this]() {
-    QTreeWidgetItem *item = m_treeSrcHierachy->currentItem();
-    if (item == nullptr) {
-      return;
-    }
-    std::string moduleName = item->text(0).toStdString();
-
-    auto instances =
-        GlobalSession->GetCompiler()->GetIPGenerator()->IPInstances();
-
-    // Find the ip instance with a matching module name
-    auto isMatch = [moduleName](IPInstance *instance) {
-      return instance->ModuleName() == moduleName;
-    };
-    auto result =
-        std::find_if(std::begin(instances), std::end(instances), isMatch);
-
-    std::string ipName{};
-    QStringList args{};
-    if (result != std::end(instances)) {
-      ipName = (*result)->IPName();
-
-      // Step through this instance's paremeters
-      for (auto param : (*result)->Parameters()) {
-        // Create a list of parameter value pairs in the format of
-        // -P<param_name> <value>
-        args.append(QString("-P%1 %2")
-                        .arg(QString::fromStdString(param.Name()))
-                        .arg(QString::number(param.GetValue())));
-      }
-    }
-
-    // Load IP Config dialog with the previously configured values
-    FOEDAG::IpConfigDlg *dlg =
-        new FOEDAG::IpConfigDlg(this, QString::fromStdString(ipName),
-                                QString::fromStdString(moduleName), args);
-    dlg->show();
-  });
+  connect(m_actReconfigureIp, &QAction::triggered, this,
+          &SourcesForm::SlotReConfigureIp);
 }
 
 void SourcesForm::UpdateSrcHierachyTree() {

--- a/src/ProjNavigator/sources_form.cpp
+++ b/src/ProjNavigator/sources_form.cpp
@@ -435,7 +435,7 @@ void SourcesForm::CreateActions() {
   m_actCloseProject = new QAction(tr("Close project"), m_treeSrcHierachy);
   connect(m_actCloseProject, SIGNAL(triggered()), this, SIGNAL(CloseProject()));
 
-  m_actReconfigureIp = new QAction(tr("Re-Configure IP"), m_treeSrcHierachy);
+  m_actReconfigureIp = new QAction(tr("Reconfigure IP"), m_treeSrcHierachy);
   connect(m_actReconfigureIp, &QAction::triggered, this,
           &SourcesForm::SlotReConfigureIp);
 }

--- a/src/ProjNavigator/sources_form.h
+++ b/src/ProjNavigator/sources_form.h
@@ -50,6 +50,8 @@ class SourcesForm : public QWidget {
   void ShowProperty(const QString&);
   void ShowPropertyPanel();
   void CloseProject();
+  void IpReconfigRequested(const QString& ipName, const QString moduleName,
+                           const QStringList& paramList);
 
  private slots:
   void SlotItempressed(QTreeWidgetItem* item, int column);
@@ -67,6 +69,7 @@ class SourcesForm : public QWidget {
   void SlotSetActive();
   void SlotProperties();
   void SlotPropertiesTriggered();
+  void SlotReConfigureIp();
 
  private:
   Ui::SourcesForm* ui;


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-27
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Currently, the ip configuration widget is a dialog that gets popped up when an available IP is double clicked in the Available IPs tree or an ip instance in the source tree is r-clicked and "Re-Configure IP"
>
> #### What does this pull request change?
> - Ip Config Widget has been changed from a QDialog to a QWidget contained in a QDockWidget which is default placed in the right dock widget with the Available IPs tree
![image](https://user-images.githubusercontent.com/103447061/192808166-adf1d51e-ce15-4057-b9fb-c6e7a50c4faa.png)
> - Ip Config Widget is now hidden by default shown/updated on selection change in the Available IPs tree
> - IP Instances in source tree still require an r-click > "Reconfigure IP" to update the Ip Config Widget
> - IP Instances tree is now updated via signal/slot instead of explicit calls to sources_form from the Ip Config Widget
> - "Reconfiguring instance "instance" for..." has been added to the description text when reconfiguring an IP
> <img alt="image" src="https://user-images.githubusercontent.com/103447061/192814708-028d7078-2c1b-4103-a4f5-04e92aeaf5c2.png">


> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IpConfigurator, Main, ProjNavigator
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
> - These changes are GUI based so manual testing was done in Foedag as well as Raptor
> - IpConfigDlg (now IpConfigWidget) already had basic smoke tests which have been updated
