### PR TITLE
[GEMINIEDA-418] Fix ip configure output path

### DIFF
--- a/src/IpConfigurator/IpConfigWidget.cpp
+++ b/src/IpConfigurator/IpConfigWidget.cpp
@@ -140,7 +140,7 @@ void IpConfigWidget::AddDialogControls(QBoxLayout* layout) {
     std::filesystem::path baseDir(m_baseDirDefault.toStdString());
     std::filesystem::path outFile = baseDir / moduleEdit.text().toStdString();
     QString outFileStr =
-        QString::fromStdString(FileUtils::GetFullPath(outFile));
+        QString::fromStdString(FileUtils::GetFullPath(outFile).string());
 
     // Build up a cmd string to generate the IP
     QString cmd = "configure_ip " + this->m_requestedIpName + " -mod_name " +
@@ -310,6 +310,7 @@ void IpConfigWidget::updateOutputPath() {
   std::filesystem::path outPath = vlnvPath / moduleEdit.text().toStdString();
 
   // Update the output path text
-  QString outStr = QString::fromStdString(FileUtils::GetFullPath(outPath));
+  QString outStr =
+      QString::fromStdString(FileUtils::GetFullPath(outPath).string());
   outputPath.setText(outStr);
 }


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: GEMINIEDA-418
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Only the base project path is provided to the configure_ip name
>
> #### What does this pull request change?
> The passed output path now matches what configure_ip expects

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IpConfigurator
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
> - This is a gui sided change
> - Manually tested in FOEDAG and Raptor
> - Ensured output looked good with Avinash