### PR TITLE
[RG-100] Add "--gen_post_synthesis_netlist on" to Route VPR command

### DIFF
--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -1784,7 +1784,8 @@ bool CompilerOpenFPGA::Route() {
     return true;
   }
 
-  std::string command = BaseVprCommand() + " --route";
+  std::string command =
+      BaseVprCommand() + " --route --gen_post_synthesis_netlist on";
   std::ofstream ofs((std::filesystem::path(ProjManager()->projectPath()) /
                      std::string(ProjManager()->projectName() + "_route.cmd"))
                         .string());


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: [RG-100]
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> - Per comments in [GEMINIEDA-392], "--gen_post_synthesis_netlist on" was originally on by default, but got removed at some point
>
> #### What does this pull request change?
> - "--gen_post_synthesis_netlist on" has been added to CompilerOpenFPGA::Route()'s VPR command

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: Compiler
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Testing
> - Verified in Raptor with Tao's comment in [GEMINIEDA-392], ran `./build/bin/raptor --batch --mute --script tests/Testcases/and2_testcase/raptor.tcl` and confirmed that `and2_post_synthesis.blif` was in the "and2" project folder.
