### PR TITLE
[RG-222] Add task prefixes to log messages

### DIFF
--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -2146,12 +2146,10 @@ bool Compiler::IPGenerate() {
     // No instances configured, no-op w/o error
     return true;
   }
-  (*m_out) << "IP generation for design: " << m_projManager->projectName()
-           << "..." << std::endl;
+  Message("IP generation for design: " + m_projManager->projectName() + "...");
   bool status = GetIPGenerator()->Generate();
   if (status) {
-    (*m_out) << "Design " << m_projManager->projectName()
-             << " IPs are generated" << std::endl;
+    Message("Design " + m_projManager->projectName() + " IPs are generated");
     m_state = State::IPGenerated;
   } else {
     ErrorMessage("Design " + m_projManager->projectName() +

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -1884,7 +1884,7 @@ bool Compiler::Analyze() {
     AnalyzeOpt(DesignAnalysisOpt::None);
     return true;
   }
-  Message("Analyzing design2: " + m_projManager->projectName() + "...");
+  Message("Analyzing design: " + m_projManager->projectName() + "...");
 
   auto currentPath = std::filesystem::current_path();
   auto it = std::filesystem::directory_iterator{currentPath};

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -1026,7 +1026,9 @@ bool CompilerOpenFPGA::Analyze() {
     Message("Design " + ProjManager()->projectName() + " is analyzed");
   }
 
-  printTopModules(output_path, m_out);
+  std::stringstream tempOut{};
+  printTopModules(output_path, &tempOut);
+  Message(tempOut.str());
   return true;
 }
 

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -932,8 +932,8 @@ std::string CompilerOpenFPGA::FinishAnalyzeScript(const std::string& script) {
 }
 
 bool CompilerOpenFPGA::Analyze() {
-  auto printTopModules = [](const std::filesystem::path& filePath,
-                            std::ostream* out) {
+  auto printTopModules = [this](const std::filesystem::path& filePath,
+                                std::ostream* out) {
     // Check for "topModule" in a given json filePath
     // Assumed json format is [ { "topModule" : "some_value"} ]
     if (out) {
@@ -948,8 +948,7 @@ bool CompilerOpenFPGA::Analyze() {
                            return val.value("topModule", "");
                          });
 
-          (*out) << "Top Modules: " << StringUtils::join(topModules, ", ")
-                 << std::endl;
+          Message("Top Modules: " + StringUtils::join(topModules, ", "));
         }
       }
     }

--- a/src/Compiler/Task.cpp
+++ b/src/Compiler/Task.cpp
@@ -58,6 +58,11 @@ void Task::setSettingsKey(QString key) { m_settings_key = key; }
 QString Task::logFileReadPath() const { return m_logFilePath; }
 void Task::setLogFileReadPath(QString path) { m_logFilePath = path; }
 
+QString Task::abbreviation() const { return m_abbreviation; }
+void Task::setAbbreviation(QString abbreviation) {
+  m_abbreviation = abbreviation;
+}
+
 void Task::trigger() {
   if (m_status != TaskStatus::InProgress) emit taskTriggered();
 }

--- a/src/Compiler/Task.h
+++ b/src/Compiler/Task.h
@@ -68,6 +68,9 @@ class Task : public QObject {
   QString logFileReadPath() const;
   void setLogFileReadPath(QString key);
 
+  QString abbreviation() const;
+  void setAbbreviation(QString key);
+
   /*!
    * \brief trigger
    * Emits \a taskTriggered() signal to notify that some commend can be run.
@@ -102,6 +105,7 @@ class Task : public QObject {
 
  private:
   QString m_title;
+  QString m_abbreviation;
   QString m_settings_key;
   TaskStatus m_status{TaskStatus::None};
   TaskType m_type{TaskType::Action};

--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -112,6 +112,17 @@ TaskManager::TaskManager(QObject *parent) : QObject{parent} {
   m_tasks[POWER]->setLogFileReadPath("$OSRCDIR/power_analysis.rpt");
   m_tasks[BITSTREAM]->setLogFileReadPath("$OSRCDIR/bitstream.rpt");
 
+  m_tasks[IP_GENERATE]->setAbbreviation("IPG");
+  m_tasks[ANALYSIS]->setAbbreviation("ANL");
+  m_tasks[SYNTHESIS]->setAbbreviation("SYN");
+  m_tasks[PACKING]->setAbbreviation("PAC");
+  m_tasks[GLOBAL_PLACEMENT]->setAbbreviation("GPL");
+  m_tasks[PLACEMENT]->setAbbreviation("PLC");
+  m_tasks[ROUTING]->setAbbreviation("RTE");
+  m_tasks[TIMING_SIGN_OFF]->setAbbreviation("TMN");
+  m_tasks[POWER]->setAbbreviation("PWR");
+  m_tasks[BITSTREAM]->setAbbreviation("BIT");
+
   for (auto task = m_tasks.begin(); task != m_tasks.end(); task++) {
     connect((*task), &Task::statusChanged, this, &TaskManager::runNext);
     connect((*task), &Task::statusChanged, this,
@@ -162,6 +173,15 @@ QList<Task *> TaskManager::tasks() const { return m_tasks.values(); }
 Task *TaskManager::task(uint id) const { return m_tasks.value(id, nullptr); }
 
 uint TaskManager::taskId(Task *t) const { return m_tasks.key(t, invalid_id); }
+
+Task *TaskManager::currentTask() const {
+  for (auto task : m_tasks) {
+    if (task->status() == TaskStatus::InProgress) {
+      return task;
+    }
+  }
+  return nullptr;
+}
 
 void TaskManager::stopCurrentTask() {
   for (auto task = m_tasks.begin(); task != m_tasks.end(); task++) {

--- a/src/Compiler/TaskManager.h
+++ b/src/Compiler/TaskManager.h
@@ -51,7 +51,11 @@ class TaskManager : public QObject {
    * \return return id of the task \a t.
    */
   uint taskId(Task *t) const;
-
+  /*!
+   * \brief currentTask
+   * \return Task* to task with status InProgress.
+   */
+  Task *currentTask() const;
   /*!
    * \brief stopCurrentTask. Stop all tasks that are in progress.
    */

--- a/tests/TestGui/log_header.tcl
+++ b/tests/TestGui/log_header.tcl
@@ -1,8 +1,7 @@
 gui_start
-
 create_design log_header
-
 analyze
+help
 
 set fp [open "log_header/analysis.rpt" r]
 set file_data [read $fp]
@@ -46,6 +45,14 @@ set file_data [read $fp]
 close $fp
 set found [regexp "^Copyright 20\\d\\d The Foedag team" $file_data]
 if { !$found } { puts "ERROR: foedag.log's header is commented which shouldn't have occured"; exit 1 }
+
+# Verify foedag.log has ANL: abbreviation in front of analyze messages
+set found [regexp "\nANL: Design log_header is analyzed" $file_data]
+if { !$found } { puts "ERROR: foedag.log's Analyze messages don't have ANL: in front"; exit 1 }
+
+# Verify help message doesn't have an abbreviation in front of it
+set found [regexp "\n-----  FOEDAG HELP  -----" $file_data]
+if { !$found } { puts "ERROR: foedag.log's help message has an abbreviation before it or wasn't printed"; exit 1 }
 
 # passed
 exit


### PR DESCRIPTION
### This addresses part 3 of RG-222, parts 1&2 were implemented in https://github.com/os-fpga/FOEDAG/pull/856
### This currently doesn't add a prefix to ErrorMessage prints, need to confirm w/ Taras if this would break reporting

> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-222
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> - Tasks print messages to the console/log w/o prefixes
>
> #### What does this pull request change?
> - Tasks now have an abbreviation field which will be appended to to their Compiler->Message() calls if the abbreviation is set
>    - If a task prints directly to `(*m_out)` , prefixes cannot be added
> - Task related prints that used to print via `(*m_out) << ...` now print w/ `Message()` to enable prefixes

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: Compiler
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Testing
> - Updated log_header.tcl to check for prefixes
> - Manual raptor testing currently underway
