### PR TITLE
[RG-258] Add tcl command: clear_simulation_files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ test/batch: run-cmake-release
 	./build/bin/foedag --batch --script tests/Testcases/oneff_close/oneff.tcl
 	./build/bin/foedag --batch --script tests/TestBatch/test_ip_configure_load.tcl
 	./build/bin/foedag --batch --script tests/TestBatch/log_header.tcl
+	./build/bin/foedag --batch --script tests/Testcases/simulation_trivial/test.tcl
 	
 lib-only: run-cmake-release
 	cmake --build build --target foedag -j $(CPU_CORES)

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -580,6 +580,24 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
   interp->registerCmd("add_simulation_file", add_simulation_file, this,
                       nullptr);
 
+  auto clear_simulation_files = [](void* clientData, Tcl_Interp* interp,
+                                   int argc, const char* argv[]) -> int {
+    Compiler* compiler = (Compiler*)clientData;
+    if (compiler->HasInternalError()) return TCL_ERROR;
+    if (!compiler->ProjManager()->HasDesign()) {
+      compiler->ErrorMessage("Create a design first: create_design <name>");
+      return TCL_ERROR;
+    }
+    std::ostringstream out;
+    if (!compiler->m_tclCmdIntegration->TclClearSimulationFiles(out)) {
+      compiler->ErrorMessage(out.str());
+      return TCL_ERROR;
+    }
+    return TCL_OK;
+  };
+  interp->registerCmd("clear_simulation_files", clear_simulation_files, this,
+                      nullptr);
+
   auto read_netlist = [](void* clientData, Tcl_Interp* interp, int argc,
                          const char* argv[]) -> int {
     Compiler* compiler = (Compiler*)clientData;

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -145,6 +145,8 @@ void Compiler::Help(std::ostream* out) {
   (*out) << "              -work <libName> : Compiles the compilation unit "
             "into library <libName>, default is \"work\""
          << std::endl;
+  (*out) << "   clear_simulation_files     : Remove all simulation files"
+         << std::endl;
   (*out) << "   read_netlist <file>        : Read a netlist instead of an RTL "
             "design (Skip Synthesis)"
          << std::endl;

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -154,6 +154,8 @@ void CompilerOpenFPGA::Help(std::ostream* out) {
   (*out) << "              -work <libName> : Compiles the compilation unit "
             "into library <libName>, default is \"work\""
          << std::endl;
+  (*out) << "   clear_simulation_files     : Remove all simulation files"
+         << std::endl;
   (*out) << "   read_netlist <file>        : Read a netlist instead of an RTL "
             "design (Skip Synthesis)"
          << std::endl;

--- a/src/ProjNavigator/tcl_command_integration.cpp
+++ b/src/ProjNavigator/tcl_command_integration.cpp
@@ -320,6 +320,21 @@ bool TclCommandIntegration::TclCloseProject() {
   return true;
 }
 
+bool TclCommandIntegration::TclClearSimulationFiles(std::ostream &out) {
+  if (!validate()) {
+    out << "Command validation fail: internal error" << std::endl;
+    return false;
+  }
+  auto simFiles = m_projManager->getSimulationFiles(
+      m_projManager->getSimulationActiveFileSet());
+  for (const auto &strfile : simFiles) {
+    const QFileInfo info{strfile};
+    m_projManager->deleteFile(info.fileName());
+  }
+  update();
+  return true;
+}
+
 ProjectManager *TclCommandIntegration::GetProjectManager() {
   return m_projManager;
 }

--- a/src/ProjNavigator/tcl_command_integration.h
+++ b/src/ProjNavigator/tcl_command_integration.h
@@ -50,6 +50,7 @@ class TclCommandIntegration : public QObject {
   bool TclCreateProject(const QString &name, const QString &type,
                         std::ostream &out);
   bool TclCloseProject();
+  bool TclClearSimulationFiles(std::ostream &out);
 
   ProjectManager *GetProjectManager();
 

--- a/tests/Testcases/simulation_trivial/sim_main.cpp
+++ b/tests/Testcases/simulation_trivial/sim_main.cpp
@@ -1,0 +1,3 @@
+#include <iostream>
+
+int main(int argc, char** argv, char** env) { exit(0); }

--- a/tests/Testcases/simulation_trivial/test.tcl
+++ b/tests/Testcases/simulation_trivial/test.tcl
@@ -1,0 +1,22 @@
+create_design test
+architecture ../../Arch/k6_frac_N10_tileable_40nm.xml ../../Arch/k6_N10_40nm_openfpga.xml
+set_macro P1=10  P2=20
+add_design_file test.v -SV_2012
+set_top_module top
+add_simulation_file -CPP sim_main.cpp
+
+# test clear
+clear_simulation_files
+
+# add again
+add_simulation_file -CPP sim_main.cpp
+
+# regular flow
+synth
+packing
+place
+route
+sta
+power
+bitstream
+puts "done!"

--- a/tests/Testcases/simulation_trivial/test.v
+++ b/tests/Testcases/simulation_trivial/test.v
@@ -1,0 +1,7 @@
+`include "def.vh"
+module top(input logic [`P2:0] a, output logic [`P2:0] b);
+   bottom bot (a, b);
+   
+   
+endmodule // top
+


### PR DESCRIPTION
### Motivate of the pull request
- [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
- [x] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
 #### What is currently done? (Provide issue link if applicable)
 New Tcl command has been added: clear_simulation_files. 
This command remove all files that was added as simulation. When GUI mode is used, hierarchy view is updated after files removed.
Tcl test has been added.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, projnavigator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts
