### PR TITLE
[RG-154] Add file tracking for files opened in editor

### DIFF
--- a/src/TextEditor/editor.h
+++ b/src/TextEditor/editor.h
@@ -4,6 +4,7 @@
 #include <QApplication>
 #include <QFile>
 #include <QFileInfo>
+#include <QFileSystemWatcher>
 #include <QObject>
 #include <QTextStream>
 #include <QToolBar>
@@ -32,6 +33,7 @@ class Editor : public QWidget {
 
   QString getFileName() const;
   bool isModified() const;
+  void SetFileWatcher(QFileSystemWatcher* watcher);
 
   void FindFirst(const QString& strWord);
   void FindNext(const QString& strWord);
@@ -40,6 +42,7 @@ class Editor : public QWidget {
   void ReplaceAll(const QString& strFind, const QString& strDesWord);
   void markLine(int line);
   void clearMarkers();
+  void reload();
 
  signals:
   void EditorModificationChanged(bool m);
@@ -85,6 +88,7 @@ class Editor : public QWidget {
   void SetScintillaText(QString strFileName);
 
   void UpdateToolBarStates();
+  QFileSystemWatcher* m_fileWatcher{nullptr};
 };
 
 }  // namespace FOEDAG

--- a/src/TextEditor/text_editor_form.cpp
+++ b/src/TextEditor/text_editor_form.cpp
@@ -45,6 +45,9 @@ void TextEditorForm::InitForm() {
           SLOT(SlotReplaceAll(QString, QString)));
 
   initForm = true;
+
+  connect(&m_fileWatcher, &QFileSystemWatcher::fileChanged, this,
+          &TextEditorForm::fileModifiedOnDisk);
 }
 
 int TextEditorForm::OpenFile(const QString &strFileName) {
@@ -90,6 +93,8 @@ int TextEditorForm::OpenFile(const QString &strFileName) {
   pair.first = index;
   pair.second = editor;
   m_map_file_tabIndex_editor.insert(strFileName, pair);
+  m_fileWatcher.addPath(strFileName);
+  editor->SetFileWatcher(&m_fileWatcher);
 
   return ret;
 }
@@ -128,6 +133,7 @@ void TextEditorForm::SlotTabCloseRequested(int index) {
   auto iter = m_map_file_tabIndex_editor.find(tabItem->getFileName());
   if (iter != m_map_file_tabIndex_editor.end()) {
     m_map_file_tabIndex_editor.erase(iter);
+    m_fileWatcher.removePath(iter.key());
   }
   // Removes the tab at position index from this stack of widgets.
   // The page widget itself is not deleted.
@@ -145,12 +151,14 @@ void TextEditorForm::SlotCurrentChanged(int index) {
 }
 
 void TextEditorForm::SlotUpdateTabTitle(bool m) {
-  int index = m_tab_editor->currentIndex();
-  QString strName = m_tab_editor->tabText(index);
-  if (m) {
-    m_tab_editor->setTabText(index, strName + tr("*"));
-  } else {
-    m_tab_editor->setTabText(index, strName.left(strName.lastIndexOf("*")));
+  int index = m_tab_editor->indexOf(qobject_cast<Editor *>(sender()));
+  if (index != -1) {
+    QString strName = m_tab_editor->tabText(index);
+    if (m) {
+      m_tab_editor->setTabText(index, strName + tr("*"));
+    } else {
+      m_tab_editor->setTabText(index, strName.left(strName.lastIndexOf("*")));
+    }
   }
 }
 
@@ -194,5 +202,26 @@ void TextEditorForm::SlotReplaceAll(const QString &strFindWord,
   Editor *tabEditor = (Editor *)m_tab_editor->currentWidget();
   if (tabEditor) {
     tabEditor->ReplaceAll(strFindWord, strDesWord);
+  }
+}
+
+void TextEditorForm::fileModifiedOnDisk(const QString &path) {
+  auto editorPair = m_map_file_tabIndex_editor.value(path, {0, nullptr});
+  auto editor{editorPair.second};
+  if (editor) {
+    // Here we need add path again since file descriptor might be closed by
+    // other application and file watcher doesn't track this file anymore. If
+    // path has already added - nothing happened.
+    m_fileWatcher.addPath(path);
+    if (editor->isModified()) {
+      const QFileInfo info{path};
+      auto res = QMessageBox::question(
+          this, "File changed",
+          QString{
+              "The file %1 has been changed on disk. Do you want to reload it?"}
+              .arg(info.fileName()));
+      if (res == QMessageBox::No) return;
+    }
+    editor->reload();
   }
 }

--- a/src/TextEditor/text_editor_form.h
+++ b/src/TextEditor/text_editor_form.h
@@ -1,6 +1,7 @@
 #ifndef TEXT_EDITOR_FORM_H
 #define TEXT_EDITOR_FORM_H
 
+#include <QFileSystemWatcher>
 #include <QTabWidget>
 #include <QWidget>
 
@@ -37,12 +38,14 @@ class TextEditorForm : public QWidget {
   void SlotReplaceAndFind(const QString &strFindWord,
                           const QString &strDesWord);
   void SlotReplaceAll(const QString &strFindWord, const QString &strDesWord);
+  void fileModifiedOnDisk(const QString &path);
 
  private:
   QTabWidget *m_tab_editor;
   QMap<QString, QPair<int, Editor *>> m_map_file_tabIndex_editor;
 
   SearchDialog *m_searchDialog;
+  QFileSystemWatcher m_fileWatcher;
 };
 }  // namespace FOEDAG
 #endif  // TEXT_EDITOR_FORM_H


### PR DESCRIPTION
### Motivate of the pull request
Update files opened in editor, when they changed on disk. If file is in modified state - ask user if need to reload.

### Which part of the code base require a change
<!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
- [x] Library: texteditor
- [ ] Plug-in: <Specify the plugin name>
- [ ] Engine
- [ ] Documentation
- [ ] Regression tests
- [ ] Continous Integration (CI) scripts

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/199746177-ce293c0f-d6dc-4b1b-b23c-fcc167ec4a80.png)
