### PR TITLE
[RG-234] Simulation settings: simulator, options

### DIFF
--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -241,11 +241,51 @@
             }
         },
         "Simulate RTL": {
-            "input": {
+            "waveform_file": {
                 "label": "Waveform file:",
                 "widgetType": "input",
                 "default": "sim_rtl.fst",
                 "arg": "rtl_filepath"
+            },
+            "rtl_sim_type": {
+                "label": "Simulator:",
+                "widgetType": "dropdown",
+                "options": [
+                    "Verilator",
+                    "GHDL",
+                    "Icarus",
+                    "VCS",
+                    "Questa",
+                    "Xcelium"
+                ],
+                "optionsLookup": [
+                    "verilator",
+                    "ghdl",
+                    "icarus",
+                    "vcs",
+                    "questa",
+                    "xcelium"
+                ],
+                "default": "verilator",
+                "arg": "rtl_sim_type"
+            },
+            "options_sim": {
+                "label": "Simulation options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "sim_rtl_opt"
+            },
+            "options_el": {
+                "label": "Elaboration options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "el_rtl_opt"
+            },
+            "options_com": {
+                "label": "Compilation options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "com_rtl_opt"
             },
             "_META_": {
                 "hidden": false,
@@ -254,11 +294,51 @@
             }
         },
         "Simulate Gate": {
-            "input": {
+            "waveform_file": {
                 "label": "Waveform file:",
                 "widgetType": "input",
                 "default": "sim_gate.fst",
                 "arg": "gate_filepath"
+            },
+            "gate_sim_type": {
+                "label": "Simulator:",
+                "widgetType": "dropdown",
+                "options": [
+                    "Verilator",
+                    "GHDL",
+                    "Icarus",
+                    "VCS",
+                    "Questa",
+                    "Xcelium"
+                ],
+                "optionsLookup": [
+                    "verilator",
+                    "ghdl",
+                    "icarus",
+                    "vcs",
+                    "questa",
+                    "xcelium"
+                ],
+                "default": "verilator",
+                "arg": "gate_sim_type"
+            },
+            "options_sim": {
+                "label": "Simulation options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "sim_gate_opt"
+            },
+            "options_el": {
+                "label": "Elaboration options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "el_gate_opt"
+            },
+            "options_com": {
+                "label": "Compilation options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "com_gate_opt"
             },
             "_META_": {
                 "hidden": false,
@@ -267,11 +347,51 @@
             }
         },
         "Simulate PNR": {
-            "input": {
+            "waveform_file": {
                 "label": "Waveform file:",
                 "widgetType": "input",
                 "default": "sim_pnr.fst",
                 "arg": "pnr_filepath"
+            },
+            "pnr_sim_type": {
+                "label": "Simulator:",
+                "widgetType": "dropdown",
+                "options": [
+                    "Verilator",
+                    "GHDL",
+                    "Icarus",
+                    "VCS",
+                    "Questa",
+                    "Xcelium"
+                ],
+                "optionsLookup": [
+                    "verilator",
+                    "ghdl",
+                    "icarus",
+                    "vcs",
+                    "questa",
+                    "xcelium"
+                ],
+                "default": "verilator",
+                "arg": "pnr_sim_type"
+            },
+            "options_sim": {
+                "label": "Simulation options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "sim_pnr_opt"
+            },
+            "options_el": {
+                "label": "Elaboration options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "el_pnr_opt"
+            },
+            "options_com": {
+                "label": "Compilation options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "com_pnr_opt"
             },
             "_META_": {
                 "hidden": false,
@@ -280,11 +400,51 @@
             }
         },
         "Simulate Bitstream": {
-            "input": {
+            "waveform_file": {
                 "label": "Waveform file:",
                 "widgetType": "input",
                 "default": "sim_bitstream.fst",
                 "arg": "bitstream_filepath"
+            },
+            "bitstream_sim_type": {
+                "label": "Simulator:",
+                "widgetType": "dropdown",
+                "options": [
+                    "Verilator",
+                    "GHDL",
+                    "Icarus",
+                    "VCS",
+                    "Questa",
+                    "Xcelium"
+                ],
+                "optionsLookup": [
+                    "verilator",
+                    "ghdl",
+                    "icarus",
+                    "vcs",
+                    "questa",
+                    "xcelium"
+                ],
+                "default": "verilator",
+                "arg": "bitstream_sim_type"
+            },
+            "options_sim": {
+                "label": "Simulation options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "sim_bitstream_opt"
+            },
+            "options_el": {
+                "label": "Elaboration options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "el_bitstream_opt"
+            },
+            "options_com": {
+                "label": "Compilation options:",
+                "widgetType": "textedit",
+                "default": "",
+                "arg": "com_bitstream_opt"
             },
             "_META_": {
                 "hidden": false,

--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -290,7 +290,7 @@
             "_META_": {
                 "hidden": false,
                 "isSetting": true,
-                "tclArgKey": "Tasks_Simulate"
+                "tclArgKey": "Tasks_Simulate_rtl"
             }
         },
         "Simulate Gate": {
@@ -343,7 +343,7 @@
             "_META_": {
                 "hidden": false,
                 "isSetting": true,
-                "tclArgKey": "Tasks_Simulate"
+                "tclArgKey": "Tasks_Simulate_gate"
             }
         },
         "Simulate PNR": {
@@ -396,7 +396,7 @@
             "_META_": {
                 "hidden": false,
                 "isSetting": true,
-                "tclArgKey": "Tasks_Simulate"
+                "tclArgKey": "Tasks_Simulate_pnr"
             }
         },
         "Simulate Bitstream": {
@@ -449,7 +449,7 @@
             "_META_": {
                 "hidden": false,
                 "isSetting": true,
-                "tclArgKey": "Tasks_Simulate"
+                "tclArgKey": "Tasks_Simulate_bitstream"
             }
         }
     }

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -880,27 +880,33 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       std::string sim_type;
       std::string wave_file;
       bool clean{false};
+      bool sim_tool_valid{false};
       for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
-        if (arg == "verilator") {
-          sim_tool = Simulator::SimulatorType::Verilator;
-        } else if (arg == "icarus") {
-          sim_tool = Simulator::SimulatorType::Icarus;
-        } else if (arg == "ghdl") {
-          sim_tool = Simulator::SimulatorType::GHDL;
-        } else if (arg == "vcs") {
-          sim_tool = Simulator::SimulatorType::VCS;
-        } else if (arg == "questa") {
-          sim_tool = Simulator::SimulatorType::Questa;
-        } else if (arg == "xcelium") {
-          sim_tool = Simulator::SimulatorType::Xcelium;
-        } else if (arg == "rtl" || arg == "gate" || arg == "pnr" ||
-                   arg == "bitstream_fd" || arg == "bitstream_bd") {
+        bool ok{false};
+        auto sim = Simulator::ToSimulatorType(
+            arg, ok, Simulator::SimulatorType::Verilator);
+        if (ok) {
+          sim_tool = sim;
+          sim_tool_valid = true;
+        }
+        if (arg == "rtl" || arg == "gate" || arg == "pnr" ||
+            arg == "bitstream_fd" || arg == "bitstream_bd") {
           sim_type = arg;
         } else if (arg == "clean") {
           clean = true;
         } else {
           wave_file = arg;
+        }
+      }
+      if (!sim_tool_valid) {
+        bool ok{false};
+        auto level = Simulator::ToSimulationType(sim_type, ok);
+        if (ok) {
+          ok = false;
+          auto simTool =
+              compiler->GetSimulator()->UserSimulationType(level, ok);
+          if (ok) sim_tool = simTool;
         }
       }
       compiler->SetWaveformFile(wave_file);
@@ -1193,28 +1199,34 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       std::string sim_type;
       std::string wave_file;
       bool clean{false};
+      bool sim_tool_valid{false};
       Simulator::SimulatorType sim_tool = Simulator::SimulatorType::Verilator;
       for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
-        if (arg == "verilator") {
-          sim_tool = Simulator::SimulatorType::Verilator;
-        } else if (arg == "icarus") {
-          sim_tool = Simulator::SimulatorType::Icarus;
-        } else if (arg == "ghdl") {
-          sim_tool = Simulator::SimulatorType::GHDL;
-        } else if (arg == "vcs") {
-          sim_tool = Simulator::SimulatorType::VCS;
-        } else if (arg == "questa") {
-          sim_tool = Simulator::SimulatorType::Questa;
-        } else if (arg == "xcelium") {
-          sim_tool = Simulator::SimulatorType::Xcelium;
-        } else if (arg == "rtl" || arg == "gate" || arg == "pnr" ||
-                   arg == "bitstream_bd" || arg == "bitstream_fd") {
+        bool ok{false};
+        auto sim = Simulator::ToSimulatorType(
+            arg, ok, Simulator::SimulatorType::Verilator);
+        if (ok) {
+          sim_tool = sim;
+          sim_tool_valid = true;
+        }
+        if (arg == "rtl" || arg == "gate" || arg == "pnr" ||
+            arg == "bitstream_fd" || arg == "bitstream_bd") {
           sim_type = arg;
         } else if (arg == "clean") {
           clean = true;
         } else {
           wave_file = arg;
+        }
+      }
+      if (!sim_tool_valid) {
+        bool ok{false};
+        auto level = Simulator::ToSimulationType(sim_type, ok);
+        if (ok) {
+          ok = false;
+          auto simTool =
+              compiler->GetSimulator()->UserSimulationType(level, ok);
+          if (ok) sim_tool = simTool;
         }
       }
       compiler->SetWaveformFile(wave_file);

--- a/src/Main/Tasks.h
+++ b/src/Main/Tasks.h
@@ -45,8 +45,17 @@ std::string TclArgs_getExampleArgs();
 void TclArgs_setPlacementOptions(const std::string& argsStr);
 std::string TclArgs_getPlacementOptions();
 
-void TclArgs_setSimulateOptions(const std::string& argsStr);
-std::string TclArgs_getSimulateOptions();
+void TclArgs_setSimulateOptions_rtl(const std::string& argsStr);
+std::string TclArgs_getSimulateOptions_rtl();
+
+void TclArgs_setSimulateOptions_gate(const std::string& argsStr);
+std::string TclArgs_getSimulateOptions_gate();
+
+void TclArgs_setSimulateOptions_pnr(const std::string& argsStr);
+std::string TclArgs_getSimulateOptions_pnr();
+
+void TclArgs_setSimulateOptions_bitstream(const std::string& argsStr);
+std::string TclArgs_getSimulateOptions_bitstream();
 
 void TclArgs_setTimingAnalysisOptions(const std::string& argsStr);
 std::string TclArgs_getTimingAnalysisOptions();

--- a/src/Main/WidgetFactory.cpp
+++ b/src/Main/WidgetFactory.cpp
@@ -68,8 +68,16 @@ void FOEDAG::initTclArgFns() {
                                    FOEDAG::TclArgs_getSynthesisOptions});
   addTclArgFns("Tasks_placement", {FOEDAG::TclArgs_setPlacementOptions,
                                    FOEDAG::TclArgs_getPlacementOptions});
-  addTclArgFns("Tasks_Simulate", {FOEDAG::TclArgs_setSimulateOptions,
-                                  FOEDAG::TclArgs_getSimulateOptions});
+  addTclArgFns("Tasks_Simulate_rtl", {FOEDAG::TclArgs_setSimulateOptions_rtl,
+                                      FOEDAG::TclArgs_getSimulateOptions_rtl});
+  addTclArgFns("Tasks_Simulate_gate",
+               {FOEDAG::TclArgs_setSimulateOptions_gate,
+                FOEDAG::TclArgs_getSimulateOptions_gate});
+  addTclArgFns("Tasks_Simulate_pnr", {FOEDAG::TclArgs_setSimulateOptions_pnr,
+                                      FOEDAG::TclArgs_getSimulateOptions_pnr});
+  addTclArgFns("Tasks_Simulate_bitstream",
+               {FOEDAG::TclArgs_setSimulateOptions_bitstream,
+                FOEDAG::TclArgs_getSimulateOptions_bitstream});
   addTclArgFns("Tasks_TimingAnalysis",
                {FOEDAG::TclArgs_setTimingAnalysisOptions,
                 FOEDAG::TclArgs_getTimingAnalysisOptions});

--- a/src/Simulation/Simulator.h
+++ b/src/Simulation/Simulator.h
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef SIMULATOR_H
 #define SIMULATOR_H
 
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <string>

--- a/src/Simulation/Simulator.h
+++ b/src/Simulation/Simulator.h
@@ -48,7 +48,10 @@ class Simulator {
   enum class SimulationOpt { None, Clean };
 
   static SimulationType ToSimulationType(const std::string& str, bool& ok);
-
+  static SimulatorType ToSimulatorType(
+      const std::string& str, bool& ok,
+      SimulatorType defaultValue = SimulatorType::Verilator);
+  static std::string ToString(SimulatorType type);
   // Most common use case, create the compiler in your main
   Simulator() = default;
   Simulator(TclInterpreter* interp, Compiler* compiler, std::ostream* out,
@@ -104,6 +107,9 @@ class Simulator {
   void WaveFile(SimulationType type, const std::string& file);
   std::string WaveFile(SimulationType type) const;
 
+  void UserSimulationType(SimulationType simulation, SimulatorType simulator);
+  SimulatorType UserSimulationType(SimulationType simulation, bool& ok) const;
+
  protected:
   virtual bool SimulateRTL(SimulatorType type);
   virtual bool SimulateGate(SimulatorType type);
@@ -151,6 +157,7 @@ class Simulator {
   WaveformType m_waveType = WaveformType::FST;
   SimulationOpt m_simulationOpt{SimulationOpt::None};
   std::map<SimulationType, std::string> m_waveFiles;
+  std::map<SimulationType, SimulatorType> m_simulatorTypes;
   SimulationType m_simType = SimulationType::RTL;
 };
 

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -42,6 +42,7 @@ set (CPP_LIST
     Compiler/CompilerDefines_test.cpp
     PinAssignment/PortsModel_test.cpp
     PinAssignment/PinAssignmentBaseView_test.cpp
+    Simulation/Simulation_test.cpp
 )
 set (H_LIST
     PinAssignment/TestLoader.h

--- a/tests/unittest/Simulation/Simulation_test.cpp
+++ b/tests/unittest/Simulation/Simulation_test.cpp
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "Simulation/Simulator.h"
+#include "gtest/gtest.h"
+
+using namespace FOEDAG;
+
+TEST(Simulator, ToSimulatorType) {
+  // SimulatorType { Verilator, Icarus, GHDL, VCS, Questa, Xcelium };
+  bool ok{false};
+  auto res = Simulator::ToSimulatorType("verilator", ok);
+  EXPECT_EQ(res, Simulator::SimulatorType::Verilator);
+  EXPECT_EQ(ok, true);
+  ok = false;
+
+  res = Simulator::ToSimulatorType("icarus", ok);
+  EXPECT_EQ(res, Simulator::SimulatorType::Icarus);
+  EXPECT_EQ(ok, true);
+  ok = false;
+
+  res = Simulator::ToSimulatorType("ghdl", ok);
+  EXPECT_EQ(res, Simulator::SimulatorType::GHDL);
+  EXPECT_EQ(ok, true);
+  ok = false;
+
+  res = Simulator::ToSimulatorType("vcs", ok);
+  EXPECT_EQ(res, Simulator::SimulatorType::VCS);
+  EXPECT_EQ(ok, true);
+  ok = false;
+
+  res = Simulator::ToSimulatorType("questa", ok);
+  EXPECT_EQ(res, Simulator::SimulatorType::Questa);
+  EXPECT_EQ(ok, true);
+  ok = false;
+
+  res = Simulator::ToSimulatorType("xcelium", ok);
+  EXPECT_EQ(res, Simulator::SimulatorType::Xcelium);
+  EXPECT_EQ(ok, true);
+  ok = false;
+
+  auto defaultValue{Simulator::SimulatorType::Xcelium};
+  res = Simulator::ToSimulatorType("unknown", ok, defaultValue);
+  EXPECT_EQ(res, defaultValue);
+  EXPECT_EQ(ok, false);
+}
+
+TEST(Simulator, ToStringSimulatorType) {
+  EXPECT_EQ(Simulator::ToString(Simulator::SimulatorType::Verilator),
+            "verilator");
+  EXPECT_EQ(Simulator::ToString(Simulator::SimulatorType::GHDL), "ghdl");
+  EXPECT_EQ(Simulator::ToString(Simulator::SimulatorType::Icarus), "icarus");
+  EXPECT_EQ(Simulator::ToString(Simulator::SimulatorType::Questa), "questa");
+  EXPECT_EQ(Simulator::ToString(Simulator::SimulatorType::VCS), "vcs");
+  EXPECT_EQ(Simulator::ToString(Simulator::SimulatorType::Xcelium), "xcelium");
+}
+
+TEST(Simulator, ToSimulationType) {
+  // SimulationType { RTL, Gate, PNR, Bitstream };
+  bool ok{false};
+  auto res = Simulator::ToSimulationType("rtl", ok);
+  EXPECT_EQ(ok, true);
+  EXPECT_EQ(res, Simulator::SimulationType::RTL);
+
+  ok = false;
+  res = Simulator::ToSimulationType("gate", ok);
+  EXPECT_EQ(ok, true);
+  EXPECT_EQ(res, Simulator::SimulationType::Gate);
+
+  ok = false;
+  res = Simulator::ToSimulationType("pnr", ok);
+  EXPECT_EQ(ok, true);
+  EXPECT_EQ(res, Simulator::SimulationType::PNR);
+
+  ok = false;
+  res = Simulator::ToSimulationType("bitstream_bd", ok);
+  EXPECT_EQ(ok, true);
+  EXPECT_EQ(res, Simulator::SimulationType::BitstreamBackDoor);
+
+  ok = false;
+  res = Simulator::ToSimulationType("bitstream_fd", ok);
+  EXPECT_EQ(ok, true);
+  EXPECT_EQ(res, Simulator::SimulationType::BitstreamFrontDoor);
+
+  ok = false;
+  res = Simulator::ToSimulationType("unknown", ok);
+  EXPECT_EQ(ok, false);
+  EXPECT_EQ(res, Simulator::SimulationType::RTL);
+}
+
+TEST(Simulator, UserSimulationType) {
+  Simulator sim;
+  sim.UserSimulationType(Simulator::SimulationType::RTL,
+                         Simulator::SimulatorType::Xcelium);
+
+  bool ok{false};
+  auto simulator = sim.UserSimulationType(Simulator::SimulationType::RTL, ok);
+
+  EXPECT_EQ(simulator, Simulator::SimulatorType::Xcelium);
+  EXPECT_EQ(ok, true);
+
+  ok = false;
+  simulator =
+      sim.UserSimulationType(Simulator::SimulationType::BitstreamBackDoor, ok);
+
+  EXPECT_EQ(simulator, Simulator::SimulatorType::Verilator);
+  EXPECT_EQ(ok, false);
+}

--- a/tests/unittest/Utils/StringUtils_test.cpp
+++ b/tests/unittest/Utils/StringUtils_test.cpp
@@ -82,6 +82,15 @@ TEST_F(MultiLineTest, tokenizeTest) {
             "Hope that this program will be useful.");
 }
 
+// TODO @volodymyrk RG-238
+// TEST_F(MultiLineTest, tokenizeLongSeparator) {
+//  auto tokenized_lines = std::vector<std::string>{};
+//  std::string testStr{"test0SEPARATORtest1SEPARATORtest2"};
+//  StringUtils::tokenize(testStr, "SEPARATOR", tokenized_lines);
+//  ASSERT_EQ(tokenized_lines.size(), 3);
+//  EXPECT_EQ(*tokenized_lines.rbegin(), "test2");
+//}
+
 TEST_F(MultiLineTest, tokenizeTestSkipEmpty) {
   auto tokenized_lines = std::vector<std::string>{};
   auto testStr{"  string   with   empty    spaces  "};


### PR DESCRIPTION
### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: RG-234
 - [x] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
 #### What is currently done? (Provide issue link if applicable)

New settings added for simulation rtl/gate/pnr/bitstream:
![image](https://user-images.githubusercontent.com/95262932/209339565-e39d0ba9-82f6-4c68-9f1b-52e3497db51b.png)

 #### What does this pull request change?
Settings json file extended with new settings for all simulation types.
Added few conversion functions (like `ToSimulatorType` or `ToString`) to avoid code duplication.
Added integration task settings into `simulate` command. 
Changes in `src/Main/Tasks.cpp` are need for save/load data to/from settings widget.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, simulation, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts

[RG-234]: https://rapidsilicon.atlassian.net/browse/RG-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ