### PR TITLE
[RG-99] Adding logic to find litex enabled python interpreter for IP Catalog

### DIFF
--- a/src/IPGenerate/IPCatalog.cpp
+++ b/src/IPGenerate/IPCatalog.cpp
@@ -45,6 +45,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Compiler/WorkerThread.h"
 #include "IPGenerate/IPCatalog.h"
 #include "MainWindow/Session.h"
+#include "Utils/FileUtils.h"
 #include "Utils/ProcessUtils.h"
 #include "Utils/StringUtils.h"
 
@@ -112,4 +113,17 @@ VLNV FOEDAG::getIpInfoFromPath(std::filesystem::path path) {
   }
 
   return VLNV{vendor, library, name, version};
+}
+
+// This will return a path to the litex enabled python interpreter used by the
+// ip catalog. This will cache the return value the first time it's not empty
+std::filesystem::path IPCatalog::getPythonPath() {
+  static std::filesystem::path s_pythonPath{};
+  if (s_pythonPath.empty()) {
+    std::filesystem::path searchPath =
+        GlobalSession->Context()->DataPath() / "../envs/litex";
+    searchPath = FileUtils::GetFullPath(searchPath);
+    s_pythonPath = FileUtils::LocateFileRecursive(searchPath, "python");
+  }
+  return s_pythonPath;
 }

--- a/src/IPGenerate/IPCatalog.h
+++ b/src/IPGenerate/IPCatalog.h
@@ -243,6 +243,7 @@ class IPCatalog {
   const std::vector<IPDefinition*>& Definitions() { return m_definitions; }
   IPDefinition* Definition(const std::string& name);
   void WriteCatalog(std::ostream& out);
+  static std::filesystem::path getPythonPath();
 
  protected:
   std::vector<IPDefinition*> m_definitions;

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -344,9 +344,29 @@ bool IPGenerator::Generate() {
           std::stringstream buffer;
           newbuffer << newfile.rdbuf();
         }
-        std::filesystem::path python3Path =
-            FileUtils::LocateExecFile("python3");
-        std::string command = python3Path.string() + " " + executable.string() +
+
+        // Find path to litex enabled python interpreter
+        std::filesystem::path pythonPath = IPCatalog::getPythonPath();
+        if (pythonPath.empty()) {
+          std::filesystem::path python3Path =
+              FileUtils::LocateExecFile("python3");
+          if (python3Path.empty()) {
+            m_compiler->ErrorMessage(
+                "IP Generate, unable to find python interpreter in local "
+                "environment.\n");
+            return false;
+          } else {
+            pythonPath = python3Path;
+            m_compiler->ErrorMessage(
+                "IP Generate, unable to find python interpreter in local "
+                "environment, using system copy '" +
+                python3Path.string() +
+                "'. Some IP Catalog features might not work with this "
+                "interpreter.\n");
+          }
+        }
+
+        std::string command = pythonPath.string() + " " + executable.string() +
                               " --build --json " + jasonfile.string();
         std::ostringstream help;
 

--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -148,6 +148,28 @@ std::filesystem::path FileUtils::LocateExecFile(
   return result;
 }
 
+// This recursively searches searchPath for a file that exactly matches
+// filename. Partial matches and directory matches are not returned.
+std::filesystem::path FileUtils::LocateFileRecursive(
+    const std::filesystem::path& searchPath, const std::string filename) {
+  std::filesystem::path result{};
+  if (FileUtils::FileExists(searchPath)) {
+    // Recursively search searchPath
+    for (const std::filesystem::path& entry :
+         std::filesystem::recursive_directory_iterator(
+             searchPath,
+             std::filesystem::directory_options::follow_directory_symlink)) {
+      // If this is a file and the filename matches exactly
+      if (FileIsRegular(entry) && entry.filename() == filename) {
+        result = entry;
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
 int FileUtils::ExecuteSystemCommand(const std::string& command,
                                     std::ostream* result) {
   QProcess* m_process = new QProcess;

--- a/src/Utils/FileUtils.h
+++ b/src/Utils/FileUtils.h
@@ -54,6 +54,9 @@ class FileUtils final {
   static std::filesystem::path LocateExecFile(
       const std::filesystem::path& path);
 
+  static std::filesystem::path LocateFileRecursive(
+      const std::filesystem::path& searchPath, const std::string filename);
+
   static int ExecuteSystemCommand(const std::string& command,
                                   std::ostream* result);
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: [RG-99]
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> [FileUtils::LocateExecFile](https://github.com/os-fpga/FOEDAG/blob/f937d2954f15071d256b1f05019d1751864a3f17/src/Utils/FileUtils.cpp#L127) is used to search for a system copy of python3. LocateExecFile currently only works for unix. Additionally, this method of looking for a system copy of python3 will most likely fail to find the correct version of python where we've installed litex modules.
>
> #### What does this pull request change?
> A new function, FileUtils::FindFileRecursive() was added. This is used in conjunction with raptor changes to load a local copy of python that has litex/migen modules. This environment doesn't exist in foedag so in this case, we fallback to LocateExecFile for now.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IPGenerate, Utils
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
> - This has been manually tested in Foedag and Raptor
> - This is a background path change for the most part and the path change is only observable in raptor where the python venv and litex modules are installed. Raptor doesn't appear to have unittest support now so i'd suggest we explore adding raptor side testing after code freeze.
