### PR TITLE
[RG-253] Fixed issue with loading settings, when arg value has special chars like space or dash

### DIFF
--- a/src/Main/Settings.cpp
+++ b/src/Main/Settings.cpp
@@ -302,6 +302,12 @@ QString Settings::getTclArgString(json& jsonData) {
             if (tclVal.isEmpty()) {
               tclVal = val;
             }
+
+            // we expect tclVal might be multi-space value like "-a val0 -b
+            // val1" or "--some-arg=val" so need to convert spaces/dashes/new
+            // lines.
+            tclVal = convertAll(tclVal);
+
             argStr += " -" + tclArg + " " + tclVal;
           }
         }

--- a/src/Main/WidgetFactory.cpp
+++ b/src/Main/WidgetFactory.cpp
@@ -164,7 +164,7 @@ void storeTclArg(QObject* obj, const QString& argStr) {
 
 template <typename T>
 T getDefault(const json& jsonObj) {
-  T val;
+  T val{};
   if (jsonObj.contains("default")) {
     val = jsonObj["default"].get<T>();
   }
@@ -824,8 +824,7 @@ QWidget* FOEDAG::createWidget(const json& widgetJsonObj, const QString& objName,
             ptr->setProperty("tclArg", {});  // clear previous vals
             // store a tcl arg/value string if an arg was provided
             if (arg != "") {
-              userVal = convertSpaces(userVal);
-              userVal = convertDashes(userVal);
+              userVal = convertAll(userVal);
               QString argStr = "-" + arg + " " + userVal;
               storeTclArg(ptr, argStr);
             }
@@ -882,8 +881,7 @@ QWidget* FOEDAG::createWidget(const json& widgetJsonObj, const QString& objName,
 
       if (tclArgPassed) {
         // convert any spaces to a replaceable tag so the arg is 1 token
-        argVal = restoreSpaces(argVal);
-        argVal = restoreDashes(argVal);
+        argVal = restoreAll(argVal);
         setVal(ptr, argVal);
       } else if (widgetJsonObj.contains("userValue")) {
         // Load and set user value
@@ -961,9 +959,7 @@ QWidget* FOEDAG::createWidget(const json& widgetJsonObj, const QString& objName,
             ptr->setProperty("tclArg", {});  // clear previous vals
             // store a tcl arg/value string if an arg was provided
             if (arg != "") {
-              userVal = convertSpaces(userVal);
-              userVal = convertNewLines(userVal);
-              userVal = convertDashes(userVal);
+              userVal = convertAll(userVal);
               QString argStr = "-" + arg + " " + userVal;
               storeTclArg(ptr, argStr);
             }
@@ -975,10 +971,8 @@ QWidget* FOEDAG::createWidget(const json& widgetJsonObj, const QString& objName,
 
       if (tclArgPassed) {
         // convert any spaces to a replaceable tag so the arg is 1 token
-        QString tempStr = restoreSpaces(argVal);
-        tempStr = restoreNewLines(tempStr);
-        tempStr = restoreDashes(tempStr);
-        setVal(ptr, tempStr);
+        argVal = restoreAll(argVal);
+        setVal(ptr, argVal);
       } else if (widgetJsonObj.contains("userValue")) {
         // Load and set user value
         QString userVal = QString::fromStdString(
@@ -1501,4 +1495,12 @@ QList<QObject*> FOEDAG::getTargetObjectsFromLayout(QLayout* layout) {
   }
 
   return settingsObjs;
+}
+
+QString FOEDAG::convertAll(const QString& str) {
+  return convertSpaces(convertNewLines(convertDashes(str)));
+}
+
+QString FOEDAG::restoreAll(const QString& str) {
+  return restoreSpaces(restoreNewLines(restoreDashes(str)));
 }

--- a/src/Main/WidgetFactory.h
+++ b/src/Main/WidgetFactory.h
@@ -46,6 +46,8 @@ using tclArgFnMap = std::map<std::string, tclArgFns>;
 #define WF_DASH "_TclArgDash_"
 
 namespace FOEDAG {
+QString convertAll(const QString& str);
+QString restoreAll(const QString& str);
 void initTclArgFns();
 void clearTclArgFns();
 void addTclArgFns(const std::string& tclArgKey, tclArgFns argFns);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-253
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
If the settings value contains some characters like space or dash e.g:
![image](https://user-images.githubusercontent.com/95262932/212402863-475d22ca-6be5-4e30-9b95-a2cb5a6f3c83.png)

This setting lost when project loads.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [ ] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) script
