### PR TITLE
[GEMINIEDA-480] Save IP Instance info to project file

### DIFF
--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -329,6 +329,24 @@ void IPGenerator::RemoveIPInstance(IPInstance* instance) {
   if (it != m_instances.end()) {
     m_instances.erase(it);
   }
+
+  // search for stored configure/generate commands stored for this module and
+  // remove them
+  Compiler* compiler = GetCompiler();
+  ProjectManager* projManager = nullptr;
+  if (compiler && (projManager = compiler->ProjManager())) {
+    // match if the command contains "ipgenerate -modules <moduleName>"
+    std::string modName = "ipgenerate -modules " + instance->ModuleName();
+    auto isMatch = [modName](const std::string& ipGenStr) {
+      return (ipGenStr.find(modName) == std::string::npos);
+    };
+
+    // Remove any found matches
+    auto cmds = projManager->ipInstanceCmdList();
+    cmds.erase(std::remove_if(cmds.begin(), cmds.end(), isMatch), cmds.end());
+    // Store the updated instance list
+    projManager->setIpInstanceCmdList(cmds);
+  }
 }
 
 void IPGenerator::RemoveIPInstance(const std::string& moduleName) {

--- a/src/IpConfigurator/IpCatalogTree.h
+++ b/src/IpConfigurator/IpCatalogTree.h
@@ -31,12 +31,12 @@ class IpCatalogTree : public QTreeWidget {
  public:
   explicit IpCatalogTree(QWidget* parent = nullptr);
   void refresh();
+  static void loadIps(const std::vector<std::filesystem::path>& paths);
 
  private:
   QStringList prevIpCatalogResults;
 
   QStringList getAvailableIPs(const std::vector<std::filesystem::path>& paths);
-  void loadIps(const std::vector<std::filesystem::path>& paths);
 };
 
 }  // namespace FOEDAG

--- a/src/IpConfigurator/IpConfigWidget.h
+++ b/src/IpConfigurator/IpConfigWidget.h
@@ -47,7 +47,7 @@ class IpConfigWidget : public QWidget {
 
  private:
   void AddDialogControls(QBoxLayout* layout);
-  void AddIpToProject(const QString& ipBuildPath);
+  void AddIpToProject(const QString& cmd);
   void CreateParamFields();
   void CreateOutputFields();
   void updateMetaLabel(VLNV info);

--- a/src/IpConfigurator/IpConfigurator.cpp
+++ b/src/IpConfigurator/IpConfigurator.cpp
@@ -25,6 +25,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "IpConfigurator/IpConfigWidget.h"
 #include "IpConfigurator/IpTreesWidget.h"
 #include "MainWindow/Session.h"
+#include "NewProject/ProjectManager/project_manager.h"
+
+extern FOEDAG::Session* GlobalSession;
 
 using namespace FOEDAG;
 
@@ -78,6 +81,25 @@ void IpConfigurator::ShowConfigDlg() {
 
 QWidget* IpConfigurator::GetIpTreesWidget() {
   return IpTreesWidget::Instance();
+}
+
+void IpConfigurator::ReloadIps() {
+  FOEDAG::Compiler* compiler = nullptr;
+  ProjectManager* projManager = nullptr;
+  if (GlobalSession && (compiler = GlobalSession->GetCompiler()) &&
+      (projManager = compiler->ProjManager())) {
+    // Get Ip Configuration/Generate cmds from project file
+    QString projPath = projManager->getProjectPath();
+    auto cmds = projManager->ipInstanceCmdList();
+
+    // If the project path is valid and there are IP cmds
+    if (!projPath.isEmpty() && cmds.size() > 0) {
+      // Execute each configure/generate command
+      for (auto cmd : cmds) {
+        GlobalSession->TclInterp()->evalCmd(cmd);
+      }
+    }
+  }
 }
 
 void FOEDAG::registerIpConfiguratorCommands(QWidget* widget,

--- a/src/IpConfigurator/IpConfigurator.h
+++ b/src/IpConfigurator/IpConfigurator.h
@@ -35,6 +35,7 @@ class IpConfigurator : public QWidget {
   void HideIpTrees();
   void ShowConfigDlg();
   QWidget *GetIpTreesWidget();
+  static void ReloadIps();
 
  private:
 };

--- a/src/Main/ProjectFile/ProjectManagerComponent.cpp
+++ b/src/Main/ProjectFile/ProjectManagerComponent.cpp
@@ -44,6 +44,7 @@ constexpr auto PROJECT_GROUP_LIB_NAME{"LibName"};
 constexpr auto IP_CONFIG{"IpConfig"};
 constexpr auto IP_INSTANCE_PATHS{"InstancePaths"};
 constexpr auto IP_CATALOG_PATHS{"CatalogPaths"};
+constexpr auto IP_INSTANCE_CMDS{"InstanceCmds"};
 
 ProjectManagerComponent::ProjectManagerComponent(ProjectManager* pManager,
                                                  QObject* parent)
@@ -108,6 +109,10 @@ void ProjectManagerComponent::Save(QXmlStreamWriter* writer) {
   stream.writeStartElement(GENERIC_OPTION);
   stream.writeAttribute(GENERIC_NAME, IP_CATALOG_PATHS);
   stream.writeAttribute(GENERIC_VAL, m_projectManager->ipCatalogPaths());
+  stream.writeEndElement();
+  stream.writeStartElement(GENERIC_OPTION);
+  stream.writeAttribute(GENERIC_NAME, IP_INSTANCE_CMDS);
+  stream.writeAttribute(GENERIC_VAL, m_projectManager->ipInstanceCmds());
   stream.writeEndElement();
   stream.writeEndElement();
 
@@ -378,6 +383,19 @@ void ProjectManagerComponent::Load(QXmlStreamReader* r) {
               std::vector<std::string> pathList;
               StringUtils::tokenize(path.toStdString(), " ", pathList);
               m_projectManager->setIpCatalogPathList(pathList);
+            }
+            if (reader.attributes().value(GENERIC_NAME).toString() ==
+                IP_INSTANCE_CMDS) {
+              QString cmdsStr =
+                  reader.attributes().value(GENERIC_VAL).toString();
+              // Using QStringList for multi-char split() function
+              QStringList cmds = cmdsStr.split("_IP_CMD_SEP_");
+              // Convert to std::vector<std::string>
+              std::vector<std::string> cmdList;
+              for (auto cmd : cmds) {
+                cmdList.push_back(cmd.toStdString());
+              }
+              m_projectManager->setIpInstanceCmdList(cmdList);
             }
           }
         }

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -36,6 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "DesignRuns/runs_form.h"
 #include "IpConfigurator/IpCatalogTree.h"
 #include "IpConfigurator/IpConfigWidget.h"
+#include "IpConfigurator/IpConfigurator.h"
 #include "IpConfigurator/IpConfiguratorCreator.h"
 #include "Main/CompilerNotifier.h"
 #include "Main/Foedag.h"
@@ -134,6 +135,9 @@ MainWindow::MainWindow(Session* session)
   m_projectInfo = {"FOEDAG", foedag_version_number, foedag_git_hash,
                    "https://github.com/os-fpga/FOEDAG/commit/",
                    foedag_build_type};
+
+  connect(this, &MainWindow::projectOpened, this,
+          &MainWindow::handleProjectOpened);
 }
 
 void MainWindow::Tcl_NewProject(int argc, const char* argv[]) {
@@ -265,6 +269,7 @@ void MainWindow::cleanUpDockWidgets(std::vector<QDockWidget*>& dockWidgets) {
 void MainWindow::openProject(const QString& project) {
   ReShowWindow(project);
   loadFile(project);
+  emit projectOpened();
 }
 
 void MainWindow::saveToRecentSettings(const QString& project) {
@@ -938,6 +943,18 @@ void MainWindow::slotTabChanged(int index) {
   QString strName = TextEditorForm::Instance()->GetTabWidget()->tabText(index);
   SetWindowTitle((index == -1) ? QString() : strName,
                  m_projectManager->getProjectName(), m_projectInfo.name);
+}
+
+void MainWindow::handleProjectOpened() {
+  // this fires after openProject() has been fired
+
+  // Reloading IPs after full project load as during ReShowWindow, the project
+  // path variables haven't been updated yet
+  IpConfigurator::ReloadIps();
+  // Update tree to show new instances
+  updateSourceTree();
+  // Fix command prompt if any errors were printed during load
+  m_console->showPrompt();
 }
 
 void MainWindow::saveWelcomePageConfig() {

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -72,6 +72,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void recentProjectOpen();
   void openProjectSettings();
   void slotTabChanged(int index);
+  void handleProjectOpened();
 
  public slots:
   void updateSourceTree();
@@ -82,6 +83,9 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void handleRemoveIpRequested(const QString& moduleName);
   void handleDeleteIpRequested(const QString& moduleName);
   void resetIps();
+
+ signals:
+  void projectOpened();
 
  private: /* Menu bar builders */
   void updateViewMenu();

--- a/src/NewProject/ProjectManager/ip_configuration.cpp
+++ b/src/NewProject/ProjectManager/ip_configuration.cpp
@@ -48,4 +48,17 @@ void IpConfiguration::addInstancePath(const std::string &instancePath) {
   m_instancePathList.push_back(instancePath);
 }
 
+const std::vector<std::string> &IpConfiguration::instanceCmdList() const {
+  return m_instanceCmdList;
+}
+
+void IpConfiguration::setInstanceCmdList(
+    const std::vector<std::string> &newInstanceCmdList) {
+  m_instanceCmdList = newInstanceCmdList;
+}
+
+void IpConfiguration::addInstanceCmd(const std::string &instanceCmd) {
+  m_instanceCmdList.push_back(instanceCmd);
+}
+
 }  // namespace FOEDAG

--- a/src/NewProject/ProjectManager/ip_configuration.h
+++ b/src/NewProject/ProjectManager/ip_configuration.h
@@ -40,9 +40,15 @@ class IpConfiguration {
   void setInstancePathList(const std::vector<std::string> &newInstancePathList);
   void addInstancePath(const std::string &instancePath);
 
+  // Instance Paths
+  const std::vector<std::string> &instanceCmdList() const;
+  void setInstanceCmdList(const std::vector<std::string> &newInstanceCmdList);
+  void addInstanceCmd(const std::string &instanceCmd);
+
  private:
   std::vector<std::string> m_ipCatalogPathList;
   std::vector<std::string> m_instancePathList;
+  std::vector<std::string> m_instanceCmdList;
 };
 
 }  // namespace FOEDAG

--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -1587,6 +1587,28 @@ void ProjectManager::addIpInstancePath(const std::string& ipInstancePath) {
   Project::Instance()->ipConfig()->addInstancePath(ipInstancePath);
 }
 
+const std::vector<std::string>& ProjectManager::ipInstanceCmdList() const {
+  return Project::Instance()->ipConfig()->instanceCmdList();
+}
+
+QString ProjectManager::ipInstanceCmds() const {
+  auto cmdList = Project::Instance()->ipConfig()->instanceCmdList();
+  QStringList tmpList;
+  for (const auto& p : cmdList) tmpList.append(QString::fromStdString(p));
+  return tmpList.join("_IP_CMD_SEP_");
+}
+
+void ProjectManager::setIpInstanceCmdList(
+    const std::vector<std::string>& newIpInstanceCmdList) {
+  Project::Instance()->ipConfig()->setInstanceCmdList(newIpInstanceCmdList);
+  emit saveFile();
+};
+
+void ProjectManager::addIpInstanceCmd(const std::string& ipInstanceCmd) {
+  Project::Instance()->ipConfig()->addInstanceCmd(ipInstanceCmd);
+  emit saveFile();
+}
+
 int ProjectManager::CreateAndAddFile(const QString& suffix,
                                      const QString& filename,
                                      const QString& filenameAdd,

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -312,6 +312,12 @@ class ProjectManager : public QObject {
       const std::vector<std::string> &newIpInstancePathList);
   void addIpInstancePath(const std::string &ipInstancePath);
 
+  const std::vector<std::string> &ipInstanceCmdList() const;
+  QString ipInstanceCmds() const;
+  void setIpInstanceCmdList(
+      const std::vector<std::string> &newIpInstanceCmdList);
+  void addIpInstanceCmd(const std::string &ipInstanceCmd);
+
  private:
   // Please set currentfileset before using this function
   int setDesignFile(const QString &strFileName, bool isFileCopy = true,


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: [GEMINIEDA-480]
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Saving IP Instances was planned for december release and hadn't been written
>
> #### What does this pull request change?
> IP Instance config commands are now stored in the project so they can be re-configured at load time

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IpConfigurator, Main, MainWindow, NewProject
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Testing
> - Manually Tested in Foedag and Raptor