### PR TITLE
[RG-135] Enable Stop button when either task manager or console is in progress

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -232,7 +232,8 @@ void MainWindow::startStopButtonsState() {
   const bool inProgress = m_taskManager->status() == TaskStatus::InProgress;
   const bool consoleInProgress = m_console->isRunning();
   startAction->setEnabled(!inProgress && !consoleInProgress);
-  stopAction->setEnabled(inProgress && consoleInProgress);
+  // Enable Stop action when there is something to stop
+  stopAction->setEnabled(inProgress || consoleInProgress);
 }
 
 QDockWidget* MainWindow::PrepareTab(const QString& name, const QString& objName,


### PR DESCRIPTION
> ### Motivate of the pull request
Given PR aims to fix RG-135 issue, which occurs at times while evaluating the project,

> ### Describe the technical details
According to previous implementation, Stop action was only enabled when both, the console and the task manager, are in progress. Due to multiple status changes within the project compilation, sometimes console was no longer running while task manager still had in progress status. 

>
> #### What does this pull request change?
Stop button will be enabled whenever one of them is in progress. It makes sense anyway, as there is something we can stop.
