### PR TITLE
[RG-227] Add simulation options to Project settings

### DIFF
--- a/src/Main/ProjectFile/ProjectManagerComponent.cpp
+++ b/src/Main/ProjectFile/ProjectManagerComponent.cpp
@@ -31,13 +31,14 @@ constexpr auto GENERIC_NAME{"Name"};
 constexpr auto GENERIC_VAL{"Val"};
 
 constexpr auto COMPILER_CONFIG{"CompilerConfig"};
-constexpr auto COMPILER_OPTION{"Opt"};
-constexpr auto COMPILER_NAME{"Name"};
-constexpr auto COMPILER_VAL{"Val"};
-constexpr auto COMPILER_LIB_PATH{"LibPath"};
-constexpr auto COMPILER_INCLUDE_PATH{"IncludePath"};
-constexpr auto COMPILER_LIB_EXT{"LibExt"};
-constexpr auto COMPILER_MACRO{"Macro"};
+constexpr auto SIMULATION_CONFIG{"SimulationConfig"};
+constexpr auto OPTION{"Opt"};
+constexpr auto NAME{"Name"};
+constexpr auto VAL{"Val"};
+constexpr auto LIB_PATH{"LibPath"};
+constexpr auto INCLUDE_PATH{"IncludePath"};
+constexpr auto LIB_EXT{"LibExt"};
+constexpr auto MACRO{"Macro"};
 
 constexpr auto PROJECT_GROUP_LIB_COMMAND{"LibCommand"};
 constexpr auto PROJECT_GROUP_LIB_NAME{"LibName"};
@@ -84,21 +85,40 @@ void ProjectManagerComponent::Save(QXmlStreamWriter* writer) {
   stream.writeEndElement();
 
   stream.writeStartElement(COMPILER_CONFIG);
-  stream.writeStartElement(COMPILER_OPTION);
-  stream.writeAttribute(COMPILER_NAME, COMPILER_LIB_PATH);
-  stream.writeAttribute(COMPILER_VAL, m_projectManager->libraryPath());
+  stream.writeStartElement(OPTION);
+  stream.writeAttribute(NAME, LIB_PATH);
+  stream.writeAttribute(VAL, m_projectManager->libraryPath());
   stream.writeEndElement();
-  stream.writeStartElement(COMPILER_OPTION);
-  stream.writeAttribute(COMPILER_NAME, COMPILER_INCLUDE_PATH);
-  stream.writeAttribute(COMPILER_VAL, m_projectManager->includePath());
+  stream.writeStartElement(OPTION);
+  stream.writeAttribute(NAME, INCLUDE_PATH);
+  stream.writeAttribute(VAL, m_projectManager->includePath());
   stream.writeEndElement();
-  stream.writeStartElement(COMPILER_OPTION);
-  stream.writeAttribute(COMPILER_NAME, COMPILER_LIB_EXT);
-  stream.writeAttribute(COMPILER_VAL, m_projectManager->libraryExtension());
+  stream.writeStartElement(OPTION);
+  stream.writeAttribute(NAME, LIB_EXT);
+  stream.writeAttribute(VAL, m_projectManager->libraryExtension());
   stream.writeEndElement();
-  stream.writeStartElement(COMPILER_OPTION);
-  stream.writeAttribute(COMPILER_NAME, COMPILER_MACRO);
-  stream.writeAttribute(COMPILER_VAL, m_projectManager->macros());
+  stream.writeStartElement(OPTION);
+  stream.writeAttribute(NAME, MACRO);
+  stream.writeAttribute(VAL, m_projectManager->macros());
+  stream.writeEndElement();
+  stream.writeEndElement();
+
+  stream.writeStartElement(SIMULATION_CONFIG);
+  stream.writeStartElement(OPTION);
+  stream.writeAttribute(NAME, LIB_PATH);
+  stream.writeAttribute(VAL, m_projectManager->libraryPathSim());
+  stream.writeEndElement();
+  stream.writeStartElement(OPTION);
+  stream.writeAttribute(NAME, INCLUDE_PATH);
+  stream.writeAttribute(VAL, m_projectManager->includePathSim());
+  stream.writeEndElement();
+  stream.writeStartElement(OPTION);
+  stream.writeAttribute(NAME, LIB_EXT);
+  stream.writeAttribute(VAL, m_projectManager->simLibraryExtension());
+  stream.writeEndElement();
+  stream.writeStartElement(OPTION);
+  stream.writeAttribute(NAME, MACRO);
+  stream.writeAttribute(VAL, m_projectManager->macrosSim());
   stream.writeEndElement();
   stream.writeEndElement();
 
@@ -329,34 +349,67 @@ void ProjectManagerComponent::Load(QXmlStreamReader* r) {
           }
 
           if (type == QXmlStreamReader::StartElement &&
-              reader.attributes().hasAttribute(COMPILER_NAME) &&
-              reader.attributes().hasAttribute(COMPILER_VAL)) {
-            if (reader.attributes().value(COMPILER_NAME).toString() ==
-                COMPILER_LIB_PATH) {
-              auto path = reader.attributes().value(COMPILER_VAL).toString();
+              reader.attributes().hasAttribute(NAME) &&
+              reader.attributes().hasAttribute(VAL)) {
+            if (reader.attributes().value(NAME).toString() == LIB_PATH) {
+              auto path = reader.attributes().value(VAL).toString();
               std::vector<std::string> pathList;
               StringUtils::tokenize(path.toStdString(), " ", pathList);
               m_projectManager->setLibraryPathList(pathList);
             }
-            if (reader.attributes().value(COMPILER_NAME).toString() ==
-                COMPILER_INCLUDE_PATH) {
-              auto inc = reader.attributes().value(COMPILER_VAL).toString();
+            if (reader.attributes().value(NAME).toString() == INCLUDE_PATH) {
+              auto inc = reader.attributes().value(VAL).toString();
               std::vector<std::string> incList;
               StringUtils::tokenize(inc.toStdString(), " ", incList);
               m_projectManager->setIncludePathList(incList);
             }
-            if (reader.attributes().value(COMPILER_NAME).toString() ==
-                COMPILER_LIB_EXT) {
-              auto ext = reader.attributes().value(COMPILER_VAL).toString();
+            if (reader.attributes().value(NAME).toString() == LIB_EXT) {
+              auto ext = reader.attributes().value(VAL).toString();
               std::vector<std::string> extList;
               StringUtils::tokenize(ext.toStdString(), " ", extList);
               m_projectManager->setLibraryExtensionList(extList);
             }
-            if (reader.attributes().value(COMPILER_NAME).toString() ==
-                COMPILER_MACRO) {
-              auto macro = reader.attributes().value(COMPILER_VAL).toString();
+            if (reader.attributes().value(NAME).toString() == MACRO) {
+              auto macro = reader.attributes().value(VAL).toString();
               auto macroList = ProjectManager::ParseMacro(macro);
               m_projectManager->setMacroList(macroList);
+            }
+          }
+        }
+      }
+      if (reader.name() == SIMULATION_CONFIG) {
+        while (true) {
+          type = reader.readNext();
+          if (type == QXmlStreamReader::EndElement &&
+              reader.name() == SIMULATION_CONFIG) {
+            break;
+          }
+
+          if (type == QXmlStreamReader::StartElement &&
+              reader.attributes().hasAttribute(NAME) &&
+              reader.attributes().hasAttribute(VAL)) {
+            if (reader.attributes().value(NAME).toString() == LIB_PATH) {
+              auto path = reader.attributes().value(VAL).toString();
+              std::vector<std::string> pathList;
+              StringUtils::tokenize(path.toStdString(), " ", pathList);
+              m_projectManager->setLibraryPathListSim(pathList);
+            }
+            if (reader.attributes().value(NAME).toString() == INCLUDE_PATH) {
+              auto inc = reader.attributes().value(VAL).toString();
+              std::vector<std::string> incList;
+              StringUtils::tokenize(inc.toStdString(), " ", incList);
+              m_projectManager->setIncludePathListSim(incList);
+            }
+            if (reader.attributes().value(NAME).toString() == LIB_EXT) {
+              auto ext = reader.attributes().value(VAL).toString();
+              std::vector<std::string> extList;
+              StringUtils::tokenize(ext.toStdString(), " ", extList);
+              m_projectManager->setSimLibraryExtensionList(extList);
+            }
+            if (reader.attributes().value(NAME).toString() == MACRO) {
+              auto macro = reader.attributes().value(VAL).toString();
+              auto macroList = ProjectManager::ParseMacro(macro);
+              m_projectManager->setSimMacroList(macroList);
             }
           }
         }

--- a/src/Main/ProjectFile/TaskManagerComponent.cpp
+++ b/src/Main/ProjectFile/TaskManagerComponent.cpp
@@ -63,9 +63,11 @@ void TaskManagerComponent::Load(QXmlStreamReader *reader) {
               TaskStatus status = static_cast<TaskStatus>(
                   reader->attributes().value(TASK_STATUS).toInt());
               auto task = m_taskManager->task(id);
-              task->blockSignals(true);
-              task->setStatus(status);
-              task->blockSignals(false);
+              if (task) {
+                task->blockSignals(true);
+                task->setStatus(status);
+                task->blockSignals(false);
+              }
             }
           }
         }

--- a/src/NewProject/ProjectManager/project.cpp
+++ b/src/NewProject/ProjectManager/project.cpp
@@ -14,6 +14,7 @@ void Project::InitProject() {
   m_projectConfig->moveToThread(thread());
   m_projectConfig->setParent(this);
   m_compilerConfig.reset(new CompilerConfiguration);
+  m_simulationConfig.reset(new CompilerConfiguration);
   m_ipConfig.reset(new IpConfiguration);
   qDeleteAll(m_mapProjectRun);
   m_mapProjectRun.clear();
@@ -38,6 +39,10 @@ ProjectConfiguration *Project::projectConfig() const { return m_projectConfig; }
 
 CompilerConfiguration *Project::compilerConfig() const {
   return m_compilerConfig.get();
+}
+
+CompilerConfiguration *Project::simulationConfig() const {
+  return m_simulationConfig.get();
 }
 
 IpConfiguration *Project::ipConfig() {

--- a/src/NewProject/ProjectManager/project.h
+++ b/src/NewProject/ProjectManager/project.h
@@ -28,6 +28,7 @@ class Project : public QObject {
 
   ProjectConfiguration *projectConfig() const;
   CompilerConfiguration *compilerConfig() const;
+  CompilerConfiguration *simulationConfig() const;
   IpConfiguration *ipConfig();
 
   ProjectFileSet *getProjectFileset(const QString &strName) const;
@@ -52,6 +53,7 @@ class Project : public QObject {
 
   ProjectConfiguration *m_projectConfig;
   std::unique_ptr<CompilerConfiguration> m_compilerConfig;
+  std::unique_ptr<CompilerConfiguration> m_simulationConfig;
   std::unique_ptr<IpConfiguration> m_ipConfig;
   QMap<QString, ProjectFileSet *> m_mapProjectFileset;
   QMap<QString, ProjectRun *> m_mapProjectRun;

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -104,6 +104,14 @@ struct ProjectOptions {
     QList<filedata> fileData;
     bool isCopySource;
   };
+  struct Options {
+    QString topModule;
+    QString topModuleLib;
+    QString includePathList;
+    QString libraryPathList;
+    QString libraryExtList;
+    QString macroList;
+  };
   QString projectName;
   QString projectPath;
   int projectType;
@@ -113,12 +121,8 @@ struct ProjectOptions {
   QStringList device;
   bool rewriteProject;
   QString currentFileSet;
-  QString topModule;
-  QString topModuleLib;
-  QString includePathList;
-  QString libraryPathList;
-  QString libraryExtList;
-  QString macroList;
+  Options designOptions;
+  Options simulationOptions;
 };
 
 struct Suffixes {
@@ -135,6 +139,9 @@ enum ProjectType {
 class ProjectManager : public QObject {
   Q_OBJECT
  public:
+  using Libraries = std::vector<
+      std::pair<std::vector<std::string>, std::vector<std::string>>>;
+  using CompilationUnits = std::vector<std::pair<CompilationUnit, std::string>>;
   enum ErrorCode : int {
     EC_Success = 0,
     EC_FileSetNotExist = -1,
@@ -207,6 +214,7 @@ class ProjectManager : public QObject {
 
   // Please set currentfileset before using this function
   int setTopModule(const QString &strModuleName);
+  ErrorCode setTopModuleSim(const QString &strModuleName);
   int setTopModuleLibrary(const QString &strModuleNameLib);
   // Please set currentfileset before using this function
   int setTargetConstrs(const QString &strFileName);
@@ -219,15 +227,13 @@ class ProjectManager : public QObject {
   QStringList getDesignFiles() const;
   // Compiler interface
   // design
-  std::vector<std::pair<std::vector<std::string>, std::vector<std::string>>>
-  DesignLibraries() const;
-  std::vector<std::pair<CompilationUnit, std::string>> DesignFiles() const;
+  Libraries DesignLibraries() const;
+  CompilationUnits DesignFiles() const;
   std::vector<std::pair<CompilationUnit, std::vector<std::string>>>
   DesignFileList() const;
   // simulation
-  std::vector<std::pair<std::vector<std::string>, std::vector<std::string>>>
-  SimulationLibraries() const;
-  std::vector<std::pair<CompilationUnit, std::string>> SimulationFiles() const;
+  Libraries SimulationLibraries() const;
+  CompilationUnits SimulationFiles() const;
   std::vector<std::pair<CompilationUnit, std::vector<std::string>>>
   SimulationFileList() const;
   // --------------------
@@ -235,9 +241,16 @@ class ProjectManager : public QObject {
   QString getDesignTopModule() const;
   std::string DesignTopModule() const;
 
+  QString getSimulationTopModule() const;
+  std::string SimulationTopModule() const;
+
   QString getDesignTopModuleLib(const QString &strFileSet) const;
   QString getDesignTopModuleLib() const;
   std::string DesignTopModuleLib() const;
+
+  QString getSimulationTopModuleLib(const QString &strFileSet) const;
+  QString getSimulationTopModuleLib() const;
+  std::string SimulationTopModuleLib() const;
 
   int setConstrFileSet(const QString &strSetName);
   QStringList getConstrFileSets() const;
@@ -320,6 +333,30 @@ class ProjectManager : public QObject {
   void addMacro(const std::string &macroName, const std::string &macroValue);
   const std::vector<std::pair<std::string, std::string>> &macroList() const;
   QString macros() const;
+
+  const std::vector<std::string> &simLibraryExtensionList() const;
+  QString simLibraryExtension() const;
+  void setSimLibraryExtensionList(
+      const std::vector<std::string> &newLibraryExtensionList);
+  void addSimLibraryExtension(const std::string &libraryExt);
+
+  void setSimMacroList(
+      const std::vector<std::pair<std::string, std::string>> &newMacroList);
+  void addSimMacro(const std::string &macroName, const std::string &macroValue);
+  const std::vector<std::pair<std::string, std::string>> &macroListSim() const;
+  QString macrosSim() const;
+
+  const std::vector<std::string> &includePathListSim() const;
+  QString includePathSim() const;
+  void setIncludePathListSim(
+      const std::vector<std::string> &newIncludePathList);
+  void addIncludePathSim(const std::string &includePath);
+
+  const std::vector<std::string> &libraryPathListSim() const;
+  QString libraryPathSim() const;
+  void setLibraryPathListSim(
+      const std::vector<std::string> &newLibraryPathList);
+  void addLibraryPathSim(const std::string &libraryPath);
 
   void setTargetDevice(const std::string &deviceName);
   std::string getTargetDevice();

--- a/src/NewProject/add_source_form.cpp
+++ b/src/NewProject/add_source_form.cpp
@@ -8,17 +8,24 @@
 
 using namespace FOEDAG;
 
-addSourceForm::addSourceForm(QWidget *parent)
+addSourceForm::addSourceForm(GridType gt, QWidget *parent)
     : QWidget(parent), ui(new Ui::addSourceForm) {
   ui->setupUi(this);
   ui->m_labelTitle->setText(tr("Add Design Files"));
-  ui->m_labelDetail->setText(tr(
-      "Specify design files, or directories containing those files, to add to "
-      "your project. "
-      "Create a new source file on disk and add it to your project. "));
+  if (gt == GT_SOURCE) {
+    ui->m_labelDetail->setText(
+        tr("Specify design files, or directories containing those files, to "
+           "add to your project. Create a new source file on disk and add it "
+           "to your project. "));
+  } else if (gt == GT_SIM) {
+    ui->m_labelDetail->setText(
+        tr("Specify simulation specific files, or directories containing "
+           "HDL files, to add to your project. Create a new source file on "
+           "disk and add it to your project. "));
+  }
 
   m_widgetGrid = new sourceGrid(ui->m_frame);
-  m_widgetGrid->setGridType(GT_SOURCE);
+  m_widgetGrid->setGridType(gt);
   QBoxLayout *box = new QBoxLayout(QBoxLayout::TopToBottom, ui->m_frame);
   box->addWidget(m_widgetGrid);
   box->setContentsMargins(0, 0, 0, 0);
@@ -82,38 +89,55 @@ QString addSourceForm::Macros() const {
 void addSourceForm::updateUi(ProjectManager *pm) {
   if (!pm) return;
 
-  ui->lineEditTopModule->setText(pm->getDesignTopModule());
-  ui->lineEditTopModuleLib->setText(pm->getDesignTopModuleLib());
-  ui->lineEditLibraryExt->setText(pm->libraryExtension());
-  ui->lineEditLibraryPath->setText(pm->libraryPath());
-  ui->lineEditIncludePath->setText(pm->includePath());
-  ui->lineEditSetMacro->setText(pm->macros());
-
-  m_widgetGrid->ClearTable();
-  auto libs = pm->DesignLibraries();
-  int index{0};
-  for (const auto &lang_file : pm->DesignFiles()) {
-    filedata data;
-    data.m_language = lang_file.first.language;
-    data.m_groupName = lang_file.first.group;
-    if (index < libs.size()) {
-      if (!libs.at(index).first.empty()) {
-        if (!libs.at(index).second.empty())
-          data.m_workLibrary =
-              QString::fromStdString(libs.at(index).second.front());
+  auto fillTable = [this, pm](
+                       const ProjectManager::Libraries &libs,
+                       const ProjectManager::CompilationUnits &allFiles) {
+    int index{0};
+    for (const auto &lang_file : allFiles) {
+      filedata data;
+      data.m_language = lang_file.first.language;
+      data.m_groupName = lang_file.first.group;
+      if (index < libs.size()) {
+        if (!libs.at(index).first.empty()) {
+          if (!libs.at(index).second.empty())
+            data.m_workLibrary =
+                QString::fromStdString(libs.at(index).second.front());
+        }
       }
+      const QStringList fileList =
+          QString::fromStdString(lang_file.second).split(" ");
+      for (const auto &file : fileList) {
+        const QFileInfo info{file};
+        data.m_fileName = info.fileName();
+        data.m_filePath = info.path();
+        data.m_isFolder = false;
+        data.m_fileType = info.suffix();
+        m_widgetGrid->AddTableItem(data);
+      }
+      index++;
     }
-    const QStringList fileList =
-        QString::fromStdString(lang_file.second).split(" ");
-    for (const auto &file : fileList) {
-      const QFileInfo info{file};
-      data.m_fileName = info.fileName();
-      data.m_filePath = info.path();
-      data.m_isFolder = false;
-      data.m_fileType = info.suffix();
-      m_widgetGrid->AddTableItem(data);
-    }
-    index++;
+  };
+
+  if (m_widgetGrid->gridType() == GT_SOURCE) {
+    ui->lineEditTopModule->setText(pm->getDesignTopModule());
+    ui->lineEditTopModuleLib->setText(pm->getDesignTopModuleLib());
+    ui->lineEditLibraryExt->setText(pm->libraryExtension());
+    ui->lineEditLibraryPath->setText(pm->libraryPath());
+    ui->lineEditIncludePath->setText(pm->includePath());
+    ui->lineEditSetMacro->setText(pm->macros());
+
+    m_widgetGrid->ClearTable();
+    fillTable(pm->DesignLibraries(), pm->DesignFiles());
+  } else if (m_widgetGrid->gridType() == GT_SIM) {
+    ui->lineEditTopModule->setText(pm->getSimulationTopModule());
+    ui->lineEditTopModuleLib->setText(pm->getSimulationTopModuleLib());
+    ui->lineEditLibraryExt->setText(pm->simLibraryExtension());
+    ui->lineEditLibraryPath->setText(pm->libraryPathSim());
+    ui->lineEditIncludePath->setText(pm->includePathSim());
+    ui->lineEditSetMacro->setText(pm->macrosSim());
+
+    m_widgetGrid->ClearTable();
+    fillTable(pm->SimulationLibraries(), pm->SimulationFiles());
   }
 }
 

--- a/src/NewProject/add_source_form.h
+++ b/src/NewProject/add_source_form.h
@@ -16,7 +16,7 @@ class addSourceForm : public QWidget, public SettingsGuiInterface {
   Q_OBJECT
 
  public:
-  explicit addSourceForm(QWidget *parent = nullptr);
+  explicit addSourceForm(GridType gt, QWidget *parent = nullptr);
   ~addSourceForm();
   void setProjectType(int projectType);
   int projectType() const;

--- a/src/NewProject/new_project_dialog.cpp
+++ b/src/NewProject/new_project_dialog.cpp
@@ -157,11 +157,11 @@ void newProjectDialog::ResetToNewProject() {
                              tr("Type of Project"));
   QObject::connect(m_proTypeForm, &projectTypeForm::skipSources, this,
                    [this](bool skip) { m_skipSources = skip; });
-  m_addSrcForm = new addSourceForm(this);
+  m_addSrcForm = new addSourceForm(GT_SOURCE, this);
   m_addSrcForm->SetTitle("Add Design Files");
   ui->m_tabWidget->insertTab(INDEX_ADDSOURC, m_addSrcForm,
                              tr("Add Design Files"));
-  m_addSimForm = new addSimForm(this);
+  m_addSimForm = new addSourceForm(GT_SIM, this);
   m_addSimForm->SetTitle("Add Simulation Files");
   ui->m_tabWidget->insertTab(INDEX_ADDSIM, m_addSimForm,
                              tr("Add Simulation Files"));
@@ -186,13 +186,13 @@ void newProjectDialog::ResetToProjectSettings() {
   setWindowTitle(tr("Project settings"));
   m_settings.clear();
 
-  m_addSrcForm = new addSourceForm(this);
+  m_addSrcForm = new addSourceForm(GT_SOURCE, this);
   m_addSrcForm->SetTitle("Design Files");
   m_settings.append(m_addSrcForm);
   auto index = ui->m_tabWidget->insertTab(INDEX_ADDSOURC, m_addSrcForm,
                                           tr("Design Files"));
   m_tabIndexes.insert(INDEX_ADDSOURC, index);
-  m_addSimForm = new addSimForm(this);
+  m_addSimForm = new addSourceForm(GT_SIM, this);
   m_addSimForm->SetTitle("Simulation Files");
   m_settings.append(m_addSimForm);
   index = ui->m_tabWidget->insertTab(INDEX_ADDSIM, m_addSimForm,
@@ -302,12 +302,14 @@ void newProjectDialog::on_buttonBox_accepted() {
       m_devicePlanForm->getSelectedDevice(),
       false /*rewrite*/,
       DEFAULT_FOLDER_SOURCE,
-      m_addSrcForm->TopModule(),
-      m_addSrcForm->LibraryForTopModule(),
-      m_addSrcForm->IncludePath(),
-      m_addSrcForm->LibraryPath(),
-      m_addSrcForm->LibraryExt(),
-      m_addSrcForm->Macros()};
+      ProjectOptions::Options{
+          m_addSrcForm->TopModule(), m_addSrcForm->LibraryForTopModule(),
+          m_addSrcForm->IncludePath(), m_addSrcForm->LibraryPath(),
+          m_addSrcForm->LibraryExt(), m_addSrcForm->Macros()},
+      ProjectOptions::Options{
+          m_addSimForm->TopModule(), m_addSimForm->LibraryForTopModule(),
+          m_addSimForm->IncludePath(), m_addSimForm->LibraryPath(),
+          m_addSimForm->LibraryExt(), m_addSimForm->Macros()}};
   Compiler *compiler = GlobalSession->GetCompiler();
   if (m_addConstrsForm->IsRandom())
     compiler->PinAssignOpts(Compiler::PinAssignOpt::Random);

--- a/src/NewProject/new_project_dialog.h
+++ b/src/NewProject/new_project_dialog.h
@@ -67,7 +67,7 @@ class newProjectDialog : public QDialog {
   locationForm* m_locationForm;
   projectTypeForm* m_proTypeForm;
   addSourceForm* m_addSrcForm;
-  addSimForm* m_addSimForm;
+  addSourceForm* m_addSimForm;
   addConstraintsForm* m_addConstrsForm;
   devicePlannerForm* m_devicePlanForm;
   summaryForm* m_sumForm;

--- a/src/NewProject/source_grid.cpp
+++ b/src/NewProject/source_grid.cpp
@@ -162,6 +162,8 @@ void sourceGrid::setGridType(GridType type) {
   }
 }
 
+GridType sourceGrid::gridType() const { return m_type; }
+
 QList<filedata> sourceGrid::getTableViewData() { return m_lisFileData; }
 
 void sourceGrid::currentFileSet(const QString &fileSet) {

--- a/src/NewProject/source_grid.h
+++ b/src/NewProject/source_grid.h
@@ -38,6 +38,7 @@ class sourceGrid : public QWidget {
   int projectType() const;
 
   void setGridType(GridType type);
+  GridType gridType() const;
   QList<filedata> getTableViewData();
 
   void currentFileSet(const QString &fileSet);

--- a/src/ProjNavigator/tcl_command_integration.cpp
+++ b/src/ProjNavigator/tcl_command_integration.cpp
@@ -335,8 +335,8 @@ void TclCommandIntegration::createNewDesign(const QString &projName,
                      {},
                      true /*rewrite*/,
                      DEFAULT_FOLDER_SOURCE,
-                     {},
-                     {}};
+                     ProjectOptions::Options{},
+                     ProjectOptions::Options{}};
   m_projManager->CreateProject(opt);
   QString newDesignStr{m_projManager->getProjectPath() + "/" +
                        m_projManager->getProjectName() + PROJECT_FILE_FORMAT};

--- a/src/Simulation/Simulator.h
+++ b/src/Simulation/Simulator.h
@@ -45,7 +45,6 @@ class Simulator {
   Simulator() = default;
   Simulator(TclInterpreter* interp, Compiler* compiler, std::ostream* out,
             TclInterpreterHandler* tclInterpreterHandler = nullptr);
-  void SetSimulationTop(const std::string& top) { m_simulationTop = top; }
   void SetInterpreter(TclInterpreter* interp) { m_interp = interp; }
   void SetOutStream(std::ostream* out) { m_out = out; };
   void SetErrStream(std::ostream* err) { m_err = err; };
@@ -132,7 +131,6 @@ class Simulator {
   std::map<SimulatorType, std::string> m_simulatorElaborationOptionMap;
   std::map<SimulatorType, std::string> m_simulatorRuntimeOptionMap;
   std::vector<std::filesystem::path> m_gateSimulationModels;
-  std::string m_simulationTop;
   std::string m_waveFile;
   WaveformType m_waveType = WaveformType::FST;
   SimulationOpt m_simulationOpt{SimulationOpt::None};


### PR DESCRIPTION
### Motivate of the pull request
Add top module name for simulation and all other option as Design source page have.

### Describe the technical details
Simulation top module was moved from Simulation (`Simulator::SetSimulationTop`) to Project manager (`ProjectManager::setTopModuleSim`)
This change required because now simulation top module could be set from tcl command and GUI.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: simulation, newproject
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts

### Screenshots
![image](https://user-images.githubusercontent.com/95262932/207388454-5d07cc49-7b32-4b0a-b865-396638efab57.png)
