### PR TITLE
[RG-109] Updating close project and exit program messages

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -163,11 +163,7 @@ void MainWindow::CloseOpenedTabs() {
 }
 
 void MainWindow::closeEvent(QCloseEvent* event) {
-  QMessageBox::StandardButton closeBtn = QMessageBox::warning(
-      this, "Warning", tr("Do you really want to close the project?\n"),
-      QMessageBox::No | QMessageBox::Yes);
-
-  if (closeBtn == QMessageBox::Yes) {
+  if (confirmExitProgram()) {
     event->accept();
   } else {
     event->ignore();
@@ -200,7 +196,8 @@ void MainWindow::openProjectDialog(const QString& dir) {
 }
 
 void MainWindow::closeProject() {
-  if (m_projectManager && m_projectManager->HasDesign()) {
+  if (m_projectManager && m_projectManager->HasDesign() &&
+      confirmCloseProject()) {
     Project::Instance()->InitProject();
     newProjdialog->Reset();
     CloseOpenedTabs();
@@ -470,8 +467,10 @@ void MainWindow::createActions() {
   });
 
   connect(exitAction, &QAction::triggered, qApp, [this]() {
-    Command cmd("gui_stop; exit");
-    GlobalSession->CmdStack()->push_and_exec(&cmd);
+    if (this->confirmExitProgram()) {
+      Command cmd("gui_stop; exit");
+      GlobalSession->CmdStack()->push_and_exec(&cmd);
+    }
   });
 
   pinAssignmentAction = new QAction(tr("Pin Assignment"), this);
@@ -920,4 +919,17 @@ void MainWindow::replaceIpConfigDockWidget(QWidget* newWidget) {
         PrepareTab(tr("Configure IP"), "configureIpsWidget", newWidget, nullptr,
                    Qt::RightDockWidgetArea);
   }
+}
+
+bool MainWindow::confirmCloseProject() {
+  return (QMessageBox::question(
+              this, "Close Project?",
+              tr("Are you sure you want to close your project?\n"),
+              QMessageBox::No | QMessageBox::Yes) == QMessageBox::Yes);
+}
+bool MainWindow::confirmExitProgram() {
+  return (QMessageBox::question(
+              this, "Exit Program?",
+              tr("Are you sure you want to exit the program?\n"),
+              QMessageBox::No | QMessageBox::Yes) == QMessageBox::Yes);
 }

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -107,6 +107,8 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   // configuration
   void saveWelcomePageConfig();
   void replaceIpConfigDockWidget(QWidget* widget);
+  bool confirmCloseProject();
+  bool confirmExitProgram();
 
   // Welcome page config file name
   static const QString WELCOME_PAGE_CONFIG_FILE;


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: [RG-109]
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Currently when the users presses the close button, a warning message box is shown asking if the user wants to close the project. 
![image](https://user-images.githubusercontent.com/103447061/193324155-3d241962-c1e1-422a-ac5f-f29993e1dd4d.png)

>
> #### What does this pull request change?
> - There is now a close project message box and an exit program message box
> - Both use a Question message box instead of a Warning message box
> - Logic has been added to show the close project message when a user selects File > Close Project
> - Logic has been added to show the exit program message when a user selects File > Exit
> - Existing messagebox on close has been updated to use "Exit Program" wording.
![image](https://user-images.githubusercontent.com/103447061/193324521-0f1d16dd-fbbe-43c9-b565-47b3a90d82c3.png)

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: Main
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
> - These changes require a ui testing harness to test as they are all message box related.
> - Manual testing done in Foedag and Raptor