### PR TITLE
[RG-164] Cleanup code for compiler class

### DIFF
--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -240,7 +240,7 @@ Compiler::~Compiler() {
   delete m_simulator;
 }
 
-std::string Compiler::GetMessagePrefix() {
+std::string Compiler::GetMessagePrefix() const {
   std::string prefix{};
 
   auto task = GetTaskManager()->currentTask();
@@ -252,11 +252,11 @@ std::string Compiler::GetMessagePrefix() {
   return prefix;
 }
 
-void Compiler::Message(const std::string& message) {
+void Compiler::Message(const std::string& message) const {
   if (m_out) (*m_out) << "INFO: " << GetMessagePrefix() << message << std::endl;
 }
 
-void Compiler::ErrorMessage(const std::string& message) {
+void Compiler::ErrorMessage(const std::string& message) const {
   if (m_err)
     (*m_err) << "ERROR: " << GetMessagePrefix() << message << std::endl;
   Tcl_AppendResult(m_interp->getInterp(), message.c_str(), nullptr);
@@ -484,9 +484,8 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
   auto close_design = [](void* clientData, Tcl_Interp* interp, int argc,
                          const char* argv[]) -> int {
     Compiler* compiler = (Compiler*)clientData;
-    if (compiler->m_tclCmdIntegration) {
-      compiler->m_tclCmdIntegration->TclCloseProject();
-    }
+    if (compiler->HasInternalError()) return TCL_ERROR;
+    compiler->m_tclCmdIntegration->TclCloseProject();
     return TCL_OK;
   };
   interp->registerCmd("close_design", close_design, this, nullptr);
@@ -499,17 +498,16 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       compiler->ErrorMessage("Specify a top module name");
       return TCL_ERROR;
     }
+    if (compiler->HasInternalError()) return TCL_ERROR;
     if (!compiler->ProjManager()->HasDesign()) {
       compiler->ErrorMessage("Create a design first: create_design <name>");
       return TCL_ERROR;
     }
-    if (compiler->m_tclCmdIntegration) {
-      std::ostringstream out;
-      bool ok = compiler->m_tclCmdIntegration->TclSetTopModule(argc, argv, out);
-      if (!ok) {
-        compiler->ErrorMessage(out.str());
-        return TCL_ERROR;
-      }
+    std::ostringstream out;
+    bool ok = compiler->m_tclCmdIntegration->TclSetTopModule(argc, argv, out);
+    if (!ok) {
+      compiler->ErrorMessage(out.str());
+      return TCL_ERROR;
     }
     return TCL_OK;
   };
@@ -581,6 +579,7 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
   auto read_netlist = [](void* clientData, Tcl_Interp* interp, int argc,
                          const char* argv[]) -> int {
     Compiler* compiler = (Compiler*)clientData;
+    if (compiler->HasInternalError()) return TCL_ERROR;
     if (!compiler->ProjManager()->HasDesign()) {
       compiler->ErrorMessage("Create a design first: create_design <name>");
       return TCL_ERROR;
@@ -631,14 +630,12 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
 
     compiler->Message(std::string("Reading ") + actualType + " " +
                       expandedFile + std::string("\n"));
-    if (compiler->m_tclCmdIntegration) {
-      std::ostringstream out;
-      bool ok = compiler->m_tclCmdIntegration->TclAddDesignFiles(
-          {}, {}, origPathFileList.c_str(), language, out);
-      if (!ok) {
-        compiler->ErrorMessage(out.str());
-        return TCL_ERROR;
-      }
+    std::ostringstream out;
+    bool ok = compiler->m_tclCmdIntegration->TclAddDesignFiles(
+        {}, {}, origPathFileList.c_str(), language, out);
+    if (!ok) {
+      compiler->ErrorMessage(out.str());
+      return TCL_ERROR;
     }
     return TCL_OK;
   };
@@ -746,6 +743,7 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
   auto add_constraint_file = [](void* clientData, Tcl_Interp* interp, int argc,
                                 const char* argv[]) -> int {
     Compiler* compiler = (Compiler*)clientData;
+    if (compiler->HasInternalError()) return TCL_ERROR;
     if (!compiler->ProjManager()->HasDesign()) {
       compiler->ErrorMessage("Create a design first: create_design <name>");
       return TCL_ERROR;
@@ -777,22 +775,13 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
     }
     compiler->Message(std::string("Adding constraint file ") + expandedFile +
                       std::string("\n"));
-    if (compiler->m_tclCmdIntegration) {
-      std::ostringstream out;
-      bool ok = compiler->m_tclCmdIntegration->TclAddConstrFiles(
-          expandedFile.c_str(), out);
-      if (!ok) {
-        compiler->ErrorMessage(out.str());
-        return TCL_ERROR;
-      }
-    } else {
-      int status = Tcl_Eval(
-          interp, std::string("read_sdc {" + expandedFile + "}").c_str());
-      if (status) {
-        return TCL_ERROR;
-      }
+    std::ostringstream out;
+    bool ok = compiler->m_tclCmdIntegration->TclAddConstrFiles(
+        expandedFile.c_str(), out);
+    if (!ok) {
+      compiler->ErrorMessage(out.str());
+      return TCL_ERROR;
     }
-
     return TCL_OK;
   };
   interp->registerCmd("add_constraint_file", add_constraint_file, this, 0);
@@ -1920,6 +1909,14 @@ void Compiler::AddHeadersToLogs() {
   }
 }
 
+bool Compiler::HasInternalError() const {
+  if (!m_tclCmdIntegration) {
+    ErrorMessage("TCL command integration did not initialize");
+    return true;
+  }
+  return false;
+}
+
 bool Compiler::Compile(Action action) {
   uint task{toTaskId(static_cast<int>(action), this)};
   m_stop = false;
@@ -2541,6 +2538,7 @@ std::pair<bool, std::string> Compiler::IsDeviceSizeCorrect(
 
 int Compiler::add_files(Compiler* compiler, Tcl_Interp* interp, int argc,
                         const char* argv[], AddFilesType filesType) {
+  if (compiler->HasInternalError()) return TCL_ERROR;
   if (!compiler->ProjManager()->HasDesign()) {
     compiler->ErrorMessage("Create a design first: create_design <name>");
     return TCL_ERROR;
@@ -2645,23 +2643,19 @@ int Compiler::add_files(Compiler* compiler, Tcl_Interp* interp, int argc,
 
   compiler->Message(std::string("Adding ") + actualType + " " + fileList +
                     std::string("\n"));
-  if (compiler->m_tclCmdIntegration) {
-    std::ostringstream out;
-    bool ok{true};
-    if (filesType == Design) {
-      ok = compiler->m_tclCmdIntegration->TclAddDesignFiles(
-          commandsList.c_str(), libList.c_str(), fileList.c_str(), language,
-          out);
-    } else {
-      ok = compiler->m_tclCmdIntegration->TclAddSimulationFiles(
-          commandsList.c_str(), libList.c_str(), fileList.c_str(), language,
-          out);
-    }
+  std::ostringstream out;
+  bool ok{true};
+  if (filesType == Design) {
+    ok = compiler->m_tclCmdIntegration->TclAddDesignFiles(
+        commandsList.c_str(), libList.c_str(), fileList.c_str(), language, out);
+  } else {
+    ok = compiler->m_tclCmdIntegration->TclAddSimulationFiles(
+        commandsList.c_str(), libList.c_str(), fileList.c_str(), language, out);
+  }
 
-    if (!ok) {
-      compiler->ErrorMessage(out.str());
-      return TCL_ERROR;
-    }
+  if (!ok) {
+    compiler->ErrorMessage(out.str());
+    return TCL_ERROR;
   }
   return TCL_OK;
 }

--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -127,9 +127,9 @@ class Compiler {
   void setGuiTclSync(TclCommandIntegration* tclCommands);
   virtual void Help(std::ostream* out);
   virtual void Version(std::ostream* out);
-  virtual void Message(const std::string& message);
-  virtual void ErrorMessage(const std::string& message);
-  std::string GetMessagePrefix();
+  virtual void Message(const std::string& message) const;
+  virtual void ErrorMessage(const std::string& message) const;
+  std::string GetMessagePrefix() const;
   void SetUseVerific(bool on) { m_useVerific = on; }
 
   void SetIPGenerator(IPGenerator* generator) { m_IPGenerator = generator; }
@@ -260,6 +260,7 @@ class Compiler {
       int frontSpacePadCount, int descColumn);
   void writeWaveHelp(std::ostream* out, int frontSpacePadCount, int descColumn);
   void AddHeadersToLogs();
+  bool HasInternalError() const;
   /* Propected members */
   TclInterpreter* m_interp = nullptr;
   Session* m_session = nullptr;


### PR DESCRIPTION
### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-164
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
New mehod `HasInternalError` verify if pointer `m_tclCmdIntegration` not null. Normally it should never happened. 
Fail tcl command with message "Internal: tcl command integration does not initialized".

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts