### PR TITLE
[RG-290] Show messages after each task while using the play button.

### DIFF
--- a/src/MainWindow/MessagesTabWidget.cpp
+++ b/src/MainWindow/MessagesTabWidget.cpp
@@ -35,15 +35,17 @@ MessagesTabWidget::MessagesTabWidget(const TaskManager &taskManager)
       auto filePath = task->logFileReadPath();
       filePath.replace(PROJECT_OSRCDIR, Project::Instance()->projectPath());
 
-      if (!FileUtils::FileExists(filePath.toStdString()))
-        filePath = tr("log file not found");
+      const bool fileExists{FileUtils::FileExists(filePath.toStdString())};
+      if (!fileExists) filePath = tr("log file not found");
       auto itemName = QString("%1 (%2)").arg(task->title(), filePath);
       auto taskItem = new QTreeWidgetItem({itemName});
 
-      const auto &msgs = reportManager->getMessages();
-      for (auto it = msgs.cbegin(); it != msgs.cend(); it++) {
-        auto msgItem = createTaskMessageItem(it.value(), filePath);
-        taskItem->addChild(msgItem);
+      if (fileExists) {
+        const auto &msgs = reportManager->getMessages();
+        for (auto it = msgs.cbegin(); it != msgs.cend(); it++) {
+          auto msgItem = createTaskMessageItem(it.value(), filePath);
+          taskItem->addChild(msgItem);
+        }
       }
       treeWidget->addTopLevelItem(taskItem);
     }

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -1124,6 +1124,8 @@ void MainWindow::ReShowWindow(QString strProject) {
             } else {
               m_progressBar->setMaximum(max);
               m_progressBar->setValue(val);
+              showMessagesTab();
+              showReportsTab();
             }
             m_progressBar->show();
             setStatusAndProgressText(statusMsg);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Generate messages after each compiler task done.
Update for  `MessagesTabWidget` fixes issue with generating messages event when no log file.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts