### PR TITLE
[RG-256] Add auto detect of netlist verilog by file extention for post synth project type

### DIFF
--- a/src/Compiler/CompilerDefines.cpp
+++ b/src/Compiler/CompilerDefines.cpp
@@ -150,8 +150,11 @@ uint FOEDAG::toTaskId(int action, Compiler *const compiler) {
 }
 
 FOEDAG::Design::Language FOEDAG::FromFileType(const QString &type,
-                                              Design::Language defaultValue) {
-  if (QtUtils::IsEqual(type, "v")) return Design::Language::VERILOG_2001;
+                                              bool postSynth) {
+  if (QtUtils::IsEqual(type, "v")) {
+    if (postSynth) return Design::Language::VERILOG_NETLIST;
+    return Design::Language::VERILOG_2001;
+  }
   if (QtUtils::IsEqual(type, "sv")) return Design::Language::SYSTEMVERILOG_2017;
   if (QtUtils::IsEqual(type, "vhd")) return Design::Language::VHDL_2008;
   if (QtUtils::IsEqual(type, "blif")) return Design::Language::BLIF;
@@ -159,7 +162,8 @@ FOEDAG::Design::Language FOEDAG::FromFileType(const QString &type,
   if (QtUtils::IsEqual(type, "c") || QtUtils::IsEqual(type, "cc"))
     return Design::Language::C;
   if (QtUtils::IsEqual(type, "cpp")) return Design::Language::CPP;
-  return defaultValue;  // default
+  return postSynth ? Design::Language::VERILOG_NETLIST
+                   : Design::Language::VERILOG_2001;
 }
 
 int FOEDAG::read_sdc(const QString &file) {

--- a/src/Compiler/CompilerDefines.h
+++ b/src/Compiler/CompilerDefines.h
@@ -52,8 +52,7 @@ enum Language {
 };
 }  // namespace Design
 
-Design::Language FromFileType(
-    const QString &type, Design::Language defaultValue = Design::VERILOG_2001);
+Design::Language FromFileType(const QString &type, bool postSynth = false);
 
 // ID of the tasks shouln't be changed since they save to file
 static constexpr uint IP_GENERATE{0};

--- a/src/NewProject/source_grid.cpp
+++ b/src/NewProject/source_grid.cpp
@@ -210,8 +210,6 @@ void sourceGrid::AddFiles() {
   }
   if (!CheckNetlistFileExists(fileNames)) return;
 
-  auto defaultLang = CurrentProjectType() == PostSynth ? Design::VERILOG_NETLIST
-                                                       : Design::VERILOG_2001;
   for (const QString &str : fileNames) {
     const QFileInfo info{str};
     filedata fdata;
@@ -219,7 +217,8 @@ void sourceGrid::AddFiles() {
     fdata.m_fileType = info.suffix();
     fdata.m_fileName = info.fileName();
     fdata.m_filePath = info.path();
-    fdata.m_language = FromFileType(info.suffix(), defaultLang);
+    fdata.m_language =
+        FromFileType(info.suffix(), CurrentProjectType() == PostSynth);
     AddTableItem(fdata);
   }
 }
@@ -248,8 +247,6 @@ void sourceGrid::AddDirectories() {
 
   if (!CheckNetlistFileExists(checkUnique)) return;
 
-  auto defaultLang = CurrentProjectType() == PostSynth ? Design::VERILOG_NETLIST
-                                                       : Design::VERILOG_2001;
   for (auto &[fileName, filePath] : files) {
     const QFileInfo info{filePath};
     filedata fdata;
@@ -257,7 +254,8 @@ void sourceGrid::AddDirectories() {
     fdata.m_fileType = info.suffix();
     fdata.m_fileName = fileName;
     fdata.m_filePath = info.path();
-    fdata.m_language = FromFileType(info.suffix(), defaultLang);
+    fdata.m_language =
+        FromFileType(info.suffix(), CurrentProjectType() == PostSynth);
     AddTableItem(fdata);
   }
 }

--- a/tests/unittest/Compiler/CompilerDefines_test.cpp
+++ b/tests/unittest/Compiler/CompilerDefines_test.cpp
@@ -52,7 +52,8 @@ TEST(CompilerDefines, FromFileType) {
   EXPECT_EQ(FromFileType("anything"), Language::VERILOG_2001);
 }
 
-TEST(CompilerDefines, FromFileTypeDefault) {
-  auto type = FromFileType("anything", Language::CPP);
-  EXPECT_EQ(type, Language::CPP);
+TEST(CompilerDefines, FromFileTypePostSynth) {
+  EXPECT_EQ(FromFileType("v", true), Language::VERILOG_NETLIST);
+  EXPECT_EQ(FromFileType("V", true), Language::VERILOG_NETLIST);
+  EXPECT_EQ(FromFileType("anything", true), Language::VERILOG_NETLIST);
 }


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-256
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
For post synth project type we detect file *.v as **netlist** verilog. But not verilog.
The root cause of issue we have detected wrong file language:
![image](https://user-images.githubusercontent.com/95262932/209681228-48b6c97b-f9f9-45a1-a1c5-2e7c7bdc8e0d.png)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, newproject
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
