### PR TITLE
[RG-125] Clean button fixed for bitsream,power and timing Anaylsis

### DIFF
--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -84,8 +84,16 @@ TaskManager::TaskManager(QObject *parent) : QObject{parent} {
             &TaskManager::taskStateChanged);
     connect((*task), &Task::finished, this, &TaskManager::runNext);
   }
-  QVector<Task *> tmp = {m_tasks[TIMING_SIGN_OFF], m_tasks[POWER],
-                         m_tasks[BITSTREAM], m_tasks[ROUTING]};
+  QVector<Task *> tmp = {m_tasks[BITSTREAM]};
+  m_rollBack.insert(m_tasks[BITSTREAM_CLEAN], tmp);
+
+  tmp += m_tasks[POWER];
+  m_rollBack.insert(m_tasks[POWER_CLEAN], tmp);
+
+  tmp += m_tasks[TIMING_SIGN_OFF];
+  m_rollBack.insert(m_tasks[TIMING_SIGN_OFF_CLEAN], tmp);
+
+  tmp += m_tasks[ROUTING];
   m_rollBack.insert(m_tasks[ROUTING_CLEAN], tmp);
 
   tmp += m_tasks[PLACEMENT];


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] **Bitstream Clean does not clean the green status**

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)

- Timing Analysis
- Power
- Bit Stream

Clean buttons of following above do not clean the green status. Now they are fixed and they clean green status.

Testing Step

- Create new project in foedag
- Press Start button and wait untill all design compilation is completed.
- Press clean button of the mentioned options above. 
- Check that green status of that option  cleans.

> #### What does this pull request change?
Added the functionality of clean button of the above mentioned options.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
