### PR TITLE
RG-234: Add one more optional parameter to simulation_options - level.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ test/batch: run-cmake-release
 	./build/bin/foedag --batch --script tests/TestBatch/test_ip_generate.tcl
 	./build/bin/foedag --batch --script tests/Testcases/aes_decrypt_fpga/aes_decrypt.tcl
 	./build/bin/foedag --batch --script tests/TestGui/compiler_flow.tcl
+	./build/bin/foedag --batch --script tests/TestGui/simulation_flow.tcl
 	./build/bin/foedag --batch --script tests/TestBatch/test_compiler_mt.tcl
 	./build/bin/foedag --batch --script tests/TestBatch/test_compiler_stop.tcl
 	./build/bin/foedag --batch --script tests/TestBatch/test_compiler_batch.tcl

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -395,9 +395,8 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
   }
   if (m_simulator == nullptr) {
     m_simulator = new Simulator(m_interp, this, m_out, m_tclInterpreterHandler);
-  } else {
-    m_simulator->RegisterCommands(m_interp);
   }
+  m_simulator->RegisterCommands(m_interp);
   m_IPGenerator->RegisterCommands(interp, batchMode);
   if (m_constraints == nullptr) {
     SetConstraints(new Constraints{this});

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -241,7 +241,8 @@ void CompilerOpenFPGA::Help(std::ostream* out) {
   (*out) << "   set_top_testbench <module> : Sets the top-level testbench "
             "module/entity"
          << std::endl;
-  (*out) << "   simulation_options <simulator> <phase> <options>" << std::endl;
+  (*out) << "   simulation_options <simulator> <phase> ?<level>? <options>"
+         << std::endl;
   (*out) << "                                Sets the simulator specific "
             "options for the speicifed phase"
          << std::endl;

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -51,6 +51,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace FOEDAG;
 
+Simulator::SimulationType Simulator::ToSimulationType(const std::string& str,
+                                                      bool& ok) {
+  ok = true;
+  if (str == "rtl") return SimulationType::RTL;
+  if (str == "pnr") return SimulationType::PNR;
+  if (str == "gate") return SimulationType::Gate;
+  if (str == "bitstream") return SimulationType::Bitstream;
+  ok = false;
+  return SimulationType::RTL;
+}
+
 Simulator::Simulator(TclInterpreter* interp, Compiler* compiler,
                      std::ostream* out,
                      TclInterpreterHandler* tclInterpreterHandler)
@@ -61,6 +72,48 @@ Simulator::Simulator(TclInterpreter* interp, Compiler* compiler,
 
 void Simulator::AddGateSimulationModel(const std::filesystem::path& path) {
   m_gateSimulationModels.push_back(path);
+}
+
+void Simulator::SetSimulatorCompileOption(const std::string& simulation,
+                                          SimulatorType type,
+                                          const std::string& options) {
+  bool ok{false};
+  auto level = ToSimulationType(simulation, ok);
+  if (ok) {
+    m_simulatorCompileOptionMap[level].emplace(type, options);
+  } else {
+    for (auto level : {SimulationType::RTL, SimulationType::PNR,
+                       SimulationType::Gate, SimulationType::Bitstream})
+      m_simulatorCompileOptionMap[level].emplace(type, options);
+  }
+}
+
+void Simulator::SetSimulatorElaborationOption(const std::string& simulation,
+                                              SimulatorType type,
+                                              const std::string& options) {
+  bool ok{false};
+  auto level = ToSimulationType(simulation, ok);
+  if (ok) {
+    m_simulatorElaborationOptionMap[level].emplace(type, options);
+  } else {
+    for (auto level : {SimulationType::RTL, SimulationType::PNR,
+                       SimulationType::Gate, SimulationType::Bitstream})
+      m_simulatorElaborationOptionMap[level].emplace(type, options);
+  }
+}
+
+void Simulator::SetSimulatorRuntimeOption(const std::string& simulation,
+                                          SimulatorType type,
+                                          const std::string& options) {
+  bool ok{false};
+  auto level = ToSimulationType(simulation, ok);
+  if (ok) {
+    m_simulatorRuntimeOptionMap[level].emplace(type, options);
+  } else {
+    for (auto level : {SimulationType::RTL, SimulationType::PNR,
+                       SimulationType::Gate, SimulationType::Bitstream})
+      m_simulatorRuntimeOptionMap[level].emplace(type, options);
+  }
 }
 
 void Simulator::ResetGateSimulationModel() { m_gateSimulationModels.clear(); }
@@ -84,11 +137,16 @@ bool Simulator::RegisterCommands(TclInterpreter* interp) {
     if (argc > 3) {
       std::string options;
       for (int i = 3; i < argc; i++) {
-        options += std::string(argv[i]) + " ";
+        std::string arg{argv[i]};
+        if (arg == "rtl" || arg == "pnr" || arg == "gate") {
+          continue;
+        }
+        options += arg + " ";
       }
       std::string phase;
+      std::string level;
       Simulator::SimulatorType sim_tool = Simulator::SimulatorType::Verilator;
-      for (int i = 1; i < 3; i++) {
+      for (int i = 1; i < 4; i++) {
         std::string arg = argv[i];
         if (arg == "verilator") {
           sim_tool = Simulator::SimulatorType::Verilator;
@@ -114,15 +172,17 @@ bool Simulator::RegisterCommands(TclInterpreter* interp) {
           phase = "simulation";
         } else if (arg == "simulation") {
           phase = "simulation";
+        } else if (arg == "rtl" || arg == "pnr" || arg == "gate") {
+          level = arg;
         }
       }
       options = StringUtils::rtrim(options);
       if (phase == "compilation") {
-        simulator->SetSimulatorCompileOption(sim_tool, options);
+        simulator->SetSimulatorCompileOption(level, sim_tool, options);
       } else if (phase == "elaboration") {
-        simulator->SetSimulatorElaborationOption(sim_tool, options);
+        simulator->SetSimulatorElaborationOption(level, sim_tool, options);
       } else if (phase == "simulation") {
-        simulator->SetSimulatorRuntimeOption(sim_tool, options);
+        simulator->SetSimulatorRuntimeOption(level, sim_tool, options);
       }
       return TCL_OK;
     }
@@ -151,23 +211,34 @@ void Simulator::ErrorMessage(const std::string& message) {
   m_compiler->ErrorMessage(message);
 }
 
-std::string Simulator::GetSimulatorCompileOption(SimulatorType type) {
-  std::map<SimulatorType, std::string>::iterator itr =
-      m_simulatorCompileOptionMap.find(type);
-  if (itr != m_simulatorCompileOptionMap.end()) return (*itr).second;
-  return "";
+std::string Simulator::GetSimulatorCompileOption(SimulationType simulation,
+                                                 SimulatorType type) {
+  if (m_simulatorCompileOptionMap.count(simulation) != 0) {
+    auto itr = m_simulatorCompileOptionMap[simulation].find(type);
+    if (itr != m_simulatorCompileOptionMap[simulation].end())
+      return (*itr).second;
+  }
+  return std::string{};
 }
-std::string Simulator::GetSimulatorElaborationOption(SimulatorType type) {
-  std::map<SimulatorType, std::string>::iterator itr =
-      m_simulatorElaborationOptionMap.find(type);
-  if (itr != m_simulatorElaborationOptionMap.end()) return (*itr).second;
-  return "";
+
+std::string Simulator::GetSimulatorElaborationOption(SimulationType simulation,
+                                                     SimulatorType type) {
+  if (m_simulatorElaborationOptionMap.count(simulation) != 0) {
+    auto itr = m_simulatorElaborationOptionMap[simulation].find(type);
+    if (itr != m_simulatorElaborationOptionMap[simulation].end())
+      return (*itr).second;
+  }
+  return std::string{};
 }
-std::string Simulator::GetSimulatorRuntimeOption(SimulatorType type) {
-  std::map<SimulatorType, std::string>::iterator itr =
-      m_simulatorRuntimeOptionMap.find(type);
-  if (itr != m_simulatorRuntimeOptionMap.end()) return (*itr).second;
-  return "";
+
+std::string Simulator::GetSimulatorRuntimeOption(SimulationType simulation,
+                                                 SimulatorType type) {
+  if (m_simulatorRuntimeOptionMap.count(simulation) != 0) {
+    auto itr = m_simulatorRuntimeOptionMap[simulation].find(type);
+    if (itr != m_simulatorRuntimeOptionMap[simulation].end())
+      return (*itr).second;
+  }
+  return std::string{};
 }
 
 void Simulator::SimulationOption(SimulationOpt option) {
@@ -491,15 +562,16 @@ std::string Simulator::LanguageDirective(SimulatorType type,
   return "Invalid";
 }
 
-std::string Simulator::SimulatorRunCommand(SimulatorType type) {
+std::string Simulator::SimulatorRunCommand(SimulationType simulation,
+                                           SimulatorType type) {
   std::string execPath =
       (SimulatorExecPath(type) / SimulatorName(type)).string();
   auto simulationTop{ProjManager()->SimulationTopModule()};
   switch (type) {
     case SimulatorType::Verilator: {
       std::string command = "obj_dir/V" + simulationTop;
-      if (!GetSimulatorRuntimeOption(type).empty())
-        command += " " + GetSimulatorRuntimeOption(type);
+      if (!GetSimulatorRuntimeOption(simulation, type).empty())
+        command += " " + GetSimulatorRuntimeOption(simulation, type);
       if (!m_waveFile.empty()) command += " " + m_waveFile;
       return command;
     }
@@ -510,8 +582,8 @@ std::string Simulator::SimulatorRunCommand(SimulatorType type) {
       if (!simulationTop.empty()) {
         command += TopModuleCmd(type) + simulationTop;
       }
-      if (!GetSimulatorRuntimeOption(type).empty())
-        command += " " + GetSimulatorRuntimeOption(type);
+      if (!GetSimulatorRuntimeOption(simulation, type).empty())
+        command += " " + GetSimulatorRuntimeOption(simulation, type);
       if (!m_waveFile.empty()) {
         command += " ";
         command += (m_waveType == WaveformType::VCD) ? "--vcd=" : "--fst=";
@@ -576,7 +648,8 @@ std::string Simulator::SimulationFileList(SimulatorType type) {
   return fileList;
 }
 
-int Simulator::SimulationJob(SimulatorType type, const std::string& fileList) {
+int Simulator::SimulationJob(SimulationType simulation, SimulatorType type,
+                             const std::string& fileList) {
   if (type == SimulatorType::Verilator) {
     std::string verilator_home = SimulatorExecPath(type).parent_path().string();
     m_compiler->SetEnvironmentVariable("VERILATOR_ROOT", verilator_home);
@@ -586,8 +659,8 @@ int Simulator::SimulationJob(SimulatorType type, const std::string& fileList) {
   std::string execPath =
       (SimulatorExecPath(type) / SimulatorName(type)).string();
   std::string command = execPath + " " + SimulatorCompilationOptions(type);
-  if (!GetSimulatorCompileOption(type).empty())
-    command += " " + GetSimulatorCompileOption(type);
+  if (!GetSimulatorCompileOption(simulation, type).empty())
+    command += " " + GetSimulatorCompileOption(simulation, type);
   command += " " + fileList;
   int status = m_compiler->ExecuteAndMonitorSystemCommand(command);
   if (status) {
@@ -602,8 +675,8 @@ int Simulator::SimulationJob(SimulatorType type, const std::string& fileList) {
     case SimulatorType::Verilator: {
       std::string command =
           "make -j -C obj_dir/ -f V" + simulationTop + ".mk V" + simulationTop;
-      if (!GetSimulatorElaborationOption(type).empty())
-        command += " " + GetSimulatorElaborationOption(type);
+      if (!GetSimulatorElaborationOption(simulation, type).empty())
+        command += " " + GetSimulatorElaborationOption(simulation, type);
       status = m_compiler->ExecuteAndMonitorSystemCommand(command);
       if (status) {
         ErrorMessage("Design " + ProjManager()->projectName() +
@@ -614,8 +687,8 @@ int Simulator::SimulationJob(SimulatorType type, const std::string& fileList) {
     }
     case SimulatorType::GHDL: {
       std::string command = execPath + " -e -fsynopsys";
-      if (!GetSimulatorElaborationOption(type).empty())
-        command += " " + GetSimulatorElaborationOption(type);
+      if (!GetSimulatorElaborationOption(simulation, type).empty())
+        command += " " + GetSimulatorElaborationOption(simulation, type);
       if (!simulationTop.empty()) {
         command += TopModuleCmd(type) + simulationTop;
       }
@@ -632,7 +705,7 @@ int Simulator::SimulationJob(SimulatorType type, const std::string& fileList) {
   }
 
   // Actual simulation
-  command = SimulatorRunCommand(type);
+  command = SimulatorRunCommand(simulation, type);
   status = m_compiler->ExecuteAndMonitorSystemCommand(command);
   return status;
 }
@@ -668,7 +741,7 @@ bool Simulator::SimulateRTL(SimulatorType type) {
   Message("RTL simulation for design: " + ProjManager()->projectName());
   Message("##################################################");
 
-  bool status = SimulationJob(type, fileList);
+  bool status = SimulationJob(SimulationType::RTL, type, fileList);
 
   if (status) {
     ErrorMessage("Design " + ProjManager()->projectName() +
@@ -733,7 +806,7 @@ bool Simulator::SimulateGate(SimulatorType type) {
   }
   fileList = StringUtils::rtrim(fileList);
 
-  bool status = SimulationJob(type, fileList);
+  bool status = SimulationJob(SimulationType::Gate, type, fileList);
 
   if (status) {
     ErrorMessage("Design " + ProjManager()->projectName() +
@@ -766,7 +839,7 @@ bool Simulator::SimulatePNR(SimulatorType type) {
   }
   fileList = StringUtils::rtrim(fileList);
 
-  bool status = SimulationJob(type, fileList);
+  bool status = SimulationJob(SimulationType::PNR, type, fileList);
 
   if (status) {
     ErrorMessage("Design " + ProjManager()->projectName() +

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -138,7 +138,9 @@ bool Simulator::RegisterCommands(TclInterpreter* interp) {
       std::string options;
       for (int i = 3; i < argc; i++) {
         std::string arg{argv[i]};
-        if (arg == "rtl" || arg == "pnr" || arg == "gate") {
+        // skip level if available
+        if (arg == "rtl" || arg == "pnr" || arg == "gate" ||
+            arg == "bitstream") {
           continue;
         }
         options += arg + " ";
@@ -172,7 +174,8 @@ bool Simulator::RegisterCommands(TclInterpreter* interp) {
           phase = "simulation";
         } else if (arg == "simulation") {
           phase = "simulation";
-        } else if (arg == "rtl" || arg == "pnr" || arg == "gate") {
+        } else if (arg == "rtl" || arg == "pnr" || arg == "gate" ||
+                   arg == "bitstream") {
           level = arg;
         }
       }

--- a/src/Simulation/Simulator.h
+++ b/src/Simulation/Simulator.h
@@ -41,6 +41,8 @@ class Simulator {
   enum class WaveformType { VCD, FST };
   enum class SimulationOpt { None, Clean };
 
+  static SimulationType ToSimulationType(const std::string& str, bool& ok);
+
   // Most common use case, create the compiler in your main
   Simulator() = default;
   Simulator(TclInterpreter* interp, Compiler* compiler, std::ostream* out,
@@ -73,22 +75,22 @@ class Simulator {
   void ResetGateSimulationModel();
   void AddGateSimulationModel(const std::filesystem::path& path);
 
-  void SetSimulatorCompileOption(SimulatorType type,
-                                 const std::string& options) {
-    m_simulatorCompileOptionMap.emplace(type, options);
-  }
-  void SetSimulatorElaborationOption(SimulatorType type,
-                                     const std::string& options) {
-    m_simulatorElaborationOptionMap.emplace(type, options);
-  }
-  void SetSimulatorRuntimeOption(SimulatorType type,
-                                 const std::string& options) {
-    m_simulatorRuntimeOptionMap.emplace(type, options);
-  }
+  void SetSimulatorCompileOption(const std::string& simulation,
+                                 SimulatorType type,
+                                 const std::string& options);
+  void SetSimulatorElaborationOption(const std::string& simulation,
+                                     SimulatorType type,
+                                     const std::string& options);
+  void SetSimulatorRuntimeOption(const std::string& simulation,
+                                 SimulatorType type,
+                                 const std::string& options);
 
-  std::string GetSimulatorCompileOption(SimulatorType type);
-  std::string GetSimulatorElaborationOption(SimulatorType type);
-  std::string GetSimulatorRuntimeOption(SimulatorType type);
+  std::string GetSimulatorCompileOption(SimulationType simulation,
+                                        SimulatorType type);
+  std::string GetSimulatorElaborationOption(SimulationType simulation,
+                                            SimulatorType type);
+  std::string GetSimulatorRuntimeOption(SimulationType simulation,
+                                        SimulatorType type);
 
   void SimulationOption(SimulationOpt option);
   SimulationOpt SimulationOption() const;
@@ -113,8 +115,10 @@ class Simulator {
   virtual std::string LanguageDirective(SimulatorType type,
                                         Design::Language lang);
   virtual std::string SimulationFileList(SimulatorType type);
-  virtual int SimulationJob(SimulatorType type, const std::string& file_list);
-  virtual std::string SimulatorRunCommand(SimulatorType type);
+  virtual int SimulationJob(SimulationType simulation, SimulatorType type,
+                            const std::string& file_list);
+  virtual std::string SimulatorRunCommand(SimulationType simulation,
+                                          SimulatorType type);
   virtual std::string SimulatorCompilationOptions(SimulatorType type);
   class ProjectManager* ProjManager() const;
   std::string FileList(SimulationType action);
@@ -130,9 +134,10 @@ class Simulator {
   SimulatorType m_simulatorTool = SimulatorType::Verilator;
   std::string m_output;
   std::map<SimulatorType, std::filesystem::path> m_simulatorPathMap;
-  std::map<SimulatorType, std::string> m_simulatorCompileOptionMap;
-  std::map<SimulatorType, std::string> m_simulatorElaborationOptionMap;
-  std::map<SimulatorType, std::string> m_simulatorRuntimeOptionMap;
+  using SimulationOptionMap = std::map<SimulatorType, std::string>;
+  std::map<SimulationType, SimulationOptionMap> m_simulatorCompileOptionMap;
+  std::map<SimulationType, SimulationOptionMap> m_simulatorElaborationOptionMap;
+  std::map<SimulationType, SimulationOptionMap> m_simulatorRuntimeOptionMap;
   std::vector<std::filesystem::path> m_gateSimulationModels;
   std::string m_waveFile;
   WaveformType m_waveType = WaveformType::FST;

--- a/tests/TestGui/simulation_flow.tcl
+++ b/tests/TestGui/simulation_flow.tcl
@@ -1,0 +1,43 @@
+#Copyright 2021 The Foedag team
+
+#GPL License
+
+#Copyright (c) 2021 The Open-Source FPGA Foundation
+
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+create_design simulation_flow_test
+set_top_module toto
+ipgenerate
+simulation_options verilator simulation rtl "some options"
+# doesn't work for now
+# simulate rtl rtl_file.fst
+synth
+simulation_options verilator elab gate "some options"
+# doesn't work for now
+# simulate gate gate_file.fst
+packing
+globp
+place
+route
+simulation_options verilator comp pnr "some options"
+# doesn't work for now
+# simulate pnr pnr_file.fst
+sta
+power
+bitstream
+simulation_options verilator comp bitstream "some options"
+# doesn't work for now
+# simulate bitstream bitstream_file.fst
+exit


### PR DESCRIPTION
### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Add one more argument for simulation_options tcl command - level: 
`simulation_options <simulator> <task> ?<level>? <options>`
level values could be rtl, gate, pnr.
level is optional. If level not specify, options will be applied to all levels.

Also `bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode)` function changed. Now it will register simulation commands without any conditions.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: simulation
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts