### PR TITLE
[RG-203] Allow user to change default project folder

### DIFF
--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -64,6 +64,7 @@ set (SRC_CPP_LIST ../Main/Foedag.cpp
   ../MainWindow/WelcomePageWidget.cpp
   ../Main/TclSimpleParser.cpp
   CompilerNotifier.cpp
+  ../MainWindow/PathEdit.cpp
 )
 
 set (SRC_H_LIST ../Main/Foedag.h
@@ -93,6 +94,7 @@ set (SRC_H_LIST ../Main/Foedag.h
   ../MainWindow/WelcomePageWidget.h
   CompilerNotifier.h
   ../Main/TclSimpleParser.h
+  ../MainWindow/PathEdit.h
 )
 
 set (SRC_UI_LIST "")

--- a/src/MainWindow/PathEdit.cpp
+++ b/src/MainWindow/PathEdit.cpp
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "PathEdit.h"
+
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QToolButton>
+
+namespace FOEDAG {
+
+PathEdit::PathEdit(QWidget *parent) : QWidget{parent} {
+  auto layout = new QHBoxLayout{};
+
+  m_edit = new QLineEdit{this};
+  QToolButton *tool = new QToolButton{this};
+  tool->setText("...");
+  layout->addWidget(m_edit);
+  layout->addWidget(tool);
+  setLayout(layout);
+
+  connect(tool, &QToolButton::clicked, this, [this]() {
+    auto folder = QFileDialog::getExistingDirectory(
+        this, tr("Select Directory"), text(),
+        QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks |
+            QFileDialog::DontUseNativeDialog);
+    if (!folder.isEmpty()) setText(folder);
+  });
+}
+
+QString PathEdit::text() const { return m_edit->text(); }
+
+void PathEdit::setText(const QString &text) { m_edit->setText(text); }
+
+}  // namespace FOEDAG

--- a/src/MainWindow/PathEdit.h
+++ b/src/MainWindow/PathEdit.h
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <QWidget>
+
+class QLineEdit;
+namespace FOEDAG {
+
+class PathEdit : public QWidget {
+  Q_OBJECT
+ public:
+  explicit PathEdit(QWidget *parent = nullptr);
+
+  QString text() const;
+  void setText(const QString &text);
+
+ signals:
+
+ private:
+  QLineEdit *m_edit;
+};
+
+}  // namespace FOEDAG

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -50,6 +50,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "NewFile/new_file.h"
 #include "NewProject/Main/registerNewProjectCommands.h"
 #include "NewProject/new_project_dialog.h"
+#include "PathEdit.h"
 #include "PinAssignment/PinAssignmentCreator.h"
 #include "ProjNavigator/PropertyWidget.h"
 #include "ProjNavigator/sources_form.h"
@@ -75,6 +76,7 @@ const QString SHOW_STOP_COMPILATION_MESSAGE_KEY{"showStopCompilationMessage"};
 constexpr uint RECENT_PROJECT_COUNT{10};
 constexpr uint RECENT_PROJECT_COUNT_WP{5};
 constexpr const char* WELCOME_PAGE_MENU_PROP{"showOnWelcomePage"};
+constexpr const char* DEFAULT_PROJECT_PATH{"defaultProjectPath"};
 
 void centerWidget(QWidget& widget) {
   auto screenGeometry = qApp->primaryScreen()->availableGeometry();
@@ -442,6 +444,35 @@ void MainWindow::refreshPinPlanner() {
   pinPlannerSaved();
 }
 
+void MainWindow::defaultProjectPath() {
+  auto defaultPath{QDir::homePath()};
+  auto path = m_settings.value(DEFAULT_PROJECT_PATH, defaultPath).toString();
+  PathEdit* edit = new PathEdit;
+  edit->setText(path);
+
+  QDialog dialog{this};
+  dialog.setWindowTitle(defualtProjectPathAction->text());
+  auto layout = new QGridLayout;
+  dialog.setLayout(layout);
+  auto buttons =
+      new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+  auto ok = buttons->button(QDialogButtonBox::Ok);
+  auto cancel = buttons->button(QDialogButtonBox::Cancel);
+  connect(ok, &QPushButton::clicked, &dialog, &QDialog::accept);
+  connect(cancel, &QPushButton::clicked, &dialog, &QDialog::reject);
+  layout->addWidget(edit);
+  layout->addWidget(buttons, 1, 0);
+  dialog.setModal(true);
+  auto result = dialog.exec();
+  if (result == QDialog::Accepted) {
+    auto newPath = edit->text();
+    if (QDir{newPath}.exists()) {
+      m_settings.setValue(DEFAULT_PROJECT_PATH, newPath);
+      newProjdialog->SetDefaultPath(newPath);
+    }
+  }
+}
+
 void MainWindow::saveToRecentSettings(const QString& project) {
   if (project.isEmpty()) return;
 
@@ -615,6 +646,7 @@ void MainWindow::createMenus() {
   helpMenu->addSeparator();
   helpMenu->addAction(licensesAction);
 
+  preferencesMenu->addAction(defualtProjectPathAction);
   preferencesMenu->addAction(showWelcomePageAction);
   preferencesMenu->addAction(stopCompileMessageAction);
 
@@ -684,6 +716,8 @@ void MainWindow::createActions() {
   connect(closeProjectAction, SIGNAL(triggered()), this, SLOT(closeProject()));
 
   newProjdialog = new newProjectDialog(this);
+  newProjdialog->SetDefaultPath(
+      m_settings.value(DEFAULT_PROJECT_PATH, QString{}).toString());
   connect(newProjdialog, SIGNAL(accepted()), this, SLOT(newDialogAccepted()));
   newProjectAction = new QAction(tr("&New Project..."), this);
   newProjectAction->setStatusTip(tr("Create a new project"));
@@ -759,6 +793,10 @@ void MainWindow::createActions() {
   showWelcomePageAction->setChecked(m_showWelcomePage);
   connect(showWelcomePageAction, &QAction::triggered, this,
           &MainWindow::onShowWelcomePage);
+
+  defualtProjectPathAction = new QAction{tr("Default project path"), this};
+  connect(defualtProjectPathAction, &QAction::triggered, this,
+          &MainWindow::defaultProjectPath);
 
   stopCompileMessageAction =
       new QAction(tr("Show message on stop compilation"), this);

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -88,6 +88,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void showReportsTab();
   void fileModified(const QString& file);
   void refreshPinPlanner();
+  void defaultProjectPath();
 
  public slots:
   void updateSourceTree();
@@ -187,6 +188,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   QAction* simGateAction = nullptr;
   QAction* simPnrAction = nullptr;
   QAction* simBitstreamAction = nullptr;
+  QAction* defualtProjectPathAction = nullptr;
   std::vector<std::pair<QAction*, QString>> m_recentProjectsActions;
   newProjectDialog* newProjdialog = nullptr;
   /* Tool bar objects */

--- a/src/NewProject/location_form.cpp
+++ b/src/NewProject/location_form.cpp
@@ -5,12 +5,12 @@
 #include "ui_location_form.h"
 using namespace FOEDAG;
 
-locationForm::locationForm(QWidget *parent)
+locationForm::locationForm(const QString &defaultPath, QWidget *parent)
     : QWidget(parent), ui(new Ui::locationForm) {
   ui->setupUi(this);
   int count = 1;
   QString project_prefix = "project_";
-  QString homePath = QDir::homePath();
+  QString homePath = defaultPath.isEmpty() ? QDir::homePath() : defaultPath;
   QString projectPathPrefix =
       QDir::homePath() + QDir::separator() + project_prefix;
   while (QDir(projectPathPrefix + QString::number(count)).exists()) {

--- a/src/NewProject/location_form.h
+++ b/src/NewProject/location_form.h
@@ -13,7 +13,8 @@ class locationForm : public QWidget {
   Q_OBJECT
 
  public:
-  explicit locationForm(QWidget *parent = nullptr);
+  explicit locationForm(const QString &defaultPath = QString{},
+                        QWidget *parent = nullptr);
   ~locationForm();
 
   QString getProjectName();

--- a/src/NewProject/new_project_dialog.cpp
+++ b/src/NewProject/new_project_dialog.cpp
@@ -113,6 +113,10 @@ void newProjectDialog::SetPageActive(FormIndex index) {
   }
 }
 
+void newProjectDialog::SetDefaultPath(const QString &path) {
+  m_defaultPath = path;
+}
+
 void newProjectDialog::updateSummaryPage() {
   if (m_mode == Mode::NewProject) return;
   auto currentPage = ui->m_tabWidget->currentWidget();
@@ -149,7 +153,7 @@ void newProjectDialog::ResetToNewProject() {
   setWindowTitle(tr("New Project"));
   ui->m_tabWidget->clear();
 
-  m_locationForm = new locationForm(this);
+  m_locationForm = new locationForm(m_defaultPath, this);
   ui->m_tabWidget->insertTab(INDEX_LOCATION, m_locationForm,
                              tr("Project Directory"));
   m_proTypeForm = new projectTypeForm(this);

--- a/src/NewProject/new_project_dialog.h
+++ b/src/NewProject/new_project_dialog.h
@@ -52,6 +52,8 @@ class newProjectDialog : public QDialog {
   Mode GetMode() const;
   void SetPageActive(FormIndex index);
 
+  void SetDefaultPath(const QString& path);
+
  private slots:
   void updateSummaryPage();
   void on_buttonBox_accepted();
@@ -74,6 +76,7 @@ class newProjectDialog : public QDialog {
   Mode m_mode{NewProject};
   QVector<SettingsGuiInterface*> m_settings;
   QMap<FormIndex, int> m_tabIndexes;
+  QString m_defaultPath;
 
   ProjectManager* m_projectManager;
   bool m_skipSources{false};


### PR DESCRIPTION
### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Menu File->Preferences extended with Default project path:
![image](https://user-images.githubusercontent.com/95262932/209541119-34b54706-22ae-4e13-90e6-f649953106b2.png)

Dialog allow to select path. This path then will be used when create new project:
![image](https://user-images.githubusercontent.com/95262932/209541235-fe7387d5-67bf-4618-82df-0ff07fd92e74.png)

This setting is persistent.

`PathEdit` new class that encapsulate QTextEdit with button and QFileDialog.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: newproject, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
