### PR TITLE
[RG-222] Set bitstream abbreviation

### DIFF
--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -143,6 +143,7 @@ TaskManager::TaskManager(QObject *parent) : QObject{parent} {
   m_tasks[ROUTING]->setAbbreviation("RTE");
   m_tasks[TIMING_SIGN_OFF]->setAbbreviation("TMN");
   m_tasks[POWER]->setAbbreviation("PWR");
+  m_tasks[BITSTREAM]->setAbbreviation("BIT");
   m_tasks[SIMULATE_RTL]->setAbbreviation("SRT");
   m_tasks[SIMULATE_GATE]->setAbbreviation("SGT");
   m_tasks[SIMULATE_PNR]->setAbbreviation("SPR");


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: RG-222

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> - Bitstream task didn't have an abbreviation set
>
> #### What does this pull request change?
> - Bitstream task now has it's abbreviation set to "BIT"

![image](https://user-images.githubusercontent.com/103447061/206812339-b1aee809-7ae5-4a39-8a71-af0aa049ee11.png)


> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: Compiler
