### PR TITLE
[RG-242] Extend placement/routing statistical timing report table with extra rows

### DIFF
--- a/src/Compiler/Reports/AbstractReportManager.cpp
+++ b/src/Compiler/Reports/AbstractReportManager.cpp
@@ -17,12 +17,6 @@ static const QRegExp ERROR_REGEXP("Error [0-9].*:");
 
 static const QString STAT_TIMING_COL{"Statistics"};
 static const QString VAL_TIMING_COL{"Value"};
-
-static const QStringList TIMING_FIELDS{"Critical path delay (least slack)",
-                                       "FMax", "Setup WNS", "Setup TNS"};
-
-static const QRegularExpression FIND_STAT_TIMING{
-    "([-]?(([0-9]*[.])?[0-9]+) (ns|MHz))"};
 }  // namespace
 
 namespace FOEDAG {
@@ -215,14 +209,7 @@ void AbstractReportManager::fillTimingData(const QStringList &timingData) {
 
   createTimingDataFile(timingData);
 
-  auto timingStr = timingData.join(' ');
-  auto matchIt = FIND_STAT_TIMING.globalMatch(timingStr);
-  if (FIND_STAT_TIMING.captureCount() != TIMING_FIELDS.size()) return;
-  auto valueIndex = 0;
-  while (matchIt.hasNext()) {
-    auto match = matchIt.next();
-    m_timingData.push_back({TIMING_FIELDS[valueIndex++], match.captured()});
-  }
+  splitTimingData(timingData.join(' '));
 }
 
 void AbstractReportManager::createTimingDataFile(

--- a/src/Compiler/Reports/AbstractReportManager.h
+++ b/src/Compiler/Reports/AbstractReportManager.h
@@ -68,6 +68,8 @@ class AbstractReportManager : public QObject, public ITaskReportManager {
   // Fills the values from given 'timingData' to m_timingData.
   void fillTimingData(const QStringList &timingData);
   void createTimingDataFile(const QStringList &timingData);
+  // Timing data is task specific and can't be split on generic level
+  virtual void splitTimingData(const QString &timingStr) = 0;
 
   // Keyword to recognize the start of resource usage section
   static const QRegExp FIND_RESOURCES;

--- a/src/Compiler/Reports/PlacementReportManager.h
+++ b/src/Compiler/Reports/PlacementReportManager.h
@@ -39,6 +39,7 @@ class PlacementReportManager final : public AbstractReportManager {
   const Messages &getMessages() override;
   QString getTimingLogFileName() const override;
   bool isStatisticalTimingLine(const QString &line) override;
+  void splitTimingData(const QString &timingStr) override;
 
   void parseLogFile();
 

--- a/src/Compiler/Reports/RoutingReportManager.h
+++ b/src/Compiler/Reports/RoutingReportManager.h
@@ -41,14 +41,18 @@ class RoutingReportManager final : public AbstractReportManager {
   const Messages &getMessages() override;
   QString getTimingLogFileName() const override;
   bool isStatisticalTimingLine(const QString &line) override;
+  void splitTimingData(const QString &timingStr) override;
 
   IDataReport::TableData parseCircuitStats(QTextStream &in, int &lineNr);
+  IDataReport::TableData parseHistogram(QTextStream &in, int &lineNr);
 
   void parseLogFile();
 
   void reset();
 
+  IDataReport::TableData m_histogramData;
   IDataReport::TableData m_circuitData;
+
   QStringList m_circuitColumns;
   SectionKeys m_routingKeys;
 };

--- a/src/Compiler/Reports/SynthesisReportManager.cpp
+++ b/src/Compiler/Reports/SynthesisReportManager.cpp
@@ -197,4 +197,7 @@ QString SynthesisReportManager::getTimingLogFileName() const {
   return {};
 }
 
+void SynthesisReportManager::splitTimingData(const QString &timingStr) {
+  // Current synthesis log implementation doesn't contain timing info
+}
 }  // namespace FOEDAG

--- a/src/Compiler/Reports/SynthesisReportManager.h
+++ b/src/Compiler/Reports/SynthesisReportManager.h
@@ -48,6 +48,7 @@ class SynthesisReportManager final : public AbstractReportManager {
   std::unique_ptr<ITaskReport> createReport(const QString &reportId) override;
   const Messages &getMessages() override;
   QString getTimingLogFileName() const override;
+  void splitTimingData(const QString &timingStr) override;
 
   // Retrieves maximum and average levels out of given line and fills into stats
   void fillLevels(const QString &line, IDataReport::TableData &stats) const;


### PR DESCRIPTION
> ### Motivate of the pull request
This PR fills the gap of statistical timing reports and extend the table with more info. (RG-242)

> ### Describe the technical details
(This PR also contains some preparation code to histogram report, but it doesn't work yet - will be implemented in a following PR).

Initially we only included following info to the report:
Final critical path delay (least slack): 9.36799 ns, Fmax: 106.746 MHz
Final setup Worst Negative Slack (sWNS): -6.86799 ns
Final setup Total Negative Slack (sTNS): -2830.4 ns

This PR extends it with:
Placement
Placement estimated geomean non-virtual intra-domain period: 8.36557 ns (119.538 MHz)
Placement estimated fanout-weighted geomean non-virtual intra-domain period: 8.36557 ns (119.538 MHz)

Routing:
Final hold Worst Negative Slack (hWNS): 0 ns
Final hold Total Negative Slack (hTNS): 0 ns

Final geomean non-virtual intra-domain period: 9.36799 ns (106.746 MHz)
Final fanout-weighted geomean non-virtual intra-domain period: 9.36799 ns (106.746 MHz)
>
> #### What does this pull request change?
Now timing reports look as follows:
![image](https://user-images.githubusercontent.com/109239890/208684535-a1741e9f-b233-4132-b681-09a3d95a9e0e.png)

![image](https://user-images.githubusercontent.com/109239890/208684709-31c872d6-13e6-407f-bc98-56d208e6a801.png)