### PR TITLE
[RG-124] Remove MOCK_IP from IP Catalog builder

### DIFF
--- a/src/IPGenerate/IPCatalogBuilder.cpp
+++ b/src/IPGenerate/IPCatalogBuilder.cpp
@@ -76,7 +76,6 @@ void buildMockUpIPDef(IPCatalog* catalog) {
 bool IPCatalogBuilder::buildLiteXCatalog(
     IPCatalog* catalog, const std::filesystem::path& litexIPgenPath) {
   bool result = true;
-  buildMockUpIPDef(catalog);
   if (FileUtils::FileExists(litexIPgenPath)) {
     std::filesystem::path execPath = litexIPgenPath;
     if (!std::filesystem::is_directory(execPath)) {

--- a/tests/TestBatch/test_ip_generate.tcl
+++ b/tests/TestBatch/test_ip_generate.tcl
@@ -1,7 +1,49 @@
-create_design ip_test
-add_litex_ip_catalog ./
-configure_ip MOCK_IP -mod_name mockup_ip -version 1.0 -PWidth=10 -out_file rs_ips/mockup_ip.v
-ipgenerate
-set_top_module use_ip
-#add_design_file rs_ips/mockup_ip.v use_ip.v
-#synth
+#Copyright 2022 The Foedag team
+
+#GPL License
+
+#Copyright (c) 2022 The Open-Source FPGA Foundation
+
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set platform $::tcl_platform(platform)
+if { $platform == "windows" } {
+    # TODO @skyler-rs Oct2022 Enable in windows once GH-661 is resolved
+    puts "SKIPPING ON WINDOWS: This test requires python which FileUtils::ExecuteSystemCommand() currently fails to find on Windows. Disabling windows run of test until python issues on windows are resolved.\n"
+    # returning a pass condition because this is an expected failure for now
+    exit 0
+} else {
+    # Load IPs
+    create_design ip_test
+    architecture ../../Arch/k6_frac_N10_tileable_40nm.xml ../../Arch/k6_N10_40nm_openfpga.xml
+    add_litex_ip_catalog ../Testcases/IPGenerate/IP_Catalog
+
+    # Configure an IP w/ module named inst1
+    configure_ip axis_converter_V1_0 -mod_name inst1 -version V1_0 -Pcore_in_width=128 -Pcore_out_width=64 -Pcore_user_width=0 -Pcore_reverse=0 -out_file rs_ips/inst1
+
+    # Generate ip
+    ipgenerate
+
+    set fp [open "foedag.log" r]
+    set file_data [read $fp]
+    close $fp
+    # Error out if inst1 wasn't generated
+    set found [regexp "rs_ips/inst1" $file_data]
+    if { !$found } {
+        puts "TEST FAILED: ipgenerate failed to generate inst1"
+        exit 1
+    }
+
+    exit 0
+}


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: [RG-124]
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> A dummy IP called MOCK_IP was always added to the catalog when loading the IP system
>
> #### What does this pull request change?
> The code to create MOCK_IP has been removed from build catalog code
![image](https://user-images.githubusercontent.com/103447061/195121461-09b421b3-bc57-4252-88bb-ca3561462e67.png)

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IPGenerate
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
> - Manually Tested in foedag and Raptor
