### PR TITLE
[RG-262] Add hyperlink to last known error message from a task pointing to a rpt file

### DIFF
--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -129,7 +129,8 @@ class Compiler {
   virtual void Help(std::ostream* out);
   virtual void Version(std::ostream* out);
   virtual void Message(const std::string& message) const;
-  virtual void ErrorMessage(const std::string& message) const;
+  virtual void ErrorMessage(const std::string& message,
+                            bool append = true) const;
   std::string GetMessagePrefix() const;
   void SetUseVerific(bool on) { m_useVerific = on; }
 
@@ -261,6 +262,7 @@ class Compiler {
       int frontSpacePadCount, int descColumn);
   void writeWaveHelp(std::ostream* out, int frontSpacePadCount, int descColumn);
   void AddHeadersToLogs();
+  void AddErrorLink(const class Task* const current);
   bool HasInternalError() const;
   /* Propected members */
   TclInterpreter* m_interp = nullptr;

--- a/src/Console/TclErrorParser.cpp
+++ b/src/Console/TclErrorParser.cpp
@@ -30,8 +30,9 @@ TclErrorParser::TclErrorParser() {}
 LineParser::Result TclErrorParser::handleLine(const QString &message,
                                               OutputFormat format) {
   Q_UNUSED(format);
-  const QRegularExpression getFile{"(?<=file \")(.*)(?=\" line*)"};
-  const QRegularExpression getLine{"(?<=line )(\\d+)"};
+  // use static to fix use-static-qregularexpression clazy warning
+  static const QRegularExpression getFile{"(?<=file \")(.*)(?=\" line*)"};
+  static const QRegularExpression getLine{"(?<=line )(\\d+)"};
   auto regExpMatch = getFile.match(message);
   auto lineMatch = getLine.match(message);
   if (regExpMatch.hasMatch() && lineMatch.hasMatch()) {

--- a/src/TextEditor/editor.cpp
+++ b/src/TextEditor/editor.cpp
@@ -68,6 +68,7 @@ void Editor::ReplaceAll(const QString &strFind, const QString &strDesWord) {
 
 void Editor::markLine(int line) {
   m_scintilla->markerAdd(line - 1, ERROR_MARKER);
+  m_scintilla->ensureLineVisible(line - 1);
 }
 
 void Editor::selectLines(int lineFrom, int lineTo) {


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-262
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
We analyze log file after every compilation step. In case some error (here is the regexp: `"Error [0-9].*:"`) we put a link into the console. This link is open log file and show exact line with error.

 #### What does this pull request change?
Text editor was fixed. Now method `Editor::markLine` ensures that marked line is visible.
For the `TclErrorParser::handleLine` fixed clazy warning.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, console, texteditor
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
