### PR TITLE
update macos-gcc to gcc-11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -395,8 +395,8 @@ jobs:
 
     - name: Configure shell
       run: |
-        echo 'CC=gcc-9' >> $GITHUB_ENV
-        echo 'CXX=g++-9' >> $GITHUB_ENV
+        echo 'CC=gcc-11' >> $GITHUB_ENV
+        echo 'CXX=g++-11' >> $GITHUB_ENV
         echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
         echo 'PREFIX=${GITHUB_WORKSPACE}/install' >> $GITHUB_ENV
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -395,6 +395,11 @@ jobs:
 
     - name: Configure shell
       run: |
+        # Default xcode version 14.0.1 has reported bugs with linker
+        # Current recommended workaround is to downgrade to last known good version.
+        # https://github.com/actions/runner-images/issues/6350
+        sudo xcode-select -s '/Applications/Xcode_13.4.1.app/Contents/Developer'
+        
         echo 'CC=gcc-11' >> $GITHUB_ENV
         echo 'CXX=g++-11' >> $GITHUB_ENV
         echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.
> - [x] macos-gcc target started failing after mac latest updated
>   - Mac 12 removed gcc9

> #### What does this pull request change?
> - Updates macos-gcc target to use gcc-11
> - Downgrades mac CLT to 13.4.1 to avoid a known linker assertion https://github.com/actions/runner-images/issues/6350

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [x] Continous Integration (CI) scripts
