### PR TITLE
Add logic to delete cached json when deleting ip

### DIFF
--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -518,7 +518,7 @@ std::filesystem::path IPGenerator::GetCachePath(IPInstance* instance) const {
 
   ProjectManager* projManager = nullptr;
   if (m_compiler && (projManager = m_compiler->ProjManager())) {
-    std::string projectPath = m_compiler->ProjManager()->projectPath();
+    std::string projectPath = projManager->projectPath();
     auto def = instance->Definition();
     std::string ip_config_file =
         def->Name() + "_" + instance->ModuleName() + ".json";

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -407,15 +407,15 @@ bool IPGenerator::Generate() {
       }
       case IPDefinition::IPType::LiteXGenerator: {
         const std::filesystem::path executable = def->FilePath();
-        std::filesystem::path jasonfile = GetCachePath(inst);
+        std::filesystem::path jsonFile = GetCachePath(inst);
         std::stringstream previousbuffer;
-        if (FileUtils::FileExists(jasonfile)) {
-          std::ifstream previous(jasonfile);
+        if (FileUtils::FileExists(jsonFile)) {
+          std::ifstream previous(jsonFile);
           std::stringstream buffer;
           previousbuffer << previous.rdbuf();
         }
 
-        std::ofstream jsonF(jasonfile);
+        std::ofstream jsonF(jsonFile);
         jsonF << "{" << std::endl;
         for (auto param : inst->Parameters()) {
           std::string value;
@@ -437,14 +437,14 @@ bool IPGenerator::Generate() {
         jsonF << "   \"build_name\": " << inst->OutputFile().filename() << ","
               << std::endl;
         jsonF << "   \"build\": true," << std::endl;
-        jsonF << "   \"json\": \"" << jasonfile.filename().string() << "\","
+        jsonF << "   \"json\": \"" << jsonFile.filename().string() << "\","
               << std::endl;
         jsonF << "   \"json_template\": false" << std::endl;
         jsonF << "}" << std::endl;
         jsonF.close();
         std::stringstream newbuffer;
-        if (FileUtils::FileExists(jasonfile)) {
-          std::ifstream newfile(jasonfile);
+        if (FileUtils::FileExists(jsonFile)) {
+          std::ifstream newfile(jsonFile);
           std::stringstream buffer;
           newbuffer << newfile.rdbuf();
         }
@@ -471,7 +471,7 @@ bool IPGenerator::Generate() {
         }
 
         std::string command = pythonPath.string() + " " + executable.string() +
-                              " --build --json " + jasonfile.string();
+                              " --build --json " + jsonFile.string();
         std::ostringstream help;
 
         if (newbuffer.str() == previousbuffer.str()) {

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -498,14 +498,13 @@ bool IPGenerator::Generate() {
 std::filesystem::path IPGenerator::GetBuildDir(IPInstance* instance) const {
   std::filesystem::path dir{};
 
-  Compiler* compiler = GlobalSession->GetCompiler();
   auto meta = FOEDAG::getIpInfoFromPath(instance->Definition()->FilePath());
-  if (compiler) {
-    QString projName = compiler->ProjManager()->getProjectName();
+  ProjectManager* projManager = nullptr;
+  if (m_compiler && (projManager = m_compiler->ProjManager())) {
+    QString projName = projManager->getProjectName();
 
     // Build up the expected ip build path
-    std::filesystem::path baseDir(
-        compiler->ProjManager()->getProjectPath().toStdString());
+    std::filesystem::path baseDir(projManager->getProjectPath().toStdString());
     std::string projIpDir = projName.toStdString() + ".IPs";
     dir = baseDir / projIpDir / meta.vendor / meta.library / meta.name /
           meta.version / instance->ModuleName();
@@ -517,11 +516,9 @@ std::filesystem::path IPGenerator::GetBuildDir(IPInstance* instance) const {
 std::filesystem::path IPGenerator::GetCachePath(IPInstance* instance) const {
   std::filesystem::path dir{};
 
-  Compiler* compiler = GlobalSession->GetCompiler();
-
   ProjectManager* projManager = nullptr;
-  if (compiler && (projManager = compiler->ProjManager())) {
-    std::string projectPath = compiler->ProjManager()->projectPath();
+  if (m_compiler && (projManager = m_compiler->ProjManager())) {
+    std::string projectPath = m_compiler->ProjManager()->projectPath();
     auto def = instance->Definition();
     std::string ip_config_file =
         def->Name() + "_" + instance->ModuleName() + ".json";

--- a/src/IPGenerate/IPGenerator.h
+++ b/src/IPGenerate/IPGenerator.h
@@ -56,6 +56,7 @@ class IPGenerator {
   }
   bool Generate();
   std::filesystem::path GetBuildDir(IPInstance* instance) const;
+  std::filesystem::path GetCachePath(IPInstance* instance) const;
 
  protected:
   IPCatalog* m_catalog = nullptr;


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.
> - [x] Fixing an oversite in previous implementation

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> - When deleting an ip from the UI w/ r-click > Delete IP, the ip build files were removed, but the cached .json file wasn't which would result in a failure to generate the actual ip files the next time someone tried to generate that IP again.
>
> #### What does this pull request change?
> - Abstracted the logic for determining the cached json path
> - Added logic to delete the cached json file when an IP is requested to be deleted from the UI.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: IPGenerate
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
> - [x] None

> ### Testing
> - Manually tested in Foedag and Raptor
