### PR TITLE
GTKWave: Set download location to a fixed location

### DIFF
--- a/tests/TestGui/gtkwave_invoke.tcl
+++ b/tests/TestGui/gtkwave_invoke.tcl
@@ -21,7 +21,7 @@ proc delay { time } { set delayDone 0; after $time set delayDone 1; vwait delayD
 
 # open gtkwave and give it time to load
 wave_open
-delay 1000
+delay 3000
 
 # close gtkwave via the menu
 wave_cmd gtkwave::/File/Quit

--- a/third_party/gtkwave_cmake/CMakeLists.txt
+++ b/third_party/gtkwave_cmake/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
 endif()
 
 set(download_path "https://github.com/RapidSilicon/post_build_artifacts/releases/download/v0.1/${gtkwave_tar}")
-set(temp_path ${CMAKE_CURRENT_SOURCE_DIR}/${gtkwave_tar})
+set(temp_path ${CMAKE_CURRENT_SOURCE_DIR}/gtkwaveTcl.tar.gz)
 set(install_path ${build_dir}/bin)
 set(gtkwave_path ${install_path}/gtkwave)
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - This will simplify other clients accessing gtkwave

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> - The GTKWave archive was downloaded to a path that had a different name in windows
>
> #### What does this pull request change?
> - Both windows and unix archives are now downloaded to the same location so that other client CMake files don't have to determine where the file will be found based on platform.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: GTKWave
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts
