### PR TITLE
[RG-239] Update task table: Enable/Disable for simulation tasks only, hide some tasks for post synth project

### DIFF
--- a/src/Compiler/CompilerDefines.cpp
+++ b/src/Compiler/CompilerDefines.cpp
@@ -37,8 +37,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 extern FOEDAG::Session *GlobalSession;
 
-QWidget *FOEDAG::prepareCompilerView(Compiler *compiler,
-                                     TaskManager **taskManager) {
+QTableView *FOEDAG::prepareCompilerView(Compiler *compiler,
+                                        TaskManager **taskManager) {
   TaskManager *tManager = new TaskManager;
   TaskModel *model = new TaskModel{tManager};
   TaskTableView *view = new TaskTableView{tManager};

--- a/src/Compiler/CompilerDefines.h
+++ b/src/Compiler/CompilerDefines.h
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <QWidget>
+#include <QTableView>
 
 namespace FOEDAG {
 
@@ -117,8 +117,8 @@ static constexpr const char *BITSTREAM_LOG{"bitstream.rpt"};
  * \param taskManager - output parameter to receive pointer to task manager.
  * \return widget with compiler task view
  */
-QWidget *prepareCompilerView(Compiler *compiler,
-                             TaskManager **taskManager = nullptr);
+QTableView *prepareCompilerView(Compiler *compiler,
+                                TaskManager **taskManager = nullptr);
 
 uint toTaskId(int action, Compiler *const compiler);
 

--- a/src/Compiler/TaskModel.h
+++ b/src/Compiler/TaskModel.h
@@ -43,6 +43,7 @@ class TaskModel : public QAbstractTableModel {
 
   TaskManager *taskManager() const;
   void setTaskManager(TaskManager *newTaskManager);
+  int ToRowIndex(uint taskId) const;
 
  private:
   bool setData(const QModelIndex &index, const QVariant &value,
@@ -56,7 +57,6 @@ class TaskModel : public QAbstractTableModel {
   bool hasChildren(const QModelIndex &parent) const override;
   Qt::ItemFlags flags(const QModelIndex &index) const override;
   uint ToTaskId(const QModelIndex &index) const;
-  int ToRowIndex(uint taskId) const;
 
  private:
   TaskManager *m_taskManager{nullptr};

--- a/src/Compiler/TaskTableView.cpp
+++ b/src/Compiler/TaskTableView.cpp
@@ -135,7 +135,7 @@ void TaskTableView::customMenuRequested(const QPoint &pos) {
       }
     }
     addExpandCollapse(menu);
-    addEnableDisableTask(menu, task);
+    if (TaskManager::isSimulation(task)) addEnableDisableTask(menu, task);
     menu->popup(viewport()->mapToGlobal(pos));
   }
 }
@@ -258,6 +258,7 @@ void TaskTableView::TasksDelegate::paint(QPainter *painter,
   if (index.column() == StatusCol) {
     auto statusData = index.data(Qt::DecorationRole);
     auto label = qobject_cast<QLabel *>(m_view.indexWidget(index));
+    if (!label) return;
     // QTableView can't paint animations. Do it manually via QLabel.
     if (statusData.type() == QVariant::Bool) {
       label->setMovie(m_inProgressMovie);

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -216,6 +216,8 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   bool m_progressVisible{false};
   bool m_askStopCompilation{true};
   bool m_blockRefereshEn{false};
+  QTableView* m_taskView{nullptr};
+  class TaskModel* m_taskModel{nullptr};
 };
 
 }  // namespace FOEDAG


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-239
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Make Enable/Disable option available for simulation tasks only.
For post synth project hide all tasks above Simulate Gate.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts

### Screenshots
RTL project:
![image](https://user-images.githubusercontent.com/95262932/208429443-928bb929-3502-4833-bda7-4d9ce3aa65ba.png)


Post synth project:
![image](https://user-images.githubusercontent.com/95262932/208429370-97f03708-99a1-4038-8267-aa4f606eee69.png)
