### PR TITLE
[GEMINIEDA-463] Fixed bitstream generation

### DIFF
--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -2146,7 +2146,7 @@ bool CompilerOpenFPGA::GenerateBitstream() {
                           std::string("fabric_independent_bitstream.xml"));
   // Create OpenFpga command and execute
   script_path =
-      (std::filesystem::path(ProjManager()->projectName()) / script_path)
+      (std::filesystem::path(ProjManager()->projectPath()) / script_path)
           .string();
   std::ofstream sofs(script_path);
   sofs << script;
@@ -2158,7 +2158,7 @@ bool CompilerOpenFPGA::GenerateBitstream() {
   }
 
   std::ofstream ofs(
-      (std::filesystem::path(ProjManager()->projectName()) /
+      (std::filesystem::path(ProjManager()->projectPath()) /
        std::string(ProjManager()->projectName() + "_bitstream.cmd"))
           .string());
   ofs << command << std::endl;


### PR DESCRIPTION
 ### Motivate of the pull request
Fix for bitstream generation caused by wrong path to generated files.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
