### PR TITLE
[RG-138] Introduce --project cmdline option to open a project directly at startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ test_install:
 
 test/gui: run-cmake-debug
 	$(XVFB) ./dbuild/bin/foedag --script tests/TestGui/compiler_flow.tcl
+	$(XVFB) ./dbuild/bin/foedag --replay tests/TestGui/open_project_test/open_project.tcl
 	$(XVFB) ./dbuild/bin/foedag --script tests/TestGui/compiler_flow_with_clean.tcl
 	$(XVFB) ./dbuild/bin/console_test --replay tests/TestGui/gui_console.tcl
 	$(XVFB) ./dbuild/bin/console_test --replay tests/TestGui/gui_console_negative_test.tcl && exit 1 || (echo "PASSED: Caught negative test")

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -1317,7 +1317,7 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       return TCL_ERROR;
     }
     qobject_cast<FOEDAG::MainWindow*>(mainWindow)
-        ->openProject(QString::fromStdString(expandedFile));
+        ->openProject(QString::fromStdString(expandedFile), false);
     return TCL_OK;
   };
   interp->registerCmd("open_project", open_project, this, nullptr);

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -51,6 +51,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Main/Settings.h"
 #include "Main/Tasks.h"
 #include "MainWindow/Session.h"
+#include "MainWindow/main_window.h"
 #include "NewProject/ProjectManager/project_manager.h"
 #include "ProjNavigator/tcl_command_integration.h"
 #include "TaskManager.h"
@@ -95,6 +96,7 @@ void Compiler::Help(std::ostream* out) {
   (*out) << "   --batch          : Tcl only, no GUI" << std::endl;
   (*out) << "   --replay <script>: Replay GUI test" << std::endl;
   (*out) << "   --script <script>: Execute a Tcl script" << std::endl;
+  (*out) << "   --project <project file>: Open a project" << std::endl;
   (*out) << "   --compiler <name>: Compiler name {openfpga...}, default is "
             "a dummy compiler"
          << std::endl;
@@ -102,6 +104,9 @@ void Compiler::Help(std::ostream* out) {
   (*out) << "Tcl commands:" << std::endl;
   (*out) << "   help                       : This help" << std::endl;
   (*out) << "   create_design <name>       : Creates a design with <name> name"
+         << std::endl;
+  (*out) << "   open_project <file>        : Opens a project in started "
+            "upfront GUI"
          << std::endl;
   (*out) << "   add_design_file <file list> ?type?   ?-work <libName>?  "
          << std::endl;
@@ -1281,6 +1286,41 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     return TCL_OK;
   };
   interp->registerCmd("architecture", architecture, nullptr, nullptr);
+
+  auto open_project = [](void* clientData, Tcl_Interp* interp, int argc,
+                         const char* argv[]) -> int {
+    Compiler* compiler = (Compiler*)clientData;
+    if (argc != 2) {
+      compiler->ErrorMessage("Specify a project file name");
+      return TCL_ERROR;
+    }
+    std::string file = argv[1];
+    std::string expandedFile = file;
+    bool use_orig_path = false;
+    if (FileUtils::FileExists(expandedFile)) {
+      use_orig_path = true;
+    }
+
+    if ((!use_orig_path) &&
+        (!compiler->GetSession()->CmdLine()->Script().empty())) {
+      std::filesystem::path script =
+          compiler->GetSession()->CmdLine()->Script();
+      std::filesystem::path scriptPath = script.parent_path();
+      std::filesystem::path fullPath = scriptPath;
+      fullPath.append(file);
+      expandedFile = fullPath.string();
+    }
+    auto mainWindow = compiler->GetSession()->MainWindow();
+    if (!mainWindow) {
+      compiler->ErrorMessage(
+          "Gui has to be started before calling 'open_project'");
+      return TCL_ERROR;
+    }
+    qobject_cast<FOEDAG::MainWindow*>(mainWindow)
+        ->openProject(QString::fromStdString(expandedFile));
+    return TCL_OK;
+  };
+  interp->registerCmd("open_project", open_project, this, nullptr);
   return true;
 }
 

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -83,6 +83,7 @@ void CompilerOpenFPGA::Help(std::ostream* out) {
   (*out) << "   --batch          : Tcl only, no GUI" << std::endl;
   (*out) << "   --replay <script>: Replay GUI test" << std::endl;
   (*out) << "   --script <script>: Execute a Tcl script" << std::endl;
+  (*out) << "   --project <project file>: Open a project" << std::endl;
   (*out) << "   --compiler <name>: Compiler name {openfpga...}, default is "
             "a dummy compiler"
          << std::endl;
@@ -91,6 +92,9 @@ void CompilerOpenFPGA::Help(std::ostream* out) {
   (*out) << "Tcl commands:" << std::endl;
   (*out) << "   help                       : This help" << std::endl;
   (*out) << "   create_design <name>       : Creates a design with <name> name"
+         << std::endl;
+  (*out) << "   open_project <file>        : Opens a project in started "
+            "upfront GUI"
          << std::endl;
   (*out) << "   target_device <name>       : Targets a device with <name> name"
          << std::endl;

--- a/src/Main/CommandLine.cpp
+++ b/src/Main/CommandLine.cpp
@@ -59,6 +59,8 @@ void CommandLine::processArgs() {
     } else if (token == "--verific") {
       m_useVerific = true;
     } else if (token == "--script") {
+      if (!m_projectFile.empty())
+        ErrorAndExit("--script and --project can't be used at the same time!");
       i++;
       if (i < m_argc) {
         m_runScript = m_argv[i];
@@ -67,6 +69,16 @@ void CommandLine::processArgs() {
         }
       } else
         ErrorAndExit("Specify a script file!");
+    } else if (token == "--project") {
+      if (!m_runScript.empty())
+        ErrorAndExit("--script and --project can't be used at the same time!");
+      i++;
+      if (i < m_argc) {
+        m_projectFile = m_argv[i];
+        if (!FileExists(m_projectFile))
+          ErrorAndExit("Cannot open project file: " + m_projectFile);
+      } else
+        ErrorAndExit("Specify a project file!");
     } else if (token == "--cmd") {
       i++;
       if (i < m_argc) {

--- a/src/Main/CommandLine.h
+++ b/src/Main/CommandLine.h
@@ -53,6 +53,8 @@ class CommandLine {
 
   const std::string& CompilerName() const { return m_compilerName; }
 
+  const std::string& ProjectFile() const { return m_projectFile; }
+
   bool UseVerific() { return m_useVerific; }
 
   bool PrintHelp() { return m_help; }
@@ -76,6 +78,7 @@ class CommandLine {
   std::string m_runGuiTest;
   std::string m_runTclCmd;
   std::string m_compilerName;
+  std::string m_projectFile;
   bool m_help = false;
   bool m_version = false;
   bool m_useVerific = false;

--- a/src/MainWindow/Session.cpp
+++ b/src/MainWindow/Session.cpp
@@ -47,7 +47,8 @@ void Session::windowShow() {
                             cmdLine->GuiTestScript().empty());
       }
       if (hasProjectFile) {
-        topLevel->openProject(QString::fromStdString(cmdLine->ProjectFile()));
+        topLevel->openProject(QString::fromStdString(cmdLine->ProjectFile()),
+                              true);
       } else if (hasScriptCmd) {
         int returnCode{TCL_OK};
         if (m_compiler) {

--- a/src/MainWindow/Session.cpp
+++ b/src/MainWindow/Session.cpp
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Compiler/TaskManager.h"
 #include "Main/TclSimpleParser.h"
-#include "TopLevelInterface.h"
+#include "main_window.h"
 
 using namespace FOEDAG;
 
@@ -38,36 +38,41 @@ void Session::windowShow() {
   switch (m_guiType) {
     case GUI_TYPE::GT_WIDGET: {
       m_mainWindow->show();
-      auto hasScriptCmd = !CmdLine()->Script().empty();
-      if (auto topLevel = dynamic_cast<TopLevelInterface *>(m_mainWindow)) {
-        topLevel->gui_start(!hasScriptCmd &&
-                            CmdLine()->GuiTestScript().empty());
+      const auto cmdLine = CmdLine();
+      auto hasScriptCmd = !cmdLine->Script().empty();
+      auto hasProjectFile = !cmdLine->ProjectFile().empty();
+      auto topLevel = dynamic_cast<FOEDAG::TopLevelInterface *>(m_mainWindow);
+      if (topLevel) {
+        topLevel->gui_start(!hasScriptCmd && !hasProjectFile &&
+                            cmdLine->GuiTestScript().empty());
       }
-      if (hasScriptCmd) {
+      if (hasProjectFile) {
+        topLevel->openProject(cmdLine->ProjectFile());
+      } else if (hasScriptCmd) {
         int returnCode{TCL_OK};
         if (m_compiler) {
           TclSimpleParser tclParser;
-          const auto &[res, msg] = tclParser.parse(CmdLine()->Script());
+          const auto &[res, msg] = tclParser.parse(cmdLine->Script());
           int counter{0};
           if (!res)
             m_compiler->ErrorMessage(msg);
           else
             counter = std::stoi(msg);
           m_compiler->GetTaskManager()->setTaskCount(counter);
-          if (auto m = dynamic_cast<TopLevelInterface *>(m_mainWindow)) {
-            m->ProgressVisible(true);
+          if (topLevel) {
+            topLevel->ProgressVisible(true);
           }
           m_compiler->start();
         }
-        auto result = TclInterp()->evalFile(CmdLine()->Script(), &returnCode);
+        auto result = TclInterp()->evalFile(cmdLine->Script(), &returnCode);
         if (m_compiler) {
           if (returnCode == TCL_OK)
             m_compiler->Message(result);
           else
             m_compiler->ErrorMessage(result);
           m_compiler->finish();
-          if (auto m = dynamic_cast<TopLevelInterface *>(m_mainWindow)) {
-            m->ProgressVisible(false);
+          if (topLevel) {
+            topLevel->ProgressVisible(false);
           }
         }
       }

--- a/src/MainWindow/Session.cpp
+++ b/src/MainWindow/Session.cpp
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Compiler/TaskManager.h"
 #include "Main/TclSimpleParser.h"
-#include "main_window.h"
+#include "TopLevelInterface.h"
 
 using namespace FOEDAG;
 
@@ -47,7 +47,7 @@ void Session::windowShow() {
                             cmdLine->GuiTestScript().empty());
       }
       if (hasProjectFile) {
-        topLevel->openProject(cmdLine->ProjectFile());
+        topLevel->openProject(QString::fromStdString(cmdLine->ProjectFile()));
       } else if (hasScriptCmd) {
         int returnCode{TCL_OK};
         if (m_compiler) {

--- a/src/MainWindow/TopLevelInterface.h
+++ b/src/MainWindow/TopLevelInterface.h
@@ -20,12 +20,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
 
+#include <string>
+
 namespace FOEDAG {
 
 class TopLevelInterface {
  public:
   virtual ~TopLevelInterface() = default;
   virtual void gui_start(bool showWP) = 0;
+  virtual void openProject(const std::string& projectFile) = 0;
   virtual void ProgressVisible(bool visible) = 0;
 };
 

--- a/src/MainWindow/TopLevelInterface.h
+++ b/src/MainWindow/TopLevelInterface.h
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <string>
+class QString;
 
 namespace FOEDAG {
 
@@ -28,7 +28,7 @@ class TopLevelInterface {
  public:
   virtual ~TopLevelInterface() = default;
   virtual void gui_start(bool showWP) = 0;
-  virtual void openProject(const std::string& projectFile) = 0;
+  virtual void openProject(const QString& projectFile) = 0;
   virtual void ProgressVisible(bool visible) = 0;
 };
 

--- a/src/MainWindow/TopLevelInterface.h
+++ b/src/MainWindow/TopLevelInterface.h
@@ -28,7 +28,9 @@ class TopLevelInterface {
  public:
   virtual ~TopLevelInterface() = default;
   virtual void gui_start(bool showWP) = 0;
-  virtual void openProject(const QString& projectFile) = 0;
+  // Delayed argument indicates whether project opening should be delayed.
+  // May be necessary to initialize UI first and open the project afterwards
+  virtual void openProject(const QString& projectFile, bool delayed) = 0;
   virtual void ProgressVisible(bool visible) = 0;
 };
 

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -306,10 +306,6 @@ void MainWindow::openProject(const QString& project) {
   emit projectOpened();
 }
 
-void MainWindow::openProject(const std::string& projectFile) {
-  openProject(QString::fromStdString(projectFile));
-}
-
 void MainWindow::saveToRecentSettings(const QString& project) {
   if (project.isEmpty()) return;
 

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -306,6 +306,10 @@ void MainWindow::openProject(const QString& project) {
   emit projectOpened();
 }
 
+void MainWindow::openProject(const std::string& projectFile) {
+  openProject(QString::fromStdString(projectFile));
+}
+
 void MainWindow::saveToRecentSettings(const QString& project) {
   if (project.isEmpty()) return;
 

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -106,8 +106,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
                           Qt::DockWidgetArea area = Qt::BottomDockWidgetArea);
 
   void cleanUpDockWidgets(std::vector<QDockWidget*>& dockWidgets);
-  void openProject(const QString& project);
-  void openProject(const std::string& projectFile) override;
+  void openProject(const QString& project) override;
   void saveToRecentSettings(const QString& project);
 
   void showMenus(bool show);

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -107,6 +107,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
 
   void cleanUpDockWidgets(std::vector<QDockWidget*>& dockWidgets);
   void openProject(const QString& project);
+  void openProject(const std::string& projectFile) override;
   void saveToRecentSettings(const QString& project);
 
   void showMenus(bool show);

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -52,6 +52,8 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void CloseOpenedTabs();
   void ProgressVisible(bool visible) override;
 
+  void openProject(const QString& project) override;
+
  protected:
   void closeEvent(QCloseEvent* event) override;
 
@@ -106,7 +108,6 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
                           Qt::DockWidgetArea area = Qt::BottomDockWidgetArea);
 
   void cleanUpDockWidgets(std::vector<QDockWidget*>& dockWidgets);
-  void openProject(const QString& project) override;
   void saveToRecentSettings(const QString& project);
 
   void showMenus(bool show);

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -52,7 +52,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void CloseOpenedTabs();
   void ProgressVisible(bool visible) override;
 
-  void openProject(const QString& project) override;
+  void openProject(const QString& project, bool delayed) override;
 
  protected:
   void closeEvent(QCloseEvent* event) override;
@@ -75,6 +75,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void openProjectSettings();
   void slotTabChanged(int index);
   void handleProjectOpened();
+  void onOpenProjectRequested(const QString& project);
 
  public slots:
   void updateSourceTree();
@@ -88,6 +89,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
 
  signals:
   void projectOpened();
+  void openProjectRequested(const QString& project);
 
  private: /* Menu bar builders */
   void updateViewMenu();

--- a/tests/TestGui/open_project_test/open_project.tcl
+++ b/tests/TestGui/open_project_test/open_project.tcl
@@ -1,0 +1,21 @@
+#Copyright 2021 The Foedag team
+
+#GPL License
+
+#Copyright (c) 2021 The Open-Source FPGA Foundation
+
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+puts "OPENING PROJECT"; flush stdout ; open_project test.ospr
+puts "PROJECT OPENED"; flush stdout ; exit

--- a/tests/TestGui/open_project_test/test.ospr
+++ b/tests/TestGui/open_project_test/test.ospr
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--                                                   -->
+<!--Copyright (c) 2021-2022 The Open-Source FPGA Foundation.-->
+<Project Version="0.0.35">
+    <Configuration>
+        <Option Name="ID" Val="20221021164400034"/>
+        <Option Name="ActiveSimSet" Val="sim_1"/>
+        <Option Name="Project Type" Val="RTL"/>
+    </Configuration>
+    <CompilerConfig>
+        <Opt Name="LibPath" Val=""/>
+        <Opt Name="IncludePath" Val=""/>
+        <Opt Name="LibExt" Val=""/>
+        <Opt Name="Macro" Val="P1=10 P2=20"/>
+    </CompilerConfig>
+    <IpConfig>
+        <Option Name="InstancePaths" Val=""/>
+        <Option Name="CatalogPaths" Val=""/>
+        <Option Name="InstanceCmds" Val=""/>
+    </IpConfig>
+    <FileSets>
+        <FileSet Name="constrs_1" Type="Constrs" RelSrcDir="/test.srcs/constrs_1"/>
+        <FileSet Name="sim_1" Type="SimulationSrcs" RelSrcDir="/test.srcs/sim_1"/>
+        <FileSet Name="sources_1" Type="DesignSrcs" RelSrcDir="/test.srcs/sources_1">
+            <File Path="$OSRCDIR/test.srcs/sources_1/test.v"/>
+            <File Path="$OSRCDIR/test.srcs/sources_1/bottom.v"/>
+            <Group Id="11" Name="unit_0" Files="$OSRCDIR/test.srcs/sources_1/test.v $OSRCDIR/test.srcs/sources_1/bottom.v" LibCommand="" LibName=""/>
+            <Config>
+                <Option Name="TopModule" Val="top"/>
+                <Option Name="TopModuleLib" Val=""/>
+            </Config>
+        </FileSet>
+    </FileSets>
+    <Runs>
+        <Run Name="imple_1" Type="Implementation" SrcSet="sources_1" ConstrsSet="constrs_1" State="current" SynthRun="synth_1"/>
+        <Run Name="synth_1" Type="Synthesis" SrcSet="sources_1" ConstrsSet="constrs_1" State="current" SynthRun="">
+            <Option Name="Compilation Flow" Val="Classic Flow"/>
+            <Option Name="LanguageVersion" Val="SYSTEMVERILOG_2005"/>
+            <Option Name="TargetLanguage" Val="VERILOG"/>
+        </Run>
+    </Runs>
+    <Tasks Version="0.0.0">
+        <Task ID="0" Status="0"/>
+        <Task ID="1" Status="0"/>
+        <Task ID="4" Status="0"/>
+        <Task ID="5" Status="0"/>
+        <Task ID="6" Status="0"/>
+        <Task ID="8" Status="0"/>
+        <Task ID="10" Status="0"/>
+        <Task ID="13" Status="0"/>
+        <Task ID="14" Status="0"/>
+        <Task ID="15" Status="0"/>
+        <Task ID="18" Status="0"/>
+        <Task ID="19" Status="0"/>
+        <Task ID="20" Status="0"/>
+        <Task ID="21" Status="0"/>
+        <Task ID="23" Status="0"/>
+    </Tasks>
+    <Compiler Version="0.0.0" CompilerState="7"/>
+</Project>

--- a/tests/TestGui/open_project_test/test.srcs/sources_1/bottom.v
+++ b/tests/TestGui/open_project_test/test.srcs/sources_1/bottom.v
@@ -1,0 +1,3 @@
+module bottom (input logic [`P1:0] a, output logic [`P1:0] b);
+assign b = a;
+endmodule

--- a/tests/TestGui/open_project_test/test.srcs/sources_1/test.v
+++ b/tests/TestGui/open_project_test/test.srcs/sources_1/test.v
@@ -1,0 +1,7 @@
+`include "def.vh"
+module top(input logic [`P2:0] a, output logic [`P2:0] b);
+   bottom bot (a, b);
+   
+   
+endmodule // top
+


### PR DESCRIPTION
> ### Motivate of the pull request
This PR fulfills RG-138 and introduces new '--project' cmdline option.

> ### Describe the technical details
Command line arguments parsing has been extended with '--project' option. In case it's used together with '--script', an error is given and startup fails.
>
> #### What does this pull request change?
'--project' allows setting a project file (*.ospr) in the cmdline and corresponding gets opened after startup. As if the application was started without any cmdline options and Open Project action for indicated project was executed.

Tested on FOEDAG and Raptor:
![image](https://user-images.githubusercontent.com/109239890/196527478-d2b4b81c-c704-40d6-940e-a99f6c761e5a.png)


> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [+] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts
