### PR TITLE
GTKWave:: Fix typo in archive name

### DIFF
--- a/third_party/gtkwave_cmake/CMakeLists.txt
+++ b/third_party/gtkwave_cmake/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
 endif()
 
 set(download_path "https://github.com/RapidSilicon/post_build_artifacts/releases/download/v0.1/${gtkwave_tar}")
-set(temp_path ${CMAKE_CURRENT_SOURCE_DIR}/gtkwaveTcl.tar.gz)
+set(temp_path ${CMAKE_CURRENT_SOURCE_DIR}/gtkwaveTCL.tar.gz)
 set(install_path ${build_dir}/bin)
 set(gtkwave_path ${install_path}/gtkwave)
 


### PR DESCRIPTION
> ### Motivate of the pull request
This fixes a typo in https://github.com/os-fpga/FOEDAG/pull/873 which accidentally saves the file under gtkwave**Tcl**.tar.gz instead of gtkwave**TCL**.tar.gz which is what other clients are looking for.
