### PR TITLE
Fixed wrong file type when file extension is in upper case

### DIFF
--- a/src/Compiler/CompilerDefines.cpp
+++ b/src/Compiler/CompilerDefines.cpp
@@ -31,6 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "TaskManager.h"
 #include "TaskModel.h"
 #include "TaskTableView.h"
+#include "Utils/QtUtils.h"
 
 extern FOEDAG::Session *GlobalSession;
 
@@ -121,9 +122,11 @@ uint FOEDAG::toTaskId(int action, const Compiler *const compiler) {
 }
 
 FOEDAG::Design::Language FOEDAG::FromFileType(const QString &type) {
-  if (type == "v") return Design::Language::VERILOG_2001;
-  if (type == "sv") return Design::Language::SYSTEMVERILOG_2017;
-  if (type == "vhd") return Design::Language::VHDL_2008;
+  if (QtUtils::IsEqual(type, "v")) return Design::Language::VERILOG_2001;
+  if (QtUtils::IsEqual(type, "sv")) return Design::Language::SYSTEMVERILOG_2017;
+  if (QtUtils::IsEqual(type, "vhd")) return Design::Language::VHDL_2008;
+  if (QtUtils::IsEqual(type, "blif")) return Design::Language::BLIF;
+  if (QtUtils::IsEqual(type, "eblif")) return Design::Language::EBLIF;
   return Design::Language::VERILOG_2001;  // default
 }
 

--- a/src/Utils/QtUtils.cpp
+++ b/src/Utils/QtUtils.cpp
@@ -30,4 +30,8 @@ QStringList QtUtils::StringSplit(const QString &str, const QChar &sep) {
 #endif
 }
 
+bool QtUtils::IsEqual(const QString &str, const QString &s) {
+  return str.compare(s, Qt::CaseInsensitive) == 0;
+}
+
 }  // namespace FOEDAG

--- a/src/Utils/QtUtils.h
+++ b/src/Utils/QtUtils.h
@@ -28,6 +28,9 @@ class QtUtils {
  public:
   // no empty parts
   static QStringList StringSplit(const QString &str, const QChar &sep);
+
+  // return true if str is equal to s with Qt::CaseInsensitive
+  static bool IsEqual(const QString &str, const QString &s);
 };
 
 }  // namespace FOEDAG

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -39,6 +39,7 @@ set (CPP_LIST
     Utils/QtUtils_test.cpp
     PinAssignment/TestLoader.cpp
     PinAssignment/TestPortsLoader.cpp
+    Compiler/CompilerDefines_test.cpp
 )
 set (H_LIST
     PinAssignment/TestLoader.h

--- a/tests/unittest/Compiler/CompilerDefines_test.cpp
+++ b/tests/unittest/Compiler/CompilerDefines_test.cpp
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "Compiler/CompilerDefines.h"
+
+#include "gtest/gtest.h"
+using namespace FOEDAG;
+using namespace Design;
+
+TEST(CompilerDefines, FromFileType) {
+  EXPECT_EQ(FromFileType("v"), Language::VERILOG_2001);
+  EXPECT_EQ(FromFileType("V"), Language::VERILOG_2001);
+  EXPECT_EQ(FromFileType("sv"), Language::SYSTEMVERILOG_2017);
+  EXPECT_EQ(FromFileType("SV"), Language::SYSTEMVERILOG_2017);
+  EXPECT_EQ(FromFileType("sV"), Language::SYSTEMVERILOG_2017);
+  EXPECT_EQ(FromFileType("vhd"), Language::VHDL_2008);
+  EXPECT_EQ(FromFileType("VHD"), Language::VHDL_2008);
+  EXPECT_EQ(FromFileType("vhD"), Language::VHDL_2008);
+  EXPECT_EQ(FromFileType("blif"), Language::BLIF);
+  EXPECT_EQ(FromFileType("BLIF"), Language::BLIF);
+  EXPECT_EQ(FromFileType("bLIf"), Language::BLIF);
+  EXPECT_EQ(FromFileType("eblif"), Language::EBLIF);
+  EXPECT_EQ(FromFileType("EBLIF"), Language::EBLIF);
+  EXPECT_EQ(FromFileType("EbLIf"), Language::EBLIF);
+
+  // default
+  EXPECT_EQ(FromFileType("anything"), Language::VERILOG_2001);
+}

--- a/tests/unittest/Utils/QtUtils_test.cpp
+++ b/tests/unittest/Utils/QtUtils_test.cpp
@@ -35,3 +35,14 @@ TEST(QtUtils, SplitStringSkipEmpty) {
   auto expect = QStringList{{"test", "test"}};
   EXPECT_EQ(QtUtils::StringSplit(test, ' '), expect);
 }
+
+TEST(QtUtils, IsEqual) {
+  const QString test{"test"};
+  EXPECT_EQ(QtUtils::IsEqual(test, "test"), true);
+  EXPECT_EQ(QtUtils::IsEqual(test, "TEST"), true);
+  EXPECT_EQ(QtUtils::IsEqual(test, "TesT"), true);
+  EXPECT_EQ(QtUtils::IsEqual(test, "tESt"), true);
+  EXPECT_EQ(QtUtils::IsEqual(test, "tes"), false);
+  EXPECT_EQ(QtUtils::IsEqual(test, "t"), false);
+  EXPECT_EQ(QtUtils::IsEqual(test, "any"), false);
+}


### PR DESCRIPTION
### Motivate of the pull request
When user add files we detect wrong file type in case file extension is in upper case.

### Which part of the code base require a change
<!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
- [x] Library: compiler
- [ ] Plug-in: <Specify the plugin name>
- [ ] Engine
- [ ] Documentation
- [x] Regression tests
- [ ] Continous Integration (CI) scripts

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/203295880-7bc60dc3-16a0-4a8d-8688-9f2f90390b59.png)
