### PR TITLE
[RG-158] Add star to the tab name of pin planner views when modified by user.

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -830,7 +830,15 @@ void MainWindow::updatePRViewButton(int state) {
 }
 
 void MainWindow::saveActionTriggered() {
-  if (saveConstraintFile()) saveAction->setEnabled(false);
+  if (saveConstraintFile()) {
+    saveAction->setEnabled(false);
+    for (auto& dock : m_pinAssignmentDocks) {
+      if (dock->windowTitle().endsWith("*")) {
+        dock->setWindowTitle(
+            dock->windowTitle().mid(0, dock->windowTitle().size() - 1));
+      }
+    }
+  }
 }
 
 void MainWindow::pinAssignmentActionTriggered() {
@@ -849,8 +857,8 @@ void MainWindow::pinAssignmentActionTriggered() {
 
     PinAssignmentCreator* creator = new PinAssignmentCreator{
         m_projectManager, GlobalSession->Context(), m_compiler, this};
-    connect(creator, &PinAssignmentCreator::selectionHasChanged, this,
-            [this]() { saveAction->setEnabled(true); });
+    connect(creator, &PinAssignmentCreator::changed, this,
+            &MainWindow::pinAssignmentChanged);
 
     auto portsDockWidget = PrepareTab(tr("IO Ports"), "portswidget",
                                       creator->GetPortsWidget(), m_dockConsole);
@@ -888,6 +896,15 @@ void MainWindow::pinAssignmentActionTriggered() {
     auto pinAssignment = findChild<PinAssignmentCreator*>();
     if (pinAssignment) delete pinAssignment;
   }
+}
+
+void MainWindow::pinAssignmentChanged() {
+  for (auto& dock : m_pinAssignmentDocks) {
+    if (!dock->windowTitle().endsWith("*")) {
+      dock->setWindowTitle(dock->windowTitle() + "*");
+    }
+  }
+  saveAction->setEnabled(true);
 }
 
 void MainWindow::ipConfiguratorActionTriggered() {

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -69,6 +69,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void updatePRViewButton(int state);
   void saveActionTriggered();
   void pinAssignmentActionTriggered();
+  void pinAssignmentChanged();
   void ipConfiguratorActionTriggered();
   void newDialogAccepted();
   void recentProjectOpen();

--- a/src/PinAssignment/PinAssignmentCreator.cpp
+++ b/src/PinAssignment/PinAssignmentCreator.cpp
@@ -58,12 +58,12 @@ PinAssignmentCreator::PinAssignmentCreator(ProjectManager *projectManager,
 
   auto portsView = new PortsView(m_baseModel);
   connect(portsView, &PortsView::selectionHasChanged, this,
-          &PinAssignmentCreator::selectionHasChanged);
+          &PinAssignmentCreator::changed);
   m_portsView = CreateLayoutedWidget(portsView);
 
   auto packagePins = new PackagePinsView(m_baseModel);
   connect(packagePins, &PackagePinsView::selectionHasChanged, this,
-          &PinAssignmentCreator::selectionHasChanged);
+          &PinAssignmentCreator::changed);
   m_packagePinsView = CreateLayoutedWidget(packagePins);
   if (c && c->getConstraints()) {
     auto constraint = c->getConstraints();

--- a/src/PinAssignment/PinAssignmentCreator.h
+++ b/src/PinAssignment/PinAssignmentCreator.h
@@ -49,7 +49,7 @@ class PinAssignmentCreator : public QObject {
   static void RegisterLoader(const QString &device, PackagePinsLoader *l);
 
  signals:
-  void selectionHasChanged();
+  void changed();
 
  private:
   QWidget *CreateLayoutedWidget(QWidget *main);


### PR DESCRIPTION
### Motivate of the pull request
Improve usability. Show better indication for pin planner modification. 

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/199259033-28613f4b-c138-4986-bc64-471572724136.png)
