### PR TITLE
[RG-111]Fix alignment of summary tab

### DIFF
--- a/src/NewProject/summary_form.ui
+++ b/src/NewProject/summary_form.ui
@@ -79,7 +79,7 @@
       <number>0</number>
      </property>
      <property name="leftMargin">
-      <number>15</number>
+      <number>0</number>
      </property>
      <item>
       <widget class="QLabel" name="m_labelSourcesPic">
@@ -109,7 +109,7 @@
       <number>0</number>
      </property>
      <property name="leftMargin">
-      <number>15</number>
+      <number>0</number>
      </property>
      <item>
       <widget class="QLabel" name="m_labelConstraintsPic">


### PR DESCRIPTION
> ### Motivate of the pull request
This is a final remark of RG-111 issue: alignment fix of summary tab.

![image](https://user-images.githubusercontent.com/109239890/193817641-2b638870-ace3-4cab-897c-551634c16784.png)