### PR TITLE
[RG-156] Add support *.pin constraint file for pin planner

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -26,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Compiler/Compiler.h"
 #include "Compiler/CompilerDefines.h"
+#include "Compiler/Constraints.h"
 #include "Compiler/TaskManager.h"
 #include "Console/DummyParser.h"
 #include "Console/StreamBuffer.h"
@@ -375,21 +376,22 @@ void MainWindow::saveToRecentSettings(const QString& project) {
 
 bool MainWindow::saveConstraintFile() {
   auto pinAssignment = findChild<PinAssignmentCreator*>();
-  auto constrFiles = m_projectManager->getConstrFiles();
-  if (constrFiles.empty()) {
-    auto form = findChild<SourcesForm*>();
-    form->CreateConstraint();
+  auto constrFile = m_projectManager->getConstrPinFile();
+  if (constrFile.empty()) {
+    newProjdialog->Reset(Mode::ProjectSettings);
+    newProjdialog->SetPageActive(FormIndex::INDEX_ADDCONST);
+    newProjdialog->exec();
   }
-  constrFiles = m_projectManager->getConstrFiles();
-  if (constrFiles.empty()) {
-    QMessageBox::warning(this, "No constraint file...",
-                         "Please create constraint file.");
+  constrFile = m_projectManager->getConstrPinFile();
+  if (constrFile.empty()) {
+    QMessageBox::warning(this, "No *.pin constraint file...",
+                         "Please create *.pin constraint file.");
     return false;
   }
   bool rewrite = false;
-  auto constraint{constrFiles[0].c_str()};
-  QFile file{constraint};  // TODO @volodymyrk, need to fix issue
-                           // with target constraint
+  auto constraint = QString::fromStdString(constrFile);
+  QFile file{constraint};  // TODO @volodymyrk, need to fix
+                           // issue with target constraint
   QFile::OpenMode openFlags = QFile::ReadWrite;
   if (file.size() != 0) {
     auto btns = QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel;
@@ -408,18 +410,10 @@ bool MainWindow::saveConstraintFile() {
   QString sdc{pinAssignment->generateSdc()};
   if (rewrite)
     file.resize(0);  // clean content
-  else if (!sdc.isEmpty())
+  else if (!sdc.isEmpty() && file.size() != 0)
     sdc.push_front('\n');  // make sure start with new line
   file.write(sdc.toLatin1());
   file.close();
-
-  auto res{FOEDAG::read_sdc(constraint)};
-
-  if (res != TCL_OK) {
-    // TODO @volodymyrk backlog,logging improve
-    std::cerr << "Read sdc file" << constraint << "failed!" << std::endl;
-  }
-
   return true;
 }
 
@@ -904,10 +898,16 @@ void MainWindow::pinAssignmentActionTriggered() {
       }
     }
 
-    const QString target =
-        QString::fromStdString(m_projectManager->getTargetDevice());
-    PinAssignmentCreator* creator = new PinAssignmentCreator{
-        m_projectManager, GlobalSession->Context(), m_compiler, target, this};
+    PinAssignmentData data;
+    data.context = GlobalSession->Context();
+    data.projectPath = m_projectManager->getProjectPath();
+    data.target = QString::fromStdString(m_projectManager->getTargetDevice());
+    QFile file{QString::fromStdString(m_projectManager->getConstrPinFile())};
+    if (file.open(QFile::ReadOnly)) {
+      data.commands = QString{file.readAll()}.split('\n');
+    }
+
+    PinAssignmentCreator* creator = new PinAssignmentCreator{data, this};
     connect(creator, &PinAssignmentCreator::changed, this,
             &MainWindow::pinAssignmentChanged);
 

--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -911,6 +911,16 @@ std::vector<std::string> ProjectManager::getConstrFiles() const {
   return files;
 }
 
+std::string ProjectManager::getConstrPinFile() const {
+  const Suffixes pin{{"pin"}};
+  auto constraints = getConstrFiles();
+  for (const auto& c : constraints) {
+    const QFileInfo info{QString::fromStdString(c)};
+    if (pin.TestSuffix(info.suffix())) return c;
+  }
+  return std::string{};
+}
+
 int ProjectManager::setSimulationFileSet(const QString& strSetName) {
   int ret = 0;
   ret = CreateSrcsFolder(strSetName);
@@ -1620,7 +1630,9 @@ int ProjectManager::CreateAndAddFile(const QString& suffix,
     ret = CreateSystemVerilogFile(filename);
   } else if (!suffix.compare("vhd", Qt::CaseInsensitive)) {
     ret = CreateVHDLFile(filename);
-  } else if (!suffix.compare("SDC", Qt::CaseInsensitive)) {
+  } else if (!suffix.compare("sdc", Qt::CaseInsensitive)) {
+    ret = CreateSDCFile(filename);
+  } else if (!suffix.compare("pin", Qt::CaseInsensitive)) {
     ret = CreateSDCFile(filename);
   }
   if (0 == ret) {

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -220,6 +220,7 @@ class ProjectManager : public QObject {
   QStringList getConstrFiles(const QString &strFileSet) const;
   QString getConstrTargetFile(const QString &strFileSet) const;
   std::vector<std::string> getConstrFiles() const;
+  std::string getConstrPinFile() const;
 
   int setSimulationFileSet(const QString &strSetName);
   QStringList getSimulationFileSets() const;
@@ -346,7 +347,7 @@ class ProjectManager : public QObject {
   QString m_currentRun;
   inline static const Suffixes m_designSuffixes{
       {"v", "sv", "vh", "svh", "vhd", "blif", "eblif"}};
-  inline static const Suffixes m_constrSuffixes{{"SDC", "PIN"}};
+  inline static const Suffixes m_constrSuffixes{{"sdc", "pin"}};
   inline static const Suffixes m_simSuffixes{{"v"}};
 
  signals:

--- a/src/NewProject/create_file_dialog.cpp
+++ b/src/NewProject/create_file_dialog.cpp
@@ -49,7 +49,8 @@ void createFileDialog::initialDialog(int type) {
     ui->m_labelDetailed->setText(
         tr("Create a new Constraints file and add it to your project."));
     ui->m_comboxFileType->clear();
-    ui->m_comboxFileType->addItem(tr("SDC"));
+    ui->m_comboxFileType->addItem(tr("sdc"));
+    ui->m_comboxFileType->addItem(tr("pin"));
   }
   // ui->m_comboxFileType->setStyleSheet("border: 1px solid gray;");
 }
@@ -81,16 +82,9 @@ void createFileDialog::on_m_pushBtnOK_clicked() {
     }
     fdata.m_language = FromFileType(fdata.m_fileType);
   } else if (GT_CONSTRAINTS == m_type) {
-    switch (ui->m_comboxFileType->currentIndex()) {
-      case 0:
-        fdata.m_fileName = ui->m_lineEditFileName->text() + QString(".SDC");
-        fdata.m_fileType = QString("SDC");
-        break;
-      case 1:
-        break;
-      default:
-        break;
-    }
+    auto ext = ui->m_comboxFileType->currentText();
+    fdata.m_fileName = ui->m_lineEditFileName->text() + QString(".%1").arg(ext);
+    fdata.m_fileType = ext;
   }
 
   fdata.m_filePath = ui->m_comboxFileLocation->currentText();

--- a/src/NewProject/new_project_dialog.cpp
+++ b/src/NewProject/new_project_dialog.cpp
@@ -103,6 +103,14 @@ void newProjectDialog::Reset(Mode mode) {
 
 Mode newProjectDialog::GetMode() const { return m_mode; }
 
+void newProjectDialog::SetPageActive(FormIndex index) {
+  if (m_tabIndexes.contains(index)) {
+    ui->m_tabWidget->setCurrentIndex(m_tabIndexes.value(index));
+  } else {
+    ui->m_tabWidget->setCurrentIndex(static_cast<int>(index));
+  }
+}
+
 void newProjectDialog::UpdateDialogView(Mode mode) {
   if (INDEX_LOCATION == m_index) {
     BackBtn->setEnabled(false);
@@ -168,16 +176,20 @@ void newProjectDialog::ResetToProjectSettings() {
   m_addSrcForm = new addSourceForm(this);
   m_addSrcForm->SetTitle("Design Files");
   m_settings.append(m_addSrcForm);
-  ui->m_tabWidget->insertTab(INDEX_ADDSOURC, m_addSrcForm, tr("Design Files"));
+  auto index = ui->m_tabWidget->insertTab(INDEX_ADDSOURC, m_addSrcForm,
+                                          tr("Design Files"));
+  m_tabIndexes.insert(INDEX_ADDSOURC, index);
   m_addConstrsForm = new addConstraintsForm(this);
   m_addConstrsForm->SetTitle("Design Constraints");
   m_settings.append(m_addConstrsForm);
-  ui->m_tabWidget->insertTab(INDEX_ADDCONST, m_addConstrsForm,
-                             tr("Design Constraints"));
+  index = ui->m_tabWidget->insertTab(INDEX_ADDCONST, m_addConstrsForm,
+                                     tr("Design Constraints"));
+  m_tabIndexes.insert(INDEX_ADDCONST, index);
   m_devicePlanForm = new devicePlannerForm(this);
   m_settings.append(m_devicePlanForm);
-  ui->m_tabWidget->insertTab(INDEX_DEVICEPL, m_devicePlanForm,
-                             tr("Select Target Device"));
+  index = ui->m_tabWidget->insertTab(INDEX_DEVICEPL, m_devicePlanForm,
+                                     tr("Select Target Device"));
+  m_tabIndexes.insert(INDEX_DEVICEPL, index);
 
   for (auto &settings : m_settings) settings->updateUi(m_projectManager);
 

--- a/src/NewProject/new_project_dialog.h
+++ b/src/NewProject/new_project_dialog.h
@@ -48,6 +48,7 @@ class newProjectDialog : public QDialog {
   QString getProject();
   void Reset(Mode mode = NewProject);
   Mode GetMode() const;
+  void SetPageActive(FormIndex index);
 
  private slots:
 
@@ -69,6 +70,7 @@ class newProjectDialog : public QDialog {
   summaryForm* m_sumForm;
   Mode m_mode{NewProject};
   QVector<SettingsGuiInterface*> m_settings;
+  QMap<FormIndex, int> m_tabIndexes;
 
   ProjectManager* m_projectManager;
   bool m_skipSources{false};

--- a/src/NewProject/source_grid.h
+++ b/src/NewProject/source_grid.h
@@ -39,6 +39,7 @@ class sourceGrid : public QWidget {
   void currentFileSet(const QString &fileSet);
   void selectRow(int row);
   void ClearTable();
+  bool isPinFileAdded() const;
 
  public slots:
   void AddFiles();
@@ -49,6 +50,7 @@ class sourceGrid : public QWidget {
   void DownTableItem();
   void TableViewSelectionChanged();
 
+  void CreateNewFile(FOEDAG::filedata fdata);
   void AddTableItem(FOEDAG::filedata fdata);
 
  private slots:
@@ -77,6 +79,7 @@ class sourceGrid : public QWidget {
   void MoveTableRow(int from, int to);
   bool IsFileDataExit(filedata fdata);
   static QComboBox *CreateLanguageCombo();
+  bool CheckPinFileExists(const QString &suffix);
 };
 }  // namespace FOEDAG
 

--- a/src/PinAssignment/PinAssignmentCreator.h
+++ b/src/PinAssignment/PinAssignmentCreator.h
@@ -25,18 +25,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FOEDAG {
 
-class ProjectManager;
 class ToolContext;
 class PinsBaseModel;
-class Compiler;
 class PackagePinsLoader;
-class Constraints;
 class PortsLoader;
+
+struct PinAssignmentData {
+  ToolContext *context{nullptr};
+  QString target{};
+  QStringList commands{};
+  QString projectPath{};
+};
+
 class PinAssignmentCreator : public QObject {
   Q_OBJECT
  public:
-  PinAssignmentCreator(ProjectManager *projectManager, ToolContext *context,
-                       Compiler *c, const QString &target = QString{},
+  PinAssignmentCreator(const PinAssignmentData &data,
                        QObject *parent = nullptr);
   QWidget *GetPackagePinsWidget();
   QWidget *GetPortsWidget();
@@ -63,7 +67,8 @@ class PinAssignmentCreator : public QObject {
   QString packagePinHeaderFile(ToolContext *context) const;
   PackagePinsLoader *FindPackagePinLoader(const QString &targetDevice) const;
   PortsLoader *FindPortsLoader(const QString &targetDevice) const;
-  static void parseConstraints(Constraints *c, class PackagePinsView *ppView,
+  static void parseConstraints(const QStringList &commands,
+                               class PackagePinsView *packagePins,
                                class PortsView *portsView);
 
  private:

--- a/src/PinAssignment/Test/PinAssignment_main.cpp
+++ b/src/PinAssignment/Test/PinAssignment_main.cpp
@@ -29,9 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "tclutils/TclUtils.h"
 
 QWidget* PinAssignmentBuilder(FOEDAG::Session* session) {
-  FOEDAG::PinAssignmentCreator* creator = new FOEDAG::PinAssignmentCreator{
-      session->GetCompiler()->ProjManager(), session->Context(),
-      session->GetCompiler()};
+  auto projectManager{session->GetCompiler()->ProjManager()};
+  FOEDAG::PinAssignmentData data{
+      session->Context(), {}, {}, projectManager->getProjectPath()};
+  FOEDAG::PinAssignmentCreator* creator =
+      new FOEDAG::PinAssignmentCreator{data};
   QWidget* w = new QWidget;
   w->setLayout(new QHBoxLayout);
   w->layout()->addWidget(creator->GetPackagePinsWidget());

--- a/src/ProjNavigator/tcl_command_integration.cpp
+++ b/src/ProjNavigator/tcl_command_integration.cpp
@@ -198,6 +198,16 @@ bool TclCommandIntegration::TclAddConstrFiles(const QString &file,
 
   const QString strSetName = m_projManager->getConstrActiveFileSet();
   m_projManager->setCurrentFileSet(strSetName);
+
+  const QFileInfo info{file};
+  if ((info.suffix().compare("pin", Qt::CaseInsensitive) == 0) &&
+      !m_projManager->getConstrPinFile().empty()) {
+    out << "*.pin constraint file has already added. Only one *.pin file "
+           "supported"
+        << std::endl;
+    return false;
+  }
+
   const int ret = m_projManager->addConstrsFile(file, false, false);
 
   if (ProjectManager::EC_Success != ret) {


### PR DESCRIPTION
### Motivate of the pull request
Add support for constraint *.pin file. Pin planner now works only with this file.
Only one *.pin file supported

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore, newproject
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/199510018-7571a469-7fb5-4d25-a12e-90f55cdfc0f1.png)
![image](https://user-images.githubusercontent.com/95262932/199510090-9e968eb3-ddf8-4c41-b66a-5dc14e619537.png)
![image](https://user-images.githubusercontent.com/95262932/199510194-6dc936c6-67c2-42ed-a5e4-54b428135953.png)
![image](https://user-images.githubusercontent.com/95262932/200288719-cf04b1d7-26ec-4f56-9920-c9f9fa1604ad.png)

