### PR TITLE
[RG-108]: Add compile units field to Add Design Files tab in New Project Wizard

### DIFF
--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -81,8 +81,6 @@ void ProjectManager::CreateProject(const ProjectOptions& opt) {
         language = fdata.m_language;
       } else {
         if (language != fdata.m_language) {
-          // This might be an error state, can you group files of diff
-          // languages?
           multipleLanguages = true;
         }
       }
@@ -127,7 +125,7 @@ void ProjectManager::CreateProject(const ProjectOptions& opt) {
       // This is probably an error condition as the setDesignFiles call has
       // different arguements when local or non-local
     } else if (multipleLanguages) {
-      // This seems like an error scenario as well
+      // This seems like a pontential error scenario as well
     } else if (hasLocalFiles) {
       setDesignFiles(command, libraries, fileListStr, language, false, true);
     } else {

--- a/src/NewProject/source_grid.cpp
+++ b/src/NewProject/source_grid.cpp
@@ -21,9 +21,11 @@ static const auto INDEX_COL = QObject::tr("Index");
 static const auto NAME_COL = QObject::tr("Name");
 static const auto LIBRARY_COL = QObject::tr("Library");
 static const auto LANGUAGE_COL = QObject::tr("Language");
+static const auto COMPILE_UNIT_COL = QObject::tr("Compile Unit");
 static const auto LOCATION_COL = QObject::tr("Location");
 static const int LIBRARY_COL_NUM{2};
 static const int LANG_COL_NUM{3};
+static const int COMPILE_UNIT_COL_NUM{4};
 
 static const auto CONSTR_FILTER = QObject::tr("Constraint Files(*.sdc)");
 static const auto DESIGN_SOURCES_FILTER = QObject::tr(
@@ -127,6 +129,8 @@ void sourceGrid::setGridType(GridType type) {
                                      new QStandardItem(LIBRARY_COL));
     m_model->setHorizontalHeaderItem(columnIndex++,
                                      new QStandardItem(LANGUAGE_COL));
+    m_model->setHorizontalHeaderItem(columnIndex++,
+                                     new QStandardItem(COMPILE_UNIT_COL));
   }
 
   m_model->setHorizontalHeaderItem(columnIndex++,
@@ -309,6 +313,12 @@ void sourceGrid::AddTableItem(filedata fdata) {
     item->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     item->setEditable(false);
     items.append(item);
+
+    // Group
+    item = new QStandardItem(fdata.m_groupName);
+    item->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    item->setEditable(true);
+    items.append(item);
   }
 
   item = new QStandardItem(fdata.m_filePath);
@@ -398,6 +408,10 @@ void sourceGrid::onItemChanged(QStandardItem *item) {
 
   if (item->index().column() == LIBRARY_COL_NUM)
     m_lisFileData[itemIndex.row()].m_workLibrary = item->text();
+
+  if (item->index().column() == COMPILE_UNIT_COL_NUM) {
+    m_lisFileData[itemIndex.row()].m_groupName = item->text();
+  }
 }
 
 void sourceGrid::languageHasChanged() {

--- a/src/NewProject/source_grid.h
+++ b/src/NewProject/source_grid.h
@@ -22,6 +22,7 @@ typedef struct tagFileData {
   int m_language;
   QString m_filePath;
   QString m_workLibrary;
+  QString m_groupName;
 } FILEDATA;
 
 typedef FILEDATA filedata;


### PR DESCRIPTION
NOTE this is currently a draft pr to get feedback from devs more familiar with the project system

> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-108
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> All files in the New Project Wizard are added sequentially which removes the concept of grouping multiples files in one add_design_files call
>
> #### What does this pull request change?
> - This change adds a compile units field to the Add Design Files tab:
> <img width="463" alt="image" src="https://user-images.githubusercontent.com/103447061/193952182-ef7bc419-9eac-488b-bdfc-09bf0807f699.png">

> - Any files that have the same value in the Compile Units column will be grouped together.
> - This PR attempts to combine elements like library and local/non-local files if the files are in the same group and provides conditionals in the code that look at potential edge cases that might not be allowed (like grouping files with different languages).
>  - This logic should be considered by someone more familiar with real world use cases and the project manager.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: NewProject
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] Needs review to ensure this is the right approach

> ### Testing
> This change was tested in raptor w/ the following steps:
> - Ran ./build/bin/raptor --script tests/Testcases/aes_decrypt_fpga/aes_decrypt.tcl to get a .ys file that is known to be valid
> - ./build/bin/ratpor
> - File > New Project
> - Click next until "Add Design Files Tab"
> - Click Copy sources checkbox
> - Click "Add Directory..."
> - Select folder:  tests/Testcases/aes_decrypt_fpga/
> - Update all sv2017 entries to sv2012 to match the AES test
> - Set the compile unit for all sv files to "1"
> - Set the compile unit for all verilog files to "2"
![image](https://user-images.githubusercontent.com/103447061/194127436-3c142db1-ba73-43fe-8ee2-9d8afc94ae1b.png)

> - Click next
> - Click Copy sources checkbox
> - Added the AES constraint file
> - Click next until the summary page and then click finish
> - In the tcl console execute the following commands to match the AES script
>  - set_top_module wrapper
>  - synth_options -effort high
>  - analyze
>  - message_severity VERI-1209 IGNORE
>  - synthesize area
> - Diff the 2 .ys files to ensure that the files are added the same way
