### PR TITLE
[GEMINIEDA-461] Adding View Log option to task view context menu

### DIFF
--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -67,6 +67,18 @@ extern const char* foedag_version_number;
 extern const char* foedag_git_hash;
 extern const char* foedag_build_type;
 
+auto CreateDummyLog = [](ProjectManager* projManager,
+                         const std::string& outfileName) {
+  if (projManager) {
+    std::filesystem::path projectPath(projManager->projectPath());
+    std::filesystem::path outputPath = projectPath / outfileName;
+    std::filesystem::remove(outputPath);
+    std::ofstream ofs(outputPath);
+    ofs << "Dummy log for " << outfileName << "\n";
+    ofs.close();
+  }
+};
+
 void Compiler::Version(std::ostream* out) {
   (*out) << "Foedag FPGA Compiler"
          << "\n";
@@ -1320,6 +1332,8 @@ bool Compiler::Analyze() {
   m_state = State::Analyzed;
   (*m_out) << "Design " << m_projManager->projectName() << " is analyzed!"
            << std::endl;
+
+  CreateDummyLog(m_projManager, "analysis.rpt");
   return true;
 }
 
@@ -1357,6 +1371,8 @@ bool Compiler::Synthesize() {
   m_state = State::Synthesized;
   (*m_out) << "Design " << m_projManager->projectName() << " is synthesized!"
            << std::endl;
+
+  CreateDummyLog(m_projManager, "synthesis.rpt");
   return true;
 }
 
@@ -1387,6 +1403,8 @@ bool Compiler::GlobalPlacement() {
   m_state = State::GloballyPlaced;
   (*m_out) << "Design " << m_projManager->projectName()
            << " is globally placed!" << std::endl;
+
+  CreateDummyLog(m_projManager, "global_placement.rpt");
   return true;
 }
 
@@ -1535,6 +1553,8 @@ bool Compiler::IPGenerate() {
     ErrorMessage("Design " + m_projManager->projectName() +
                  " IPs generation failed!");
   }
+
+  CreateDummyLog(m_projManager, "ip_generate.rpt");
   return status;
 }
 
@@ -1558,6 +1578,8 @@ bool Compiler::Packing() {
   (*m_out) << "Design " << m_projManager->projectName() << " is packed!"
            << std::endl;
   m_state = State::Packed;
+
+  CreateDummyLog(m_projManager, "packing.rpt");
   return true;
 }
 
@@ -1581,6 +1603,8 @@ bool Compiler::Placement() {
   (*m_out) << "Design " << m_projManager->projectName() << " is placed!"
            << std::endl;
   m_state = State::Placed;
+
+  CreateDummyLog(m_projManager, "placement.rpt");
   return true;
 }
 
@@ -1604,6 +1628,8 @@ bool Compiler::Route() {
   (*m_out) << "Design " << m_projManager->projectName() << " is routed!"
            << std::endl;
   m_state = State::Routed;
+
+  CreateDummyLog(m_projManager, "routing.rpt");
   return true;
 }
 
@@ -1617,6 +1643,8 @@ bool Compiler::TimingAnalysis() {
 
   (*m_out) << "Design " << m_projManager->projectName() << " is analyzed!"
            << std::endl;
+
+  CreateDummyLog(m_projManager, "timing_analysis.rpt");
   return true;
 }
 
@@ -1630,6 +1658,8 @@ bool Compiler::PowerAnalysis() {
 
   (*m_out) << "Design " << m_projManager->projectName() << " is analyzed!"
            << std::endl;
+
+  CreateDummyLog(m_projManager, "power_analysis.rpt");
   return true;
 }
 
@@ -1643,6 +1673,8 @@ bool Compiler::GenerateBitstream() {
 
   (*m_out) << "Design " << m_projManager->projectName()
            << " bitstream is generated!" << std::endl;
+
+  CreateDummyLog(m_projManager, "bitstream.rpt");
   return true;
 }
 

--- a/src/Compiler/CompilerDefines.cpp
+++ b/src/Compiler/CompilerDefines.cpp
@@ -41,6 +41,9 @@ QWidget *FOEDAG::prepareCompilerView(Compiler *compiler,
   TaskTableView *view = new TaskTableView{tManager};
   QObject::connect(view, &TaskTableView::TaskDialogRequested,
                    FOEDAG::handleTaskDialogRequested);
+  QObject::connect(view, &TaskTableView::ViewFileRequested,
+                   FOEDAG::handleViewFileRequested);
+
   view->setModel(model);
 
   view->resizeColumnsToContents();

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -47,6 +47,23 @@
 
 using namespace FOEDAG;
 
+auto copyLog = [](FOEDAG::ProjectManager* projManager,
+                  const std::string& srcFileName,
+                  const std::string& destFileName) -> bool {
+  bool result = false;
+  if (projManager) {
+    std::filesystem::path projectPath(projManager->projectPath());
+    std::filesystem::path src = projectPath / srcFileName;
+    std::filesystem::path dest = projectPath / destFileName;
+    if (FileUtils::FileExists(src)) {
+      std::filesystem::remove(dest);
+      std::filesystem::copy_file(src, dest);
+      result = true;
+    }
+  }
+  return result;
+};
+
 void CompilerOpenFPGA::Version(std::ostream* out) {
   (*out) << "Foedag OpenFPGA Compiler"
          << "\n";
@@ -1205,6 +1222,8 @@ bool CompilerOpenFPGA::Synthesize() {
     m_state = State::Synthesized;
     (*m_out) << "Design " << ProjManager()->projectName() << " is synthesized!"
              << std::endl;
+
+    copyLog(ProjManager(), "synth.log", "synthesis.rpt");
     return true;
   }
 }
@@ -1401,6 +1420,7 @@ bool CompilerOpenFPGA::Packing() {
   (*m_out) << "Design " << ProjManager()->projectName() << " is packed!"
            << std::endl;
 
+  copyLog(ProjManager(), "vpr_stdout.log", "packing.rpt");
   return true;
 }
 
@@ -1642,6 +1662,7 @@ bool CompilerOpenFPGA::Placement() {
   (*m_out) << "Design " << ProjManager()->projectName() << " is placed!"
            << std::endl;
 
+  copyLog(ProjManager(), "vpr_stdout.log", "placement.rpt");
   return true;
 }
 
@@ -1745,6 +1766,7 @@ bool CompilerOpenFPGA::Route() {
   (*m_out) << "Design " << ProjManager()->projectName() << " is routed!"
            << std::endl;
 
+  copyLog(ProjManager(), "vpr_stdout.log", "routing.rpt");
   return true;
 }
 
@@ -1870,6 +1892,7 @@ bool CompilerOpenFPGA::TimingAnalysis() {
   (*m_out) << "Design " << ProjManager()->projectName()
            << " is timing analysed!" << std::endl;
 
+  copyLog(ProjManager(), "vpr_stdout.log", "timing_analysis.rpt");
   return true;
 }
 
@@ -1920,6 +1943,8 @@ bool CompilerOpenFPGA::PowerAnalysis() {
 
   (*m_out) << "Design " << ProjManager()->projectName() << " is power analysed!"
            << std::endl;
+
+  copyLog(ProjManager(), "vpr_stdout.log", "power_analysis.rpt");
   return true;
 }
 

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -1223,7 +1223,8 @@ bool CompilerOpenFPGA::Synthesize() {
     (*m_out) << "Design " << ProjManager()->projectName() << " is synthesized!"
              << std::endl;
 
-    copyLog(ProjManager(), "synth.log", "synthesis.rpt");
+    copyLog(ProjManager(), ProjManager()->projectName() + "_synth.log",
+            "synthesis.rpt");
     return true;
   }
 }

--- a/src/Compiler/Task.cpp
+++ b/src/Compiler/Task.cpp
@@ -57,6 +57,9 @@ void Task::setTaskType(TaskType newType) { m_type = newType; }
 QString Task::settingsKey() const { return m_settings_key; }
 void Task::setSettingsKey(QString key) { m_settings_key = key; }
 
+QString Task::logFileReadPath() const { return m_logFilePath; }
+void Task::setLogFileReadPath(QString path) { m_logFilePath = path; }
+
 void Task::trigger() {
   if (m_status != TaskStatus::InProgress) emit taskTriggered();
 }

--- a/src/Compiler/Task.h
+++ b/src/Compiler/Task.h
@@ -67,6 +67,9 @@ class Task : public QObject {
   QString settingsKey() const;
   void setSettingsKey(QString key);
 
+  QString logFileReadPath() const;
+  void setLogFileReadPath(QString key);
+
   /*!
    * \brief trigger
    * Emits \a taskTriggered() signal to notify that some commend can be run.
@@ -109,6 +112,7 @@ class Task : public QObject {
   QVector<Task *> m_subTask;
   Task *m_parent{nullptr};
   bool m_valid{false};
+  QString m_logFilePath{};
 };
 
 }  // namespace FOEDAG

--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -79,6 +79,22 @@ TaskManager::TaskManager(QObject *parent) : QObject{parent} {
   m_tasks[PLACEMENT_SETTINGS]->setSettingsKey("Placement");
   m_tasks[ROUTING_SETTINGS]->setSettingsKey("Routing");
 
+  // These point to log files that can be opened via r-click in the task view
+  // By default, sub-tasks open their parent log file, but you can set
+  // a specific log file on sub-tasks as well for finer control
+  // Ex: m_tasks[ANALYSIS_CLEAN]->setLogFileReadPath(<some_path>);
+  m_tasks[IP_GENERATE]->setLogFileReadPath("$OSRCDIR/ip_generate.rpt");
+  m_tasks[ANALYSIS]->setLogFileReadPath("$OSRCDIR/analysis.rpt");
+  m_tasks[SYNTHESIS]->setLogFileReadPath("$OSRCDIR/synthesis.rpt");
+  m_tasks[PACKING]->setLogFileReadPath("$OSRCDIR/packing.rpt");
+  m_tasks[GLOBAL_PLACEMENT]->setLogFileReadPath(
+      "$OSRCDIR/global_placement.rpt");
+  m_tasks[PLACEMENT]->setLogFileReadPath("$OSRCDIR/placement.rpt");
+  m_tasks[ROUTING]->setLogFileReadPath("$OSRCDIR/routing.rpt");
+  m_tasks[TIMING_SIGN_OFF]->setLogFileReadPath("$OSRCDIR/timing_analysis.rpt");
+  m_tasks[POWER]->setLogFileReadPath("$OSRCDIR/power_analysis.rpt");
+  m_tasks[BITSTREAM]->setLogFileReadPath("$OSRCDIR/bitstream.rpt");
+
   for (auto task = m_tasks.begin(); task != m_tasks.end(); task++) {
     connect((*task), &Task::statusChanged, this,
             &TaskManager::taskStateChanged);

--- a/src/Compiler/TaskTableView.h
+++ b/src/Compiler/TaskTableView.h
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace FOEDAG {
 
 class TaskManager;
-
+class Task;
 /*!
  * \brief The ChildItemDelegate class
  * Implements item that has parent and it looks similar like in the tree view.
@@ -64,9 +64,11 @@ class TaskTableView : public QTableView {
 
  signals:
   void TaskDialogRequested(const QString &category);
+  void ViewFileRequested(const QString &filePath);
 
  private:
   QRect expandArea(const QModelIndex &index) const;
+  void addTaskLogAction(QMenu *menu, Task *task);
 
  private:
   TaskManager *m_taskManager{nullptr};

--- a/src/Main/Tasks.cpp
+++ b/src/Main/Tasks.cpp
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Foedag.h"
 #include "Settings.h"
+#include "TextEditor/text_editor.h"
 #include "WidgetFactory.h"
 using namespace FOEDAG;
 
@@ -199,4 +200,10 @@ void FOEDAG::handleTaskDialogRequested(const QString& category) {
   if (dlg) {
     dlg->exec();
   }
+}
+
+void FOEDAG::handleViewFileRequested(const QString& filePath) {
+  QString path = filePath;
+  path.replace(PROJECT_OSRCDIR, Project::Instance()->projectPath());
+  TextEditorForm::Instance()->OpenFile(path);
 }

--- a/src/Main/Tasks.h
+++ b/src/Main/Tasks.h
@@ -28,6 +28,7 @@ namespace FOEDAG {
 
 QDialog* createTaskDialog(const QString& taskName);
 void handleTaskDialogRequested(const QString& category);
+void handleViewFileRequested(const QString& filePath);
 
 // Setters/Getters for tclArgs
 void TclArgs_setSynthesisOptions(const std::string& argsStr);


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: [GEMINIEDA-461]
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> - logs were output to the project dir w/ no ui interface besides Open File
> - Synthesis log was saved as <project_name>_synth.log
> - Packing, Placement, Routing, Timing Anaylsis, & Power Analysis task all logged into vpr_stdout.log
>
> ### What does this pull request change?
> - Task view context menu now has a "View <task> Log" option in the context menu
![image](https://user-images.githubusercontent.com/103447061/195462858-101f1914-db5c-4b0e-96d8-425b06b79328.png)
> - Logic has been added to disable the view log option if a log file doesn't exist
![image](https://user-images.githubusercontent.com/103447061/195462915-8611a68c-3b5e-4efb-b053-55c94ecf4672.png)
> - In Foedag
>   - all tasks log to a dummy file in the project dir, for example `<project_dir>/synthesis.rpt`
> - In Raptor
>   - Packing, Placement, Routing, Timing Anaylsis, & Power Analysis now have logic to copy their vpr_stdout.log results to `<task_name>.rpt`

> ### Note for Stakeholders
> - In Raptor, the following tasks don't seem to have log files currently. Please let me know if they exist and I will add them: IP Generate, Analysis, Global Placement, Bitstream

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: Compiler, Main
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Testing
> Manually tested in foedag and raptor
