### PR TITLE
Updating GitHub CI actions (OLD)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,16 +27,16 @@ jobs:
     steps:
 
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4.3.0
       with:
         python-version: 3.8
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
         bash .github/workflows/install_ubuntu_dependencies_build.sh
 
     - name: Use ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2.3
       with:
         key: linux-${{ matrix.mode }}
 
@@ -98,7 +98,7 @@ jobs:
     - name: Upload coverage
       # will show up under https://app.codecov.io/gh/os-fpga/FOEDAG
       if: matrix.mode == 'coverage'
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: coverage-build/foedag.coverage
         fail_ci_if_error: false
@@ -113,7 +113,7 @@ jobs:
 
     - name: Archive regression artifacts
       if: matrix.mode == 'regression' && always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       with:
         name: foedag-linux-gcc-regression
         path: |
@@ -142,18 +142,18 @@ jobs:
     steps:
 
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
 
     - name: Download workflow artifact
       if: matrix.mode == 'test'
-      uses: dawidd6/action-download-artifact@v2.17.0
+      uses: dawidd6/action-download-artifact@v2.24.0
       with:
         workflow: main.yml
         repo: ${{ github.repository }}
@@ -170,7 +170,7 @@ jobs:
 
     - name: Archive QT build artifacts
       if: matrix.mode == 'test'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       with:
         name: buildqt5-centos7-gcc
         path: buildqt5-centos7-gcc.tgz
@@ -210,12 +210,12 @@ jobs:
     steps:
 
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0
@@ -277,13 +277,13 @@ jobs:
     steps:
 
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 
 # Fix Cmake version, 3.21.4 has a bug that prevents Tcl to build
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.9
+      uses: jwlawson/actions-setup-cmake@v1.13.0
       with:
         cmake-version: '3.21.3'
     - name: Use cmake
@@ -295,18 +295,18 @@ jobs:
         choco install -y swig --side-by-side --version=3.0.12
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: 3.8
         architecture: x64
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3.0.0
 
     - run: git config --global core.autocrlf input
       shell: bash
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0
@@ -348,14 +348,14 @@ jobs:
         make test/batch
 
     - name: Archive build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       with:
         name: foedag-windows-msvc
         path: ${{ github.workspace }}/install
 
     - name: Archive regression artifacts
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       with:
         name: foedag-windows-msvc-regression
         path: |
@@ -370,33 +370,33 @@ jobs:
     steps:
 
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4.3.0
       with:
         python-version: 3.8
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0
 
     - name: Install dependencies
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3.0.0
       with:
         setup-python: false
 
     - name: Use ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2.3
       with:
         key: macos-gcc
 
     - name: Configure shell
       run: |
-        echo 'CC=gcc-9' >> $GITHUB_ENV
-        echo 'CXX=g++-9' >> $GITHUB_ENV
+        echo 'CC=gcc-11' >> $GITHUB_ENV
+        echo 'CXX=g++-11' >> $GITHUB_ENV
         echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
         echo 'PREFIX=${GITHUB_WORKSPACE}/install' >> $GITHUB_ENV
 
@@ -431,26 +431,26 @@ jobs:
     steps:
 
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4.3.0
       with:
         python-version: 3.8
 
     - name: Install dependencies
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3.0.0
       with:
         setup-python: false
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0
 
     - name: Use ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2.3
       with:
         key: macos-clang
 
@@ -492,7 +492,7 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -511,12 +511,12 @@ jobs:
     steps:
 
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.8.0
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0
@@ -530,7 +530,7 @@ jobs:
                                 qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools qtdeclarative5-dev xvfb
 
     - name: Use ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2.3
       with:
         key: clang-tidy-codegen
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,7 +150,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        submodules: true
+        submodules: recursive
+        fetch-depth: 0
 
     - name: Download workflow artifact
       if: matrix.mode == 'test'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,6 +141,11 @@ jobs:
       MODE: ${{ matrix.mode }}
 
     steps:
+    - name: update Git
+      run: |
+        yum remove -y git*
+        yum install -y https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
+        yum install -y git
 
     - name: Cancel previous
       uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
         echo 'CXX=g++-9' >> $GITHUB_ENV
         echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
         echo 'PREFIX=/tmp/foedag-install' >> $GITHUB_ENV
+        echo "$PREFIX" >> $GITHUB_PATH
         echo "ADDITIONAL_CMAKE_OPTIONS='-DMY_CXX_WARNING_FLAGS="-W -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Werror -UNDEBUG"'" >> $GITHUB_ENV
         echo 'RULE_MESSAGES=off' >> $GITHUB_ENV
 
@@ -189,6 +190,7 @@ jobs:
         echo 'CXX=/opt/rh/devtoolset-9/root/usr/bin/g++' >> $GITHUB_ENV
         echo 'PATH=/usr/local/Qt-5.15.0/bin:/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
         echo 'PREFIX=/tmp/foedag-install' >> $GITHUB_ENV
+        echo "$PREFIX" >> $GITHUB_PATH
         echo "ADDITIONAL_CMAKE_OPTIONS='-DMY_CXX_WARNING_FLAGS="-W -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Werror -UNDEBUG"'" >> $GITHUB_ENV
         echo 'RULE_MESSAGES=off' >> $GITHUB_ENV
 
@@ -399,6 +401,7 @@ jobs:
         echo 'CXX=g++-11' >> $GITHUB_ENV
         echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
         echo 'PREFIX=${GITHUB_WORKSPACE}/install' >> $GITHUB_ENV
+        echo "$PREFIX" >> $GITHUB_PATH
 
     - name: Show shell configuration
       run: |
@@ -458,6 +461,7 @@ jobs:
       run: |
         echo 'PREFIX=${GITHUB_WORKSPACE}/install' >> $GITHUB_ENV
         echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
+        echo "$PREFIX" >> $GITHUB_PATH
 
     - name: Install XQuartz on macOS
       run: brew install xquartz --cask

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -397,8 +397,8 @@ jobs:
 
     - name: Configure shell
       run: |
-        echo 'CC=gcc-11' >> $GITHUB_ENV
-        echo 'CXX=g++-11' >> $GITHUB_ENV
+        echo 'CC=gcc-9' >> $GITHUB_ENV
+        echo 'CXX=g++-9' >> $GITHUB_ENV
         echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
         echo 'PREFIX=${GITHUB_WORKSPACE}/install' >> $GITHUB_ENV
         echo "$PREFIX" >> $GITHUB_PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,6 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        fetch-depth: 0
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
### NOTE
This is currently failing w/ CI issues. This was formerly a CI to update the macos-gcc build to gcc11, but that has been split into a separate PR to allow for debugging of the CI updates in this PR.
Changes from raptor PR#368 were copied for this PR, but they seem to introduce new errors into the build:
The test target now fails w/ the follow error:
```
Run actions/checkout@v3
  with:
    submodules: recursive
    fetch-depth: 0
    repository: os-fpga/FOEDAG
    token: ***
    ssh-strict: true
    persist-credentials: true
    clean: true
    lfs: false
    set-safe-directory: true
  env:
    MODE: test
/usr/bin/docker exec  69fa977a60fd90be83cbd431f4ceeb4b[2](https://github.com/os-fpga/FOEDAG/actions/runs/3299640281/jobs/5443242666#step:4:2)f6cc55e01a4577d22e4bb9892cc0[3](https://github.com/os-fpga/FOEDAG/actions/runs/3299640281/jobs/5443242666#step:4:3)a1 sh -c "cat /etc/*release | grep ^ID"
Syncing repository: os-fpga/FOEDAG
Getting Git version info
  Working directory is '/__w/FOEDAG/FOEDAG'
Deleting the contents of '/__w/FOEDAG/FOEDAG'
The repository will be downloaded using the GitHub REST API
To create a local Git repository instead, add Git 2.1[8](https://github.com/os-fpga/FOEDAG/actions/runs/3299640281/jobs/5443242666#step:4:8) or higher to the PATH
Error: Input 'submodules' not supported when falling back to download using the GitHub REST API. To create a local Git repository instead, add Git 2.[18](https://github.com/os-fpga/FOEDAG/actions/runs/3299640281/jobs/5443242666#step:4:20) or higher to the PATH.
```
Raptor doesn't use 'submodules' in their action, but foedag fails with a googletest error if it's removed here.
I tried updating the submodule command from `submodules: true` to `submodules: recursive` followed by `fetch-depth: 0` to make the other checkout actions, but that didn't help. Seems curious that only this target would be failing in checkout so maybe there is a path issue earlier in this target's setup? Not sure how to update the github version in the path like the error suggests.  
The windows target now fails with the following error:
```
swig v3.0.12 [Approved]
swig package files install completed. Performing other installation steps.
Downloading swig 64 bit
  from 'https://sourceforge.net/projects/swig/files/swigwin/swigwin-3.0.12/swigwin-3.0.12.zip/download'
ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://sourceforge.net/projects/swig/files/swigwin/swigwin-3.0.12/swigwin-3.0.12.zip/download'. Exception calling "GetResponse" with "0" argument(s): "The request was aborted: Could not create SSL/TLS secure channel." 
This package is likely not broken for licensed users - see https://docs.chocolatey.org/en-us/features/private-cdn.
The install of swig was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\swig.3.0.12\tools\chocolateyinstall.ps1'.
 See log for details.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - swig (exited 404) - Error while running 'C:\ProgramData\chocolatey\lib\swig.3.0.12\tools\chocolateyinstall.ps1'.
 See log for details.
Error: Process completed with exit code 404.
```

> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.
> - [x] update GitHub CI actions

> #### What does this pull request change?
> - Copies action updates made in raptor PR#368

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [x] Continous Integration (CI) scripts
