### PR TITLE
[GEMINIEDA-417] Add Remove and Delete IP options to source tree ip instances

### DIFF
--- a/src/IPGenerate/IPGenerator.h
+++ b/src/IPGenerate/IPGenerator.h
@@ -46,6 +46,11 @@ class IPGenerator {
   bool RegisterCommands(TclInterpreter* interp, bool batchMode);
   std::vector<IPInstance*> IPInstances() { return m_instances; }
   bool AddIPInstance(IPInstance* instance);
+  IPInstance* GetIPInstance(const std::string& moduleName);
+  void RemoveIPInstance(IPInstance* instance);
+  void RemoveIPInstance(const std::string& moduleName);
+  void DeleteIPInstance(IPInstance* instance);
+  void DeleteIPInstance(const std::string& moduleName);
   void ResetIPList() {
     m_instances.erase(m_instances.begin(), m_instances.end());
   }

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -50,6 +50,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ProjNavigator/sources_form.h"
 #include "ProjNavigator/tcl_command_integration.h"
 #include "TextEditor/text_editor.h"
+#include "Utils/FileUtils.h"
 #include "foedag_version.h"
 
 using namespace FOEDAG;
@@ -581,6 +582,10 @@ void MainWindow::ReShowWindow(QString strProject) {
   propertiesDockWidget->hide();
   connect(sourcesForm, &SourcesForm::IpReconfigRequested, this,
           &MainWindow::handleIpReConfigRequested);
+  connect(sourcesForm, &SourcesForm::IpRemoveRequested, this,
+          &MainWindow::handleRemoveIpRequested);
+  connect(sourcesForm, &SourcesForm::IpDeleteRequested, this,
+          &MainWindow::handleDeleteIpRequested);
 
   TextEditor* textEditor = new TextEditor(this);
   textEditor->RegisterCommands(GlobalSession);
@@ -860,6 +865,30 @@ void MainWindow::handleIpReConfigRequested(const QString& ipName,
   IpConfigWidget* configWidget =
       new IpConfigWidget(this, ipName, moduleName, paramList);
   replaceIpConfigDockWidget(configWidget);
+}
+
+void MainWindow::handleRemoveIpRequested(const QString& moduleName) {
+  Compiler* compiler{};
+  IPGenerator* ipGen{};
+
+  if ((compiler = GlobalSession->GetCompiler()) &&
+      (ipGen = compiler->GetIPGenerator())) {
+    ipGen->RemoveIPInstance(moduleName.toStdString());
+  }
+
+  updateSourceTree();
+}
+
+void MainWindow::handleDeleteIpRequested(const QString& moduleName) {
+  Compiler* compiler{};
+  IPGenerator* ipGen{};
+
+  if ((compiler = GlobalSession->GetCompiler()) &&
+      (ipGen = compiler->GetIPGenerator())) {
+    ipGen->DeleteIPInstance(moduleName.toStdString());
+  }
+
+  updateSourceTree();
 }
 
 void MainWindow::updateViewMenu() {

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -79,6 +79,8 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void handleIpReConfigRequested(const QString& ipName,
                                  const QString& moduleName,
                                  const QStringList& paramList);
+  void handleRemoveIpRequested(const QString& moduleName);
+  void handleDeleteIpRequested(const QString& moduleName);
 
  private: /* Menu bar builders */
   void updateViewMenu();

--- a/src/ProjNavigator/sources_form.cpp
+++ b/src/ProjNavigator/sources_form.cpp
@@ -146,6 +146,8 @@ void SourcesForm::SlotItempressed(QTreeWidgetItem *item, int column) {
       if (SRC_TREE_IP_FILE_ITEM == strPropertyRole) {
         menu->addSeparator();
         menu->addAction(m_actReconfigureIp);
+        menu->addAction(m_actRemoveIp);
+        menu->addAction(m_actDeleteIp);
       }
     }
 
@@ -390,6 +392,24 @@ void SourcesForm::SlotReConfigureIp() {
                            QString::fromStdString(moduleName), args);
 }
 
+void SourcesForm::SlotRemoveIp() {
+  QTreeWidgetItem *item = m_treeSrcHierachy->currentItem();
+  if (item == nullptr) {
+    return;
+  }
+  QString moduleName = QString::fromStdString(item->text(0).toStdString());
+  emit IpRemoveRequested(moduleName);
+}
+
+void SourcesForm::SlotDeleteIp() {
+  QTreeWidgetItem *item = m_treeSrcHierachy->currentItem();
+  if (item == nullptr) {
+    return;
+  }
+  QString moduleName = QString::fromStdString(item->text(0).toStdString());
+  emit IpDeleteRequested(moduleName);
+}
+
 void SourcesForm::CreateActions() {
   m_actRefresh = new QAction(tr("Refresh Hierarchy"), m_treeSrcHierachy);
   connect(m_actRefresh, SIGNAL(triggered()), this,
@@ -438,6 +458,18 @@ void SourcesForm::CreateActions() {
   m_actReconfigureIp = new QAction(tr("Reconfigure IP"), m_treeSrcHierachy);
   connect(m_actReconfigureIp, &QAction::triggered, this,
           &SourcesForm::SlotReConfigureIp);
+
+  m_actRemoveIp = new QAction(tr("Remove IP from Project"), m_treeSrcHierachy);
+  m_actRemoveIp->setToolTip(
+      "Remove the selectd IP instance from the project. Its build files will "
+      "remain.");
+  connect(m_actRemoveIp, &QAction::triggered, this, &SourcesForm::SlotRemoveIp);
+
+  m_actDeleteIp = new QAction(tr("Delete IP"), m_treeSrcHierachy);
+  m_actDeleteIp->setToolTip(
+      "Remove the selectd IP instance from the project and delete its build "
+      "files.");
+  connect(m_actDeleteIp, &QAction::triggered, this, &SourcesForm::SlotDeleteIp);
 }
 
 void SourcesForm::UpdateSrcHierachyTree() {

--- a/src/ProjNavigator/sources_form.cpp
+++ b/src/ProjNavigator/sources_form.cpp
@@ -147,7 +147,11 @@ void SourcesForm::SlotItempressed(QTreeWidgetItem *item, int column) {
         menu->addSeparator();
         menu->addAction(m_actReconfigureIp);
         menu->addAction(m_actRemoveIp);
-        menu->addAction(m_actDeleteIp);
+        // TODO @skyler-rs Re-enable when ipgen and stored VLNV have same cases.
+        // Currenlty ip generators save to a path in lowercase which causes a
+        // file miss when trying to delete based off the VLNV data which has
+        // capitalizations etc
+        // menu->addAction(m_actDeleteIp);
       }
     }
 

--- a/src/ProjNavigator/sources_form.h
+++ b/src/ProjNavigator/sources_form.h
@@ -52,6 +52,8 @@ class SourcesForm : public QWidget {
   void CloseProject();
   void IpReconfigRequested(const QString& ipName, const QString moduleName,
                            const QStringList& paramList);
+  void IpRemoveRequested(const QString& moduleName);
+  void IpDeleteRequested(const QString& moduleName);
 
  private slots:
   void SlotItempressed(QTreeWidgetItem* item, int column);
@@ -70,6 +72,8 @@ class SourcesForm : public QWidget {
   void SlotProperties();
   void SlotPropertiesTriggered();
   void SlotReConfigureIp();
+  void SlotRemoveIp();
+  void SlotDeleteIp();
 
  private:
   Ui::SourcesForm* ui;
@@ -87,6 +91,8 @@ class SourcesForm : public QWidget {
   QAction* m_actProperties;
   QAction* m_actCloseProject;
   QAction* m_actReconfigureIp;
+  QAction* m_actRemoveIp;
+  QAction* m_actDeleteIp;
 
   ProjectManager* m_projManager;
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: [GEMINIEDA-417]
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> No option is provide to remove or delete an IP
>![image](https://user-images.githubusercontent.com/103447061/193956457-54077ed6-59c4-4823-a1a1-290d76829606.png)

> #### What does this pull request change?
> - 2 new options are provided
![image](https://user-images.githubusercontent.com/103447061/193956592-28dd9299-26be-422f-a1b9-55ccde2acdbd.png)
> - "Remove IP from project" will remove the IP instance from the current set of ip instances but leaves IP build files.
> - "Delete IP" deletes the build files associated with this IP as well as removes its instance

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: MainWindow, ProjNavigator, IPGenerate
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
- These are primarily gui related changes
- Manual testing has been done in foedag and raptor
