### PR TITLE
[RG-208] Move simulation button on top of the task table

### DIFF
--- a/src/Compiler/CompilerDefines.h
+++ b/src/Compiler/CompilerDefines.h
@@ -90,6 +90,7 @@ static constexpr uint SIMULATE_RTL{28};
 static constexpr uint SIMULATE_GATE{29};
 static constexpr uint SIMULATE_PNR{30};
 static constexpr uint SIMULATE_BITSTREAM{31};
+static constexpr uint SIMULATE{32};
 
 static constexpr uint UserActionRole = Qt::UserRole + 1;
 static constexpr uint ExpandAreaRole = Qt::UserRole + 2;

--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -65,6 +65,7 @@ TaskManager::TaskManager(QObject *parent) : QObject{parent} {
   m_tasks.insert(SIMULATE_PNR, new Task{"Simulate PNR", TaskType::Button});
   m_tasks.insert(SIMULATE_BITSTREAM,
                  new Task{"Simulate Bitstream", TaskType::Button});
+  m_tasks.insert(SIMULATE, new Task{"Simulate", TaskType::None});
 
   m_tasks[PACKING]->appendSubTask(m_tasks[PACKING_CLEAN]);
   m_tasks[GLOBAL_PLACEMENT]->appendSubTask(m_tasks[GLOBAL_PLACEMENT_CLEAN]);
@@ -83,6 +84,10 @@ TaskManager::TaskManager(QObject *parent) : QObject{parent} {
   m_tasks[BITSTREAM]->appendSubTask(m_tasks[BITSTREAM_CLEAN]);
   m_tasks[POWER]->appendSubTask(m_tasks[POWER_CLEAN]);
   m_tasks[TIMING_SIGN_OFF]->appendSubTask(m_tasks[TIMING_SIGN_OFF_CLEAN]);
+  m_tasks[SIMULATE]->appendSubTask(m_tasks[SIMULATE_RTL]);
+  m_tasks[SIMULATE]->appendSubTask(m_tasks[SIMULATE_PNR]);
+  m_tasks[SIMULATE]->appendSubTask(m_tasks[SIMULATE_GATE]);
+  m_tasks[SIMULATE]->appendSubTask(m_tasks[SIMULATE_BITSTREAM]);
 
   m_tasks[SYNTHESIS_SETTINGS]->setSettingsKey("Synthesis");
   m_tasks[PLACEMENT_SETTINGS]->setSettingsKey("Placement");
@@ -128,10 +133,6 @@ TaskManager::TaskManager(QObject *parent) : QObject{parent} {
   m_taskQueue.append(m_tasks[POWER_CLEAN]);
   m_taskQueue.append(m_tasks[BITSTREAM]);
   m_taskQueue.append(m_tasks[BITSTREAM_CLEAN]);
-  m_taskQueue.append(m_tasks[SIMULATE_RTL]);
-  m_taskQueue.append(m_tasks[SIMULATE_GATE]);
-  m_taskQueue.append(m_tasks[SIMULATE_PNR]);
-  m_taskQueue.append(m_tasks[SIMULATE_BITSTREAM]);
 
   auto synthesisReportManager = std::make_shared<SynthesisReportManager>();
   connect(synthesisReportManager.get(), &AbstractReportManager::reportCreated,

--- a/src/Compiler/TaskModel.cpp
+++ b/src/Compiler/TaskModel.cpp
@@ -90,7 +90,8 @@ QVariant TaskModel::data(const QModelIndex &index, int role) const {
     if (task->type() != TaskType::Settings) return task->title();
     return QVariant();
   } else if (role == Qt::DecorationRole) {
-    if (task->type() != TaskType::Action) return QVariant();
+    if (task->type() != TaskType::Action && task->type() != TaskType::None)
+      return QVariant();
     if (index.column() == STATUS_COL) {
       switch (task->status()) {
         case TaskStatus::Success:
@@ -165,6 +166,11 @@ void TaskModel::setTaskManager(TaskManager *newTaskManager) {
   if (!newTaskManager) return;
   m_taskManager = newTaskManager;
   int row{0};
+  m_taskOrder.push_back({row++, SIMULATE});
+  m_taskOrder.push_back({row++, SIMULATE_RTL});
+  m_taskOrder.push_back({row++, SIMULATE_GATE});
+  m_taskOrder.push_back({row++, SIMULATE_PNR});
+  m_taskOrder.push_back({row++, SIMULATE_BITSTREAM});
   m_taskOrder.push_back({row++, IP_GENERATE});
   m_taskOrder.push_back({row++, ANALYSIS});
   m_taskOrder.push_back({row++, ANALYSIS_CLEAN});
@@ -193,10 +199,6 @@ void TaskModel::setTaskManager(TaskManager *newTaskManager) {
   m_taskOrder.push_back({row++, POWER_CLEAN});
   m_taskOrder.push_back({row++, BITSTREAM});
   m_taskOrder.push_back({row++, BITSTREAM_CLEAN});
-  m_taskOrder.push_back({row++, SIMULATE_RTL});
-  m_taskOrder.push_back({row++, SIMULATE_GATE});
-  m_taskOrder.push_back({row++, SIMULATE_PNR});
-  m_taskOrder.push_back({row++, SIMULATE_BITSTREAM});
   for (const auto &[row, id] : m_taskOrder) appendTask(m_taskManager->task(id));
 }
 

--- a/src/Compiler/TaskTableView.cpp
+++ b/src/Compiler/TaskTableView.cpp
@@ -112,7 +112,11 @@ void TaskTableView::customMenuRequested(const QPoint &pos) {
   QModelIndex index = indexAt(pos);
   if (index.column() == TitleCol) {
     auto task = m_taskManager->task(model()->data(index, TaskId).toUInt());
-    if (task && task->type() != TaskType::Settings && task->isEnable()) {
+    if (!task) return;
+    if (task->type() != TaskType::Action && task->type() != TaskType::Clean)
+      return;
+
+    if (task->isEnable()) {
       QMenu *menu = new QMenu(this);
       QAction *start = new QAction("Run", this);
       connect(start, &QAction::triggered, this,


### PR DESCRIPTION
### Motivate of the pull request
Move simulation buttons on top of the Task table.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/205044091-6704500f-f96c-470a-9f9f-ec10f5990669.png)

![image](https://user-images.githubusercontent.com/95262932/205044175-3d6634b4-c872-4ea2-8257-2cfddd1f9841.png)
