### PR TITLE
[RG-127] IP project settings changes, reset ip instances tree on project change

### DIFF
--- a/src/IpConfigurator/IpConfigWidget.cpp
+++ b/src/IpConfigurator/IpConfigWidget.cpp
@@ -166,12 +166,23 @@ void IpConfigWidget::AddDialogControls(QBoxLayout* layout) {
 
     GlobalSession->TclInterp()->evalCmd(cmd.toStdString());
 
-    // Update the Ip Instances in the source tree
-    MainWindow* win = qobject_cast<MainWindow*>(GlobalSession->MainWindow());
-    if (win) {
-      emit ipInstancesUpdated();
-    }
+    AddIpToProject(outFileStr);
+    emit ipInstancesUpdated();
   });
+}
+
+void IpConfigWidget::AddIpToProject(const QString& ipBuildPath) {
+  // TODO @skyler-rs oct2022, this is groundwork code for later
+  // The project doesn't currently track/load ips on project change, but the
+  // initial project file changes have been made so this starts saving ip paths
+  // there for future changes that will use this info
+  std::string outDir = ipBuildPath.toStdString();
+  auto instances =
+      GlobalSession->GetCompiler()->ProjManager()->ipInstancePathList();
+  if (std::find(instances.begin(), instances.end(), outDir) ==
+      instances.end()) {
+    GlobalSession->GetCompiler()->ProjManager()->addIpInstancePath(outDir);
+  }
 }
 
 void IpConfigWidget::CreateParamFields() {

--- a/src/IpConfigurator/IpConfigWidget.h
+++ b/src/IpConfigurator/IpConfigWidget.h
@@ -47,6 +47,7 @@ class IpConfigWidget : public QWidget {
 
  private:
   void AddDialogControls(QBoxLayout* layout);
+  void AddIpToProject(const QString& ipBuildPath);
   void CreateParamFields();
   void CreateOutputFields();
   void updateMetaLabel(VLNV info);

--- a/src/Main/ProjectFile/ProjectManagerComponent.cpp
+++ b/src/Main/ProjectFile/ProjectManagerComponent.cpp
@@ -25,6 +25,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FOEDAG {
 
+constexpr auto GENERIC_OPTION{"Option"};
+constexpr auto GENERIC_NAME{"Name"};
+constexpr auto GENERIC_VAL{"Val"};
+
 constexpr auto COMPILER_CONFIG{"CompilerConfig"};
 constexpr auto COMPILER_OPTION{"Opt"};
 constexpr auto COMPILER_NAME{"Name"};
@@ -36,6 +40,10 @@ constexpr auto COMPILER_MACRO{"Macro"};
 
 constexpr auto PROJECT_GROUP_LIB_COMMAND{"LibCommand"};
 constexpr auto PROJECT_GROUP_LIB_NAME{"LibName"};
+
+constexpr auto IP_CONFIG{"IpConfig"};
+constexpr auto IP_INSTANCE_PATHS{"InstancePaths"};
+constexpr auto IP_CATALOG_PATHS{"CatalogPaths"};
 
 ProjectManagerComponent::ProjectManagerComponent(ProjectManager* pManager,
                                                  QObject* parent)
@@ -89,6 +97,17 @@ void ProjectManagerComponent::Save(QXmlStreamWriter* writer) {
   stream.writeStartElement(COMPILER_OPTION);
   stream.writeAttribute(COMPILER_NAME, COMPILER_MACRO);
   stream.writeAttribute(COMPILER_VAL, m_projectManager->macros());
+  stream.writeEndElement();
+  stream.writeEndElement();
+
+  stream.writeStartElement(IP_CONFIG);
+  stream.writeStartElement(GENERIC_OPTION);
+  stream.writeAttribute(GENERIC_NAME, IP_INSTANCE_PATHS);
+  stream.writeAttribute(GENERIC_VAL, m_projectManager->ipInstancePaths());
+  stream.writeEndElement();
+  stream.writeStartElement(GENERIC_OPTION);
+  stream.writeAttribute(GENERIC_NAME, IP_CATALOG_PATHS);
+  stream.writeAttribute(GENERIC_VAL, m_projectManager->ipCatalogPaths());
   stream.writeEndElement();
   stream.writeEndElement();
 
@@ -323,6 +342,34 @@ void ProjectManagerComponent::Load(QXmlStreamReader* r) {
               auto macro = reader.attributes().value(COMPILER_VAL).toString();
               auto macroList = ProjectManager::ParseMacro(macro);
               m_projectManager->setMacroList(macroList);
+            }
+          }
+        }
+      }
+      if (reader.name() == IP_CONFIG) {
+        while (true) {
+          type = reader.readNext();
+          if (type == QXmlStreamReader::EndElement &&
+              reader.name() == IP_CONFIG) {
+            break;
+          }
+
+          if (type == QXmlStreamReader::StartElement &&
+              reader.attributes().hasAttribute(GENERIC_NAME) &&
+              reader.attributes().hasAttribute(GENERIC_VAL)) {
+            if (reader.attributes().value(GENERIC_NAME).toString() ==
+                IP_INSTANCE_PATHS) {
+              auto path = reader.attributes().value(GENERIC_VAL).toString();
+              std::vector<std::string> pathList;
+              StringUtils::tokenize(path.toStdString(), " ", pathList);
+              m_projectManager->setIpInstancePathList(pathList);
+            }
+            if (reader.attributes().value(GENERIC_NAME).toString() ==
+                IP_CATALOG_PATHS) {
+              auto path = reader.attributes().value(GENERIC_VAL).toString();
+              std::vector<std::string> pathList;
+              StringUtils::tokenize(path.toStdString(), " ", pathList);
+              m_projectManager->setIpCatalogPathList(pathList);
             }
           }
         }

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -553,6 +553,8 @@ void MainWindow::ReShowWindow(QString strProject) {
 
   newDesignCreated(strProject);
 
+  resetIps();
+
   showMenus(true);
 
   QDockWidget* sourceDockWidget = new QDockWidget(tr("Source"), this);
@@ -902,6 +904,16 @@ void MainWindow::handleDeleteIpRequested(const QString& moduleName) {
   }
 
   updateSourceTree();
+}
+
+void MainWindow::resetIps() {
+  Compiler* compiler{};
+  IPGenerator* ipGen{};
+
+  if ((compiler = GlobalSession->GetCompiler()) &&
+      (ipGen = compiler->GetIPGenerator())) {
+    ipGen->ResetIPList();
+  }
 }
 
 void MainWindow::updateViewMenu() {

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -81,6 +81,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
                                  const QStringList& paramList);
   void handleRemoveIpRequested(const QString& moduleName);
   void handleDeleteIpRequested(const QString& moduleName);
+  void resetIps();
 
  private: /* Menu bar builders */
   void updateViewMenu();

--- a/src/NewProject/CMakeLists.txt
+++ b/src/NewProject/CMakeLists.txt
@@ -38,6 +38,7 @@ set (SRC_CPP_LIST
   ProjectManager/project.cpp
   ProjectManager/project_manager.cpp
   ProjectManager/compiler_configuration.cpp
+  ProjectManager/ip_configuration.cpp
   newprojectmodel.cpp)
 
 set (SRC_H_LIST
@@ -59,6 +60,7 @@ set (SRC_H_LIST
   ProjectManager/project.h
   ProjectManager/project_manager.h
   ProjectManager/compiler_configuration.h
+  ProjectManager/ip_configuration.h
   newprojectmodel.h
   SettingsGuiInterface.h)
 
@@ -117,6 +119,7 @@ install(
       FILES ${PROJECT_SOURCE_DIR}/../NewProject/ProjectManager/project_fileset.h
       FILES ${PROJECT_SOURCE_DIR}/../NewProject/ProjectManager/project_run.h
       FILES ${PROJECT_SOURCE_DIR}/../NewProject/ProjectManager/compiler_configuration.h
+      FILES ${PROJECT_SOURCE_DIR}/../NewProject/ProjectManager/ip_configuration.h
       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/foedag/NewProject/ProjectManager)
   
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../bin)

--- a/src/NewProject/ProjectManager/ip_configuration.cpp
+++ b/src/NewProject/ProjectManager/ip_configuration.cpp
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "ip_configuration.h"
+
+namespace FOEDAG {
+
+const std::vector<std::string> &IpConfiguration::ipCatalogPathList() const {
+  return m_ipCatalogPathList;
+}
+
+void IpConfiguration::setIpCatalogPathList(
+    const std::vector<std::string> &newIpCatalogPathList) {
+  m_ipCatalogPathList = newIpCatalogPathList;
+}
+
+void IpConfiguration::addIpCatalogPath(const std::string &ipCatalogPath) {
+  m_ipCatalogPathList.push_back(ipCatalogPath);
+}
+
+const std::vector<std::string> &IpConfiguration::instancePathList() const {
+  return m_instancePathList;
+}
+
+void IpConfiguration::setInstancePathList(
+    const std::vector<std::string> &newInstancePathList) {
+  m_instancePathList = newInstancePathList;
+}
+
+void IpConfiguration::addInstancePath(const std::string &instancePath) {
+  m_instancePathList.push_back(instancePath);
+}
+
+}  // namespace FOEDAG

--- a/src/NewProject/ProjectManager/ip_configuration.h
+++ b/src/NewProject/ProjectManager/ip_configuration.h
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace FOEDAG {
+
+class IpConfiguration {
+ public:
+  IpConfiguration() = default;
+
+  // Catalog Paths
+  const std::vector<std::string> &ipCatalogPathList() const;
+  void setIpCatalogPathList(
+      const std::vector<std::string> &newIpCatalogPathList);
+  void addIpCatalogPath(const std::string &ipCatalogPath);
+
+  // Instance Paths
+  const std::vector<std::string> &instancePathList() const;
+  void setInstancePathList(const std::vector<std::string> &newInstancePathList);
+  void addInstancePath(const std::string &instancePath);
+
+ private:
+  std::vector<std::string> m_ipCatalogPathList;
+  std::vector<std::string> m_instancePathList;
+};
+
+}  // namespace FOEDAG

--- a/src/NewProject/ProjectManager/project.cpp
+++ b/src/NewProject/ProjectManager/project.cpp
@@ -14,6 +14,7 @@ void Project::InitProject() {
   m_projectConfig->moveToThread(thread());
   m_projectConfig->setParent(this);
   m_compilerConfig.reset(new CompilerConfiguration);
+  m_ipConfig.reset(new IpConfiguration);
   qDeleteAll(m_mapProjectRun);
   m_mapProjectRun.clear();
   qDeleteAll(m_mapProjectFileset);
@@ -37,6 +38,13 @@ ProjectConfiguration *Project::projectConfig() const { return m_projectConfig; }
 
 CompilerConfiguration *Project::compilerConfig() const {
   return m_compilerConfig.get();
+}
+
+IpConfiguration *Project::ipConfig() {
+  if (!m_ipConfig.get()) {
+    m_ipConfig.reset(new IpConfiguration);
+  }
+  return m_ipConfig.get();
 }
 
 ProjectFileSet *Project::getProjectFileset(const QString &strName) const {

--- a/src/NewProject/ProjectManager/project.h
+++ b/src/NewProject/ProjectManager/project.h
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "compiler_configuration.h"
+#include "ip_configuration.h"
 #include "project_configuration.h"
 #include "project_fileset.h"
 #include "project_run.h"
@@ -27,6 +28,7 @@ class Project : public QObject {
 
   ProjectConfiguration *projectConfig() const;
   CompilerConfiguration *compilerConfig() const;
+  IpConfiguration *ipConfig();
 
   ProjectFileSet *getProjectFileset(const QString &strName) const;
   int setProjectFileset(const ProjectFileSet &projectFileset);
@@ -50,6 +52,7 @@ class Project : public QObject {
 
   ProjectConfiguration *m_projectConfig;
   std::unique_ptr<CompilerConfiguration> m_compilerConfig;
+  std::unique_ptr<IpConfiguration> m_ipConfig;
   QMap<QString, ProjectFileSet *> m_mapProjectFileset;
   QMap<QString, ProjectRun *> m_mapProjectRun;
 };

--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -1566,6 +1566,46 @@ std::vector<std::pair<std::string, std::string>> ProjectManager::ParseMacro(
   return macroList;
 }
 
+const std::vector<std::string>& ProjectManager::ipCatalogPathList() const {
+  return Project::Instance()->ipConfig()->ipCatalogPathList();
+}
+
+QString ProjectManager::ipCatalogPaths() const {
+  auto pathList = Project::Instance()->ipConfig()->ipCatalogPathList();
+  QStringList tmpList;
+  for (const auto& p : pathList) tmpList.append(QString::fromStdString(p));
+  return tmpList.join(" ");
+}
+
+void ProjectManager::setIpCatalogPathList(
+    const std::vector<std::string>& newIpCatalogPathList) {
+  Project::Instance()->ipConfig()->setIpCatalogPathList(newIpCatalogPathList);
+};
+
+void ProjectManager::addIpCatalogPath(const std::string& ipCatalogPath) {
+  Project::Instance()->ipConfig()->addIpCatalogPath(ipCatalogPath);
+}
+
+const std::vector<std::string>& ProjectManager::ipInstancePathList() const {
+  return Project::Instance()->ipConfig()->instancePathList();
+}
+
+QString ProjectManager::ipInstancePaths() const {
+  auto pathList = Project::Instance()->ipConfig()->instancePathList();
+  QStringList tmpList;
+  for (const auto& p : pathList) tmpList.append(QString::fromStdString(p));
+  return tmpList.join(" ");
+}
+
+void ProjectManager::setIpInstancePathList(
+    const std::vector<std::string>& newIpInstancePathList) {
+  Project::Instance()->ipConfig()->setInstancePathList(newIpInstancePathList);
+};
+
+void ProjectManager::addIpInstancePath(const std::string& ipInstancePath) {
+  Project::Instance()->ipConfig()->addInstancePath(ipInstancePath);
+}
+
 int ProjectManager::CreateAndAddFile(const QString& suffix,
                                      const QString& filename,
                                      const QString& filenameAdd,
@@ -1608,8 +1648,8 @@ void ProjectManager::UpdateProjectInternal(const ProjectOptions& opt,
   // Step through the group key and try to combine all the settings
   for (auto key : fileGroups.keys()) {
     if (key == "") {
-      // Skip files w/ no Compile Unit set they will be added sequentially after
-      // the groups are added
+      // Skip files w/ no Compile Unit set they will be added sequentially
+      // after the groups are added
       continue;
     }
     QString fileListStr{};
@@ -1633,7 +1673,8 @@ void ProjectManager::UpdateProjectInternal(const ProjectOptions& opt,
         }
       }
 
-      // Split libraries by space and then store any new, unique library names
+      // Split libraries by space and then store any new, unique library
+      // names
       for (auto lib : fdata.m_workLibrary.split(" ")) {
         if (!libs.contains(lib)) {
           libs.append(lib);
@@ -1658,7 +1699,8 @@ void ProjectManager::UpdateProjectInternal(const ProjectOptions& opt,
       fileListStr += addFilePath;
     }  // End looping through files
 
-    // create a string of the unique libs requested by the files in this group
+    // create a string of the unique libs requested by the files in this
+    // group
     QString libraries{};
     for (auto lib : libs) {
       if (!libraries.isEmpty()) {
@@ -1670,8 +1712,8 @@ void ProjectManager::UpdateProjectInternal(const ProjectOptions& opt,
 
     // Check if we are combing local and non-local files in a group
     if (hasLocalFiles && hasNonLocalFiles) {
-      // This is probably an error condition as the setDesignFiles call has
-      // different arguements when local or non-local
+      // This is probably an error condition as the setDesignFiles call
+      // has different arguements when local or non-local
     } else if (multipleLanguages) {
       // This seems like a pontential error scenario as well
     } else if (hasLocalFiles) {

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -296,6 +296,18 @@ class ProjectManager : public QObject {
   static std::vector<std::pair<std::string, std::string>> ParseMacro(
       const QString &macro);
 
+  const std::vector<std::string> &ipCatalogPathList() const;
+  QString ipCatalogPaths() const;
+  void setIpCatalogPathList(
+      const std::vector<std::string> &newIpCatalogPathList);
+  void addIpCatalogPath(const std::string &ipCatalogPath);
+
+  const std::vector<std::string> &ipInstancePathList() const;
+  QString ipInstancePaths() const;
+  void setIpInstancePathList(
+      const std::vector<std::string> &newIpInstancePathList);
+  void addIpInstancePath(const std::string &ipInstancePath);
+
  private:
   // Please set currentfileset before using this function
   int setDesignFile(const QString &strFileName, bool isFileCopy = true,


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: [RG-127]
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> IP instances listed in the source tree would persist after a project change because the instances are still tracked by the IpGenerator class after a project change.
>
> #### What does this pull request change?
> - Added logic to reset the ip instances on project close/change
> - This also makes initial changes to the project system to allow for tracking of IP information. This will be used in later feature updates.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IpConfigurator, NewProject, Main
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
> - Manually tested (in foedag and Raptor) that the IP instances in the source tree get cleared on project close/change
