### PR TITLE
[GEMINIEDA-459] Removing IP builder "Adding" and "Found" messages

### DIFF
--- a/src/IPGenerate/IPCatalogBuilder.cpp
+++ b/src/IPGenerate/IPCatalogBuilder.cpp
@@ -77,6 +77,7 @@ bool IPCatalogBuilder::buildLiteXCatalog(
     IPCatalog* catalog, const std::filesystem::path& litexIPgenPath) {
   bool result = true;
   if (FileUtils::FileExists(litexIPgenPath)) {
+    int foundCount = 0;
     std::filesystem::path execPath = litexIPgenPath;
     if (!std::filesystem::is_directory(execPath)) {
       execPath = execPath.parent_path();
@@ -90,13 +91,16 @@ bool IPCatalogBuilder::buildLiteXCatalog(
       const std::string& exec_name = entry.string();
       if (exec_name.find("__init__.py") != std::string::npos) continue;
       if (exec_name.find("_gen.py") != std::string::npos) {
-        m_compiler->Message("IP Catalog, found IP compiler: " + exec_name);
+        foundCount++;
         bool res = buildLiteXIPFromGenerator(catalog, entry);
         if (res == false) {
           result = false;
         }
       }
     }
+    std::string msg =
+        std::string("IP Catalog, found ") + std::to_string(foundCount) + " IPs";
+    m_compiler->Message(msg);
   } else {
     result = false;
     m_compiler->ErrorMessage("IP Catalog, directory does not exist: " +
@@ -210,7 +214,6 @@ bool IPCatalogBuilder::buildLiteXIPFromGenerator(
   // get default build_name which is used during ip configuration
   std::string build_name = jopts.value("build_name", "");
 
-  m_compiler->Message("IP Catalog, adding IP: " + IPName);
   IPDefinition* def =
       new IPDefinition(IPDefinition::IPType::LiteXGenerator, IPName, build_name,
                        pythonConverterScript, connections, parameters);


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: [GEMINIEDA-459]
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Original ip builder code had print statements reported when IPs were found/loaded and added
>
> #### What does this pull request change?
> - "IP Catalog, Adding IP: ..." messages have been removed
> - "IP Catalog, found IP Compiler: ..." messages have been removed
> - 1 summary message, "IP Catalog, found X IPs", has been added
<img width="787" alt="image" src="https://user-images.githubusercontent.com/103447061/195201721-f99f2394-3ac5-4f16-974b-41069924aa8a.png">

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: IPGenerate
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
> - Manually tested in foedag and raptor
