### PR TITLE
[RG-265] Update clean tasks: remove logs, call downstream clean commands

### DIFF
--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -983,6 +983,8 @@ bool CompilerOpenFPGA::Analyze() {
     // Remove generated json files
     std::filesystem::remove(
         std::filesystem::path(ProjManager()->projectPath()) / "port_info.json");
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          ANALYSIS_LOG);
     return true;
   }
   if (!ProjManager()->HasDesign() && !CreateDesign("noname")) return false;
@@ -1074,6 +1076,11 @@ bool CompilerOpenFPGA::Synthesize() {
     std::filesystem::remove(
         std::filesystem::path(ProjManager()->projectPath()) /
         std::string(ProjManager()->projectName() + "_post_synth.v"));
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          std::string(SYNTHESIS_LOG));
+    FileUtils::removeFile(
+        std::filesystem::path(ProjManager()->projectPath()) /
+        std::string(ProjManager()->projectName() + "_synth.log"));
     return true;
   }
   if (!ProjManager()->HasDesign() && !CreateDesign("noname")) return false;
@@ -1505,6 +1512,10 @@ bool CompilerOpenFPGA::Packing() {
     std::filesystem::remove(
         std::filesystem::path(ProjManager()->projectPath()) /
         std::string(ProjManager()->projectName() + "_post_synth.net"));
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          std::string("vpr_stdout.log"));
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          std::string(PACKING_LOG));
     return true;
   }
   if (!HasTargetDevice()) return false;
@@ -1628,6 +1639,10 @@ bool CompilerOpenFPGA::Placement() {
     std::filesystem::remove(
         std::filesystem::path(ProjManager()->projectPath()) /
         std::string(ProjManager()->projectName() + "_post_synth.place"));
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          std::string("vpr_stdout.log"));
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          std::string(PLACEMENT_LOG));
     return true;
   }
   if (m_state != State::Packed && m_state != State::GloballyPlaced &&
@@ -1901,6 +1916,10 @@ bool CompilerOpenFPGA::Route() {
     std::filesystem::remove(
         std::filesystem::path(ProjManager()->projectPath()) /
         std::string(ProjManager()->projectName() + "_post_synth.route"));
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          std::string("vpr_stdout.log"));
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          std::string(ROUTING_LOG));
     return true;
   }
   if (m_state != State::Placed) {
@@ -1967,6 +1986,10 @@ bool CompilerOpenFPGA::TimingAnalysis() {
     std::filesystem::remove(
         std::filesystem::path(ProjManager()->projectPath()) /
         std::string(ProjManager()->projectName() + "_sta.cmd"));
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          std::string("vpr_stdout.log"));
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          std::string(TIMING_ANALYSIS_LOG));
     return true;
   }
 
@@ -2092,6 +2115,10 @@ bool CompilerOpenFPGA::PowerAnalysis() {
     Message("Cleaning PoweAnalysis results for " +
             ProjManager()->projectName());
     PowerAnalysisOpt(PowerOpt::None);
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          std::string("vpr_stdout.log"));
+    FileUtils::removeFile(std::filesystem::path(ProjManager()->projectPath()) /
+                          std::string(POWER_ANALYSIS_LOG));
     m_state = State::Routed;
     return true;
   }

--- a/src/Compiler/TaskManager.h
+++ b/src/Compiler/TaskManager.h
@@ -127,6 +127,12 @@ class TaskManager : public QObject {
   void cleanDownStreamStatus(Task *t);
   void appendTask(Task *t);
 
+  /*!
+   * \brief getDownstreamClearTasks
+   * \return vector of clean tasks in reverse order. Vector includes \param t.
+   */
+  QVector<Task *> getDownstreamCleanTasks(Task *t) const;
+
  private:
   QMap<uint, Task *> m_tasks;
   QVector<Task *> m_runStack;

--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -283,4 +283,16 @@ std::string FileUtils::AdjustPath(const std::string& p) {
   return the_path.string();
 }
 
+bool FileUtils::removeFile(const std::string& file) noexcept {
+  const std::filesystem::path path{file};
+  return removeFile(path);
+}
+
+bool FileUtils::removeFile(const std::filesystem::path& file) noexcept {
+  if (!FileExists(file)) return false;
+  std::error_code ec;
+  std::filesystem::remove(file, ec);
+  return ec.value() == 0;
+}
+
 }  // namespace FOEDAG

--- a/src/Utils/FileUtils.h
+++ b/src/Utils/FileUtils.h
@@ -72,6 +72,10 @@ class FileUtils final {
 
   static std::string AdjustPath(const std::string& p);
 
+  // return true if file was removed otherwise return false
+  static bool removeFile(const std::string& file) noexcept;
+  static bool removeFile(const std::filesystem::path& file) noexcept;
+
  private:
   FileUtils() = delete;
   FileUtils(const FileUtils& orig) = delete;


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
1. Remove log files from the task when user run Clean. 
2. Run recursively Clean task starting from the last (bitstream generation) till the task requested by user.
3. Cleanup code for `TaskManager::run`. 

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, utils
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
