### PR TITLE
Make IpConfigWidget Scrollable

### DIFF
--- a/src/IpConfigurator/IpConfigWidget.cpp
+++ b/src/IpConfigurator/IpConfigWidget.cpp
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QPushButton>
+#include <QScrollArea>
 #include <QWidget>
 
 #include "Main/WidgetFactory.h"
@@ -80,18 +81,32 @@ IpConfigWidget::IpConfigWidget(QWidget* parent /*nullptr*/,
 
   // Main Layout
   QVBoxLayout* topLayout = new QVBoxLayout();
+  topLayout->setContentsMargins(0, 0, 0, 0);
   this->setLayout(topLayout);
 
+  // Create container widget and QScrollArea so this widget can shrink
+  QWidget* containerWidget = new QWidget();
+  containerWidget->setObjectName("ipConfigContainerWidget");
+  QVBoxLayout* containerLayout = new QVBoxLayout();
+  // layout must be set before adding to the scroll area
+  // https://doc.qt.io/qt-6/qscrollarea.html#setWidget
+  containerWidget->setLayout(containerLayout);
+  QScrollArea* scrollArea = new QScrollArea();
+  scrollArea->setWidgetResizable(true);
+  scrollArea->setObjectName("ipConfigScrollArea");
+  scrollArea->setWidget(containerWidget);
+  topLayout->addWidget(scrollArea);
+
   // Add VLNV meta text description
-  topLayout->addWidget(&metaLabel);
+  containerLayout->addWidget(&metaLabel);
 
   // Fill and add Parameters box
   CreateParamFields();
-  topLayout->addWidget(&paramsBox);
+  containerLayout->addWidget(&paramsBox);
 
   // Add Output Box
   CreateOutputFields();
-  topLayout->addWidget(&outputBox);
+  containerLayout->addWidget(&outputBox);
   // Update the module name if one was passed (this occurs during a
   // re-configure)
   if (!moduleName.isEmpty()) {


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: existing issue, altho don't think it was captured in a jira
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Currently the IpConfigWidget displays it's dynamically generated parameters in a basic widget which can't shrink any smaller. As a result, an ip w/ many parameters can force the widget to take up too much space.
> 
![image](https://user-images.githubusercontent.com/103447061/194183581-6514dd71-cf93-42e4-a9ab-8acea9360b21.png)
>
> #### What does this pull request change?
> The fields of the IpConfigWidget have been added to a QScrollArea which allows the parent dock window to scale down the QScrollarea while still rendering the windows at full size, but in a scrollable view.
>
<img width="218" alt="image" src="https://user-images.githubusercontent.com/103447061/194184279-e10eac9e-dbb5-4e63-8c5e-1e4688c7ee55.png">

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IpConfigurator
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
> - This is a visual gui change so no tests can be run
> - This has been manually integration tested on foedag and raptor
