### PR TITLE
[GEMINIEDA-472] Update view checkmark logic for Ip Configurator

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -223,6 +223,8 @@ void MainWindow::newDesignCreated(const QString& design) {
   SetWindowTitle(QString(), path.baseName(), m_projectInfo.name);
   pinAssignmentAction->setEnabled(!design.isEmpty());
   pinAssignmentAction->setChecked(false);
+  ipConfiguratorAction->setEnabled(!design.isEmpty());
+  ipConfiguratorAction->setChecked(false);
   saveToRecentSettings(design);
   if (sourcesForm)
     sourcesForm->ProjectSettingsActions()->setEnabled(!design.isEmpty());
@@ -497,6 +499,7 @@ void MainWindow::createActions() {
 
   ipConfiguratorAction = new QAction(tr("IP Configurator"), this);
   ipConfiguratorAction->setCheckable(true);
+  ipConfiguratorAction->setEnabled(false);
   connect(ipConfiguratorAction, &QAction::triggered, this,
           &MainWindow::ipConfiguratorActionTriggered);
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: [GEMINIEDA-472]
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Checkmark is only managed when user interacts with the ip configurator action in the view menu
>
> #### What does this pull request change?
> Logic has been added to update the checkmark during project transitions
![image](https://user-images.githubusercontent.com/103447061/195457949-9ee62309-4b23-499a-9031-e01cf507a654.png)

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: MainWindow
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Testing
> - Manually Tested in foedag
