### PR TITLE
[GEMINIEDA-464] Make device selection always visible

### DIFF
--- a/src/NewProject/device_planner_form.cpp
+++ b/src/NewProject/device_planner_form.cpp
@@ -94,14 +94,23 @@ void devicePlannerForm::updateUi(ProjectManager *pm) {
   auto family = pm->getSynthOption(PROJECT_PART_FAMILY);
   auto package = pm->getSynthOption(PROJECT_PART_PACKAGE);
 
-  if (series.isEmpty() || family.isEmpty() || package.isEmpty()) return;
-  // The order is important here since every combo depends on previous selection
-  ui->m_comboBoxSeries->setCurrentIndex(
-      ui->m_comboBoxSeries->findData(series, Qt::DisplayRole));
-  ui->m_comboBoxFamily->setCurrentIndex(
-      ui->m_comboBoxFamily->findData(family, Qt::DisplayRole));
-  ui->m_comboBoxPackage->setCurrentIndex(
-      ui->m_comboBoxPackage->findData(package, Qt::DisplayRole));
+  if (!series.isEmpty() && !family.isEmpty() && !package.isEmpty()) {
+    // The order is important here since every combo depends on previous
+    // selection
+    ui->m_comboBoxSeries->setCurrentIndex(
+        ui->m_comboBoxSeries->findData(series, Qt::DisplayRole));
+    ui->m_comboBoxFamily->setCurrentIndex(
+        ui->m_comboBoxFamily->findData(family, Qt::DisplayRole));
+    ui->m_comboBoxPackage->setCurrentIndex(
+        ui->m_comboBoxPackage->findData(package, Qt::DisplayRole));
+  }
+
+  auto device = pm->getSynthOption(PROJECT_PART_DEVICE);
+  auto items = m_model->findItems(device);
+  if (!items.isEmpty()) {
+    auto index = items.first()->index();
+    UpdateSelection(index);
+  }
 }
 
 void devicePlannerForm::onSeriestextChanged(const QString &arg1) {
@@ -196,4 +205,11 @@ void devicePlannerForm::UpdateDeviceTableView() {
 
     m_model->insertRow(rows, items);
   }
+  UpdateSelection(m_selectmodel->model()->index(0, 0));
+}
+
+void devicePlannerForm::UpdateSelection(const QModelIndex &index) {
+  m_selectmodel->select(index,
+                        QItemSelectionModel::SelectionFlag::ClearAndSelect |
+                            QItemSelectionModel::Rows);
 }

--- a/src/NewProject/device_planner_form.h
+++ b/src/NewProject/device_planner_form.h
@@ -39,6 +39,7 @@ class devicePlannerForm : public QWidget, public SettingsGuiInterface {
   void UpdateFamilyComboBox();
   void UpdatePackageComboBox();
   void UpdateDeviceTableView();
+  void UpdateSelection(const QModelIndex &index);
 };
 }  // namespace FOEDAG
 #endif  // DEVICEPLANNERFORM_H


### PR DESCRIPTION
### Motivate of the pull request
Make device selection always visible.

### Describe the technical details
User must see what actual device will be selected. So, there is always be selection of one of the device.

### Which part of the code base require a change
<!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
- [x] Library: newproject
- [ ] Plug-in: <Specify the plugin name>
- [ ] Engine
- [ ] Documentation
- [ ] Regression tests
- [ ] Continous Integration (CI) scripts