### PR TITLE
[RG-114] Handle local relative paths for design files

### DIFF
--- a/src/Main/ProjectFile/ProjectManagerComponent.cpp
+++ b/src/Main/ProjectFile/ProjectManagerComponent.cpp
@@ -266,10 +266,13 @@ void ProjectManagerComponent::Load(QXmlStreamReader* r) {
                   strFile);
             }
             int index{0};
+            auto projectPath = Project::Instance()->projectPath();
             for (const auto& i : langList) {
+              auto designFiles = i.second;
+              designFiles.replace(PROJECT_OSRCDIR, projectPath);
               projectFileset.addFiles(
                   libs.at(index).first, libs.at(index).second,
-                  ProjectManager::StringSplit(i.second, " "), i.first);
+                  ProjectManager::StringSplit(designFiles, " "), i.first);
               index++;
             }
             for (auto iter = mapOption.begin(); iter != mapOption.end();


### PR DESCRIPTION
> ### Motivate of the pull request
These changes are needed to be able to fix RG-114 and store design files with relative paths in project file.

> ### Describe the technical details
Hardcoded string '$OSRCDIR' is recognized in the code as the path to the project folder : (.../Raptor/examples/sasc_testcase/)
It wasn't considered when desirializing design files though: file paths were passed to the project manager as they are. Now we replace '$OSRCDIR' with the project path. The code is backward compatible as won't replace anything if there is no such string used.
>
> #### What does this pull request change?
Now design files can be stored with relative paths in the project file.
On a screenshot below all "File Path" lines were already supported. Current change extends it for "Group ..." line, holding design files with their libraries.
![image](https://user-images.githubusercontent.com/109239890/194932693-7f221c87-7e69-4fa9-9dc1-9eedc353bcdc.png)

Another PR to fulfill RG-114 completely will come on Raptor - examples folder with *.ospr based projects.

> ### Which part of the code base require a change
> - [+] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [+] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts
