### PR TITLE
[GEMINIEDA-471] Add language mismatch check for compile units in new project / project settings

### DIFF
--- a/src/NewProject/new_project_dialog.cpp
+++ b/src/NewProject/new_project_dialog.cpp
@@ -192,25 +192,21 @@ void newProjectDialog::ResetToProjectSettings() {
 }
 
 // This will check the project wizard for potential conflicts
-// If an errStr is passed in, the found issues will be appended
-// to it.
-// This function is intended to grow as more potential conflicts
-// are discovered.
-bool newProjectDialog::ValuesValid(QString *errStr /*nullptr*/) const {
-  QString temp;
-  if (!errStr) {
-    errStr = &temp;
-  }
+// it will return an std::pair of a bool representing the validity of the
+// current values and a QString with any issues found. This function is intended
+// to grow as more potential conflicts are discovered.
+std::pair<bool, QString> newProjectDialog::ValuesValid() const {
+  QString errStr{};
 
   // Check for Language type mistmatches in Compile Units
   auto conflictKeys = FindCompileUnitConflicts();
   if (!conflictKeys.isEmpty()) {
-    *errStr += "The following Compile Units have a language mismatch: " +
-               conflictKeys.join(", ") +
-               "\nReturn to the Design Files tab to fix this.";
+    errStr += "The following Compile Units have a language mismatch: " +
+              conflictKeys.join(", ") +
+              "\nReturn to the Design Files tab to fix this.";
   }
 
-  return errStr->isEmpty();
+  return std::make_pair(errStr.isEmpty(), errStr);
 }
 
 QList<QString> newProjectDialog::FindCompileUnitConflicts() const {
@@ -245,8 +241,8 @@ QList<QString> newProjectDialog::FindCompileUnitConflicts() const {
 }
 
 void newProjectDialog::on_buttonBox_accepted() {
-  QString err;
-  if (!ValuesValid(&err)) {
+  auto [isValid, err] = ValuesValid();
+  if (!isValid) {
     QMessageBox::warning(this, "Project Settings Issue", err);
     return;
   }

--- a/src/NewProject/new_project_dialog.cpp
+++ b/src/NewProject/new_project_dialog.cpp
@@ -196,7 +196,7 @@ void newProjectDialog::ResetToProjectSettings() {
 // to it.
 // This function is intended to grow as more potential conflicts
 // are discovered.
-bool newProjectDialog::ValuesValid(QString *errStr /*nullptr*/) {
+bool newProjectDialog::ValuesValid(QString *errStr /*nullptr*/) const {
   QString temp;
   if (!errStr) {
     errStr = &temp;
@@ -213,7 +213,7 @@ bool newProjectDialog::ValuesValid(QString *errStr /*nullptr*/) {
   return errStr->isEmpty();
 }
 
-QList<QString> newProjectDialog::FindCompileUnitConflicts() {
+QList<QString> newProjectDialog::FindCompileUnitConflicts() const {
   // Group files by Compile Unit (m_groupName)
   QMap<QString, QList<filedata>> fileGroups{};
   for (const filedata &fdata : m_addSrcForm->getFileData()) {

--- a/src/NewProject/new_project_dialog.h
+++ b/src/NewProject/new_project_dialog.h
@@ -75,8 +75,8 @@ class newProjectDialog : public QDialog {
   void UpdateDialogView(Mode mode = NewProject);
   void ResetToNewProject();
   void ResetToProjectSettings();
-  bool ValuesValid(QString* errStr = nullptr);
-  QList<QString> FindCompileUnitConflicts();
+  bool ValuesValid(QString* errStr = nullptr) const;
+  QList<QString> FindCompileUnitConflicts() const;
 };
 }  // namespace FOEDAG
 #endif  // CREATEPROJECTDIALOG_H

--- a/src/NewProject/new_project_dialog.h
+++ b/src/NewProject/new_project_dialog.h
@@ -75,7 +75,7 @@ class newProjectDialog : public QDialog {
   void UpdateDialogView(Mode mode = NewProject);
   void ResetToNewProject();
   void ResetToProjectSettings();
-  bool ValuesValid(QString* errStr = nullptr) const;
+  std::pair<bool, QString> ValuesValid() const;
   QList<QString> FindCompileUnitConflicts() const;
 };
 }  // namespace FOEDAG

--- a/src/NewProject/new_project_dialog.h
+++ b/src/NewProject/new_project_dialog.h
@@ -75,6 +75,8 @@ class newProjectDialog : public QDialog {
   void UpdateDialogView(Mode mode = NewProject);
   void ResetToNewProject();
   void ResetToProjectSettings();
+  bool ValuesValid(QString* errStr = nullptr);
+  QList<QString> FindCompileUnitConflicts();
 };
 }  // namespace FOEDAG
 #endif  // CREATEPROJECTDIALOG_H


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: [GEMINIEDA-471]
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Error conditions were intentionally ignored
>
> #### What does this pull request change?
> We now check Compile Unit groups to ensure that each file has the same language type and alert the user with a message box if not:
![image](https://user-images.githubusercontent.com/103447061/195717732-4889dd39-bde2-4921-acb2-d2af90e2738a.png)


> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: NewProject
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Testing
> - Manually tested in foedag and raptor for new projects and edited projects.
