### PR TITLE
Fix extra # in console prompt when opening a project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -389,7 +389,7 @@ jobs:
         setup-python: false
 
     - name: Use ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2.3
       with:
         key: macos-gcc
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -389,7 +389,7 @@ jobs:
         setup-python: false
 
     - name: Use ccache
-      uses: hendrikmuhs/ccache-action@v1.2.3
+      uses: hendrikmuhs/ccache-action@v1
       with:
         key: macos-gcc
 

--- a/src/IpConfigurator/IpConfigurator.cpp
+++ b/src/IpConfigurator/IpConfigurator.cpp
@@ -96,7 +96,7 @@ void IpConfigurator::ReloadIps() {
     if (!projPath.isEmpty() && cmds.size() > 0) {
       // Execute each configure/generate command
       for (auto cmd : cmds) {
-        GlobalSession->TclInterp()->evalCmd(cmd);
+        GlobalSession->CmdStack()->push_and_exec(new Command(cmd));
       }
     }
   }

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -996,8 +996,6 @@ void MainWindow::handleProjectOpened() {
   IpConfigurator::ReloadIps();
   // Update tree to show new instances
   updateSourceTree();
-  // Fix command prompt if any errors were printed during load
-  m_console->showPrompt();
 }
 
 void MainWindow::saveWelcomePageConfig() {


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.
> - [x] Fix regression in gui caused by https://github.com/os-fpga/FOEDAG/pull/745

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> showPrompt() was called on the console after a project load to fix the console if any errors printed when executing tcl w/ GlobalSession->TclInterp()->evalCmd(), but if there were no errors, the the console printed two prompts indicators:
![image](https://user-images.githubusercontent.com/103447061/196781388-0f34dfa3-226a-47bc-b533-d1e581e26340.png)

>
> #### What does this pull request change?
> Switched to GlobalSession->CmdStack()->push_and_exec() which doesn't break the console on error and removed the now unnecessary showPrompt() command.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IpConfigurator, MainWindow
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Testing
> - Manually tested in foedag and raptor
