### PR TITLE
[RG-126] Hide post synth flow since it is not ready yet

### DIFF
--- a/src/NewProject/project_type_form.cpp
+++ b/src/NewProject/project_type_form.cpp
@@ -24,6 +24,9 @@ projectTypeForm::projectTypeForm(QWidget *parent)
 
   QObject::connect(ui->m_skipSourcesCheckbox, &QAbstractButton::clicked, this,
                    &projectTypeForm::skipSources);
+
+  ui->m_radioBtnPost->hide();
+  ui->m_labelPost->hide();
 }
 
 projectTypeForm::~projectTypeForm() { delete ui; }


### PR DESCRIPTION
 ### Motivate of the pull request
Hide Post Synth flow from project type since it is not ready jet.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: newproject
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts

### screenshots
![image](https://user-images.githubusercontent.com/95262932/194939762-73b56e17-0063-4393-b341-3d92fa71a93d.png)
