### PR TITLE
[RG-159] Allow refresh pin planner tables after *.pin file was changed on the disk

### DIFF
--- a/src/Main/Tasks.cpp
+++ b/src/Main/Tasks.cpp
@@ -28,8 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Compiler/Reports/ITaskReport.h"
 #include "Compiler/Reports/ITaskReportManager.h"
 #include "Foedag.h"
-#include "Settings.h"
-#include "TextEditor/text_editor.h"
+#include "TextEditor/text_editor_form.h"
 #include "WidgetFactory.h"
 
 using namespace FOEDAG;

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -84,6 +84,8 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void onShowStopMessage(bool showStopCompilationMsg);
   void onShowLicenses();
   void stopCompilation();
+  void fileModified(const QString& file);
+  void refreshPinPlanner();
 
  public slots:
   void updateSourceTree();
@@ -116,7 +118,8 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void loadFile(const QString& file);
   QDockWidget* PrepareTab(const QString& name, const QString& objName,
                           QWidget* widget, QDockWidget* tabToAdd,
-                          Qt::DockWidgetArea area = Qt::BottomDockWidgetArea);
+                          Qt::DockWidgetArea area = Qt::BottomDockWidgetArea,
+                          bool refreshButton = false);
 
   void cleanUpDockWidgets(std::vector<QDockWidget*>& dockWidgets);
   void saveToRecentSettings(const QString& project);
@@ -136,6 +139,8 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void replaceIpConfigDockWidget(QWidget* widget);
   bool confirmCloseProject();
   bool confirmExitProgram();
+  void setVisibleRefreshButtons(bool visible);
+  void pinPlannerSaved();
 
  private: /* Objects/Widgets under the main window */
   /* Enum holding different states of actions visibility on the welcome page.
@@ -204,6 +209,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   QSettings m_settings;
   bool m_progressVisible{false};
   bool m_askStopCompilation{true};
+  bool m_blockRefereshEn{false};
 };
 
 }  // namespace FOEDAG

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -118,8 +118,9 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void loadFile(const QString& file);
   QDockWidget* PrepareTab(const QString& name, const QString& objName,
                           QWidget* widget, QDockWidget* tabToAdd,
-                          Qt::DockWidgetArea area = Qt::BottomDockWidgetArea,
-                          bool refreshButton = false);
+                          Qt::DockWidgetArea area = Qt::BottomDockWidgetArea);
+
+  void addPinPlannerRefreshButton(QDockWidget* dock);
 
   void cleanUpDockWidgets(std::vector<QDockWidget*>& dockWidgets);
   void saveToRecentSettings(const QString& project);

--- a/src/PinAssignment/PackagePinsView.cpp
+++ b/src/PinAssignment/PackagePinsView.cpp
@@ -58,6 +58,7 @@ PackagePinsView::PackagePinsView(PinsBaseModel *model, QWidget *parent)
     for (auto &p : pins) {
       uint col = PortsCol + 1;
       QTreeWidgetItem *pinItem = new QTreeWidgetItem(bank);
+      m_pinItems.append(pinItem);
       insertData(p.data, PinName, NameCol, pinItem);
       insertData(p.data, RefClock, col++, pinItem);
       insertData(p.data, Bank, col++, pinItem);
@@ -151,6 +152,18 @@ void PackagePinsView::SetPort(const QString &pin, const QString &port,
     auto combo = qobject_cast<BufferedComboBox *>(
         itemWidget(itemFromIndex(index), PortsCol));
     if (combo) combo->setCurrentIndex(combo->findData(port, Qt::DisplayRole));
+  }
+}
+
+void PackagePinsView::cleanTable() {
+  for (auto it{m_allCombo.cbegin()}; it != m_allCombo.cend(); it++) {
+    it.key()->setCurrentIndex(0);
+  }
+  for (const auto &item : m_pinItems) {
+    while (item->childCount() != 0) {
+      auto child = item->child(0);
+      removeItem(item, child);
+    }
   }
 }
 

--- a/src/PinAssignment/PackagePinsView.h
+++ b/src/PinAssignment/PackagePinsView.h
@@ -34,6 +34,7 @@ class PackagePinsView : public PinAssignmentBaseView {
   void SetMode(const QString &pin, const QString &mode);
   void SetInternalPin(const QString &port, const QString &intPin);
   void SetPort(const QString &pin, const QString &port, int row);
+  void cleanTable();
 
  signals:
   void selectionHasChanged();
@@ -62,6 +63,7 @@ class PackagePinsView : public PinAssignmentBaseView {
 
  private:
   const int MAX_ROWS{};
+  QVector<QTreeWidgetItem *> m_pinItems;
 };
 
 }  // namespace FOEDAG

--- a/src/PinAssignment/PinAssignmentCreator.cpp
+++ b/src/PinAssignment/PinAssignmentCreator.cpp
@@ -39,7 +39,7 @@ QMap<QString, PortsLoader *> PinAssignmentCreator::m_portsLoader{};
 
 PinAssignmentCreator::PinAssignmentCreator(const PinAssignmentData &data,
                                            QObject *parent)
-    : QObject(parent) {
+    : QObject(parent), m_data(data) {
   PortsModel *portsModel = new PortsModel{this};
   auto packagePinModel = new PackagePinsModel;
   const QString fileName = searchCsvFile(data.target, data.context);
@@ -189,5 +189,20 @@ void PinAssignmentCreator::RegisterPortsLoader(const QString &device,
 }
 
 PinsBaseModel *PinAssignmentCreator::baseModel() const { return m_baseModel; }
+
+const PinAssignmentData &PinAssignmentCreator::data() const { return m_data; }
+
+void PinAssignmentCreator::refresh() {
+  const QSignalBlocker signalBlocker{this};
+  auto portView = m_portsView->findChild<PortsView *>();
+  if (portView) portView->cleanTable();
+  auto ppView = m_packagePinsView->findChild<PackagePinsView *>();
+  if (ppView) ppView->cleanTable();
+  QFile file{m_data.pinFile};
+  if (file.open(QFile::ReadOnly)) {
+    m_data.commands = QtUtils::StringSplit(QString{file.readAll()}, '\n');
+  }
+  if (ppView && portView) parseConstraints(m_data.commands, ppView, portView);
+}
 
 }  // namespace FOEDAG

--- a/src/PinAssignment/PinAssignmentCreator.h
+++ b/src/PinAssignment/PinAssignmentCreator.h
@@ -35,6 +35,7 @@ struct PinAssignmentData {
   QString target{};
   QStringList commands{};
   QString projectPath{};
+  QString pinFile;
 };
 
 class PinAssignmentCreator : public QObject {
@@ -46,6 +47,13 @@ class PinAssignmentCreator : public QObject {
   QWidget *GetPortsWidget();
   QString generateSdc() const;
   PinsBaseModel *baseModel() const;
+  const PinAssignmentData &data() const;
+
+  /*!
+   * \brief refresh
+   * Reload all data from *.pin file
+   */
+  void refresh();
 
   /*!
    * \brief searchPortsFile
@@ -77,6 +85,7 @@ class PinAssignmentCreator : public QObject {
   PinsBaseModel *m_baseModel{nullptr};
   static QMap<QString, PackagePinsLoader *> m_loader;
   static QMap<QString, PortsLoader *> m_portsLoader;
+  PinAssignmentData m_data;
 };
 
 }  // namespace FOEDAG

--- a/src/PinAssignment/PortsView.cpp
+++ b/src/PinAssignment/PortsView.cpp
@@ -81,6 +81,12 @@ void PortsView::SetPin(const QString &port, const QString &pin) {
   }
 }
 
+void PortsView::cleanTable() {
+  for (auto it{m_allCombo.cbegin()}; it != m_allCombo.cend(); it++) {
+    it.key()->setCurrentIndex(0);
+  }
+}
+
 void PortsView::packagePinSelectionHasChanged(const QModelIndex &index) {
   // update here Mode selection
   auto item = itemFromIndex(index);

--- a/src/PinAssignment/PortsView.h
+++ b/src/PinAssignment/PortsView.h
@@ -31,6 +31,7 @@ class PortsView : public PinAssignmentBaseView {
  public:
   PortsView(PinsBaseModel *model, QWidget *parent = nullptr);
   void SetPin(const QString &port, const QString &pin);
+  void cleanTable();
 
  signals:
   void selectionHasChanged();

--- a/src/PinAssignment/Test/PinAssignment_main.cpp
+++ b/src/PinAssignment/Test/PinAssignment_main.cpp
@@ -31,7 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 QWidget* PinAssignmentBuilder(FOEDAG::Session* session) {
   auto projectManager{session->GetCompiler()->ProjManager()};
   FOEDAG::PinAssignmentData data{
-      session->Context(), {}, {}, projectManager->getProjectPath()};
+      session->Context(), {}, {}, projectManager->getProjectPath(), {}};
   FOEDAG::PinAssignmentCreator* creator =
       new FOEDAG::PinAssignmentCreator{data};
   QWidget* w = new QWidget;

--- a/src/TextEditor/text_editor.cpp
+++ b/src/TextEditor/text_editor.cpp
@@ -1,6 +1,7 @@
 #include "text_editor.h"
 
 #include "MainWindow/Session.h"
+#include "text_editor_form.h"
 
 using namespace FOEDAG;
 
@@ -61,6 +62,8 @@ TextEditor::TextEditor(QWidget* parent) : QWidget(parent) {
   TextEditorForm::Instance()->InitForm();
   connect(TextEditorForm::Instance(), SIGNAL(CurrentFileChanged(QString)), this,
           SLOT(SlotCurrentFileChanged(QString)));
+  connect(TextEditorForm::Instance(), &TextEditorForm::FileChanged, this,
+          &TextEditor::FileChanged);
 }
 
 void TextEditor::ShowTextEditor() { TextEditorForm::Instance()->show(); }

--- a/src/TextEditor/text_editor.h
+++ b/src/TextEditor/text_editor.h
@@ -4,8 +4,6 @@
 #include <QObject>
 #include <QWidget>
 
-#include "text_editor_form.h"
-
 namespace FOEDAG {
 class Session;
 
@@ -22,6 +20,7 @@ class TextEditor : public QWidget {
 
  signals:
   void CurrentFileChanged(QString);
+  void FileChanged(const QString &);
 
  public slots:
   void SlotOpenFile(const QString &strFileName);

--- a/src/TextEditor/text_editor_form.cpp
+++ b/src/TextEditor/text_editor_form.cpp
@@ -82,6 +82,10 @@ int TextEditorForm::OpenFile(const QString &strFileName) {
   FOEDAG::Editor *editor = new FOEDAG::Editor(strFileName, filetype, this);
   connect(editor, SIGNAL(EditorModificationChanged(bool)), this,
           SLOT(SlotUpdateTabTitle(bool)));
+  connect(editor, &Editor::EditorModificationChanged, this, [=](bool m) {
+    // file saved
+    if (m == false) emit FileChanged(strFileName);
+  });
   connect(editor, SIGNAL(ShowSearchDialog(QString)), this,
           SLOT(SlotShowSearchDialog(QString)));
 

--- a/src/TextEditor/text_editor_form.h
+++ b/src/TextEditor/text_editor_form.h
@@ -23,6 +23,7 @@ class TextEditorForm : public QWidget {
 
  signals:
   void CurrentFileChanged(QString);
+  void FileChanged(const QString &);
 
  private slots:
   void SlotTabCloseRequested(int index);

--- a/src/Utils/QtUtils.h
+++ b/src/Utils/QtUtils.h
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include <QStringList>
+#include <QTimer>
 
 namespace FOEDAG {
 
@@ -31,6 +32,11 @@ class QtUtils {
 
   // return true if str is equal to s with Qt::CaseInsensitive
   static bool IsEqual(const QString &str, const QString &s);
+
+  template <class Functor>
+  static void AppendToEventQueue(Functor functor) {
+    QTimer::singleShot(1, functor);
+  }
 };
 
 }  // namespace FOEDAG

--- a/tests/unittest/Utils/QtUtils_test.cpp
+++ b/tests/unittest/Utils/QtUtils_test.cpp
@@ -21,6 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Utils/QtUtils.h"
 
+#include <QEventLoop>
+
 #include "gtest/gtest.h"
 
 using namespace FOEDAG;
@@ -45,4 +47,18 @@ TEST(QtUtils, IsEqual) {
   EXPECT_EQ(QtUtils::IsEqual(test, "tes"), false);
   EXPECT_EQ(QtUtils::IsEqual(test, "t"), false);
   EXPECT_EQ(QtUtils::IsEqual(test, "any"), false);
+}
+
+TEST(QtUtils, AppendToEventQueue) {
+  std::vector<int> testData;
+  QEventLoop eventLoop;  // event loop to handle events from AppendToEventQueue
+  QtUtils::AppendToEventQueue([&]() { testData.push_back(1); });
+  QtUtils::AppendToEventQueue([&]() {
+    testData.push_back(2);
+    eventLoop.exit(0);
+  });
+  testData.push_back(3);
+  eventLoop.exec();
+  std::vector<int> expected{3, 1, 2};
+  EXPECT_EQ(testData, expected);
 }


### PR DESCRIPTION
### Motivate of the pull request
Allow user refresh pin planner in case *.pin constraint file was changed on disk or by user or some other app.

### Which part of the code base require a change
<!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
- [x] Library: pinassignment, foedagcore, texteditor
- [ ] Plug-in: <Specify the plugin name>
- [ ] Engine
- [ ] Documentation
- [x] Regression tests
- [ ] Continous Integration (CI) scripts

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/203989821-f5100b11-dc60-4b70-a509-e07eda844f3b.png)
![image](https://user-images.githubusercontent.com/95262932/203990001-e5909db4-77d4-4f69-946b-4140df80cb5c.png)
