### PR TITLE
[RG-110] Fixed memory leaks in newProjectDialog

### DIFF
--- a/src/NewProject/new_project_dialog.cpp
+++ b/src/NewProject/new_project_dialog.cpp
@@ -93,6 +93,9 @@ void newProjectDialog::Reset(Mode mode) {
   m_mode = mode;
   m_index = INDEX_LOCATION;
   m_skipSources = false;
+  QVector<QWidget *> oldWidgets;
+  for (int i = 0; i < ui->m_tabWidget->count(); i++)
+    oldWidgets.push_back(ui->m_tabWidget->widget(i));
   ui->m_tabWidget->clear();
 
   if (mode == NewProject)
@@ -101,6 +104,7 @@ void newProjectDialog::Reset(Mode mode) {
     ResetToProjectSettings();
 
   UpdateDialogView(mode);
+  qDeleteAll(oldWidgets);
 }
 
 Mode newProjectDialog::GetMode() const { return m_mode; }
@@ -151,7 +155,6 @@ void newProjectDialog::UpdateDialogView(Mode mode) {
 
 void newProjectDialog::ResetToNewProject() {
   setWindowTitle(tr("New Project"));
-  ui->m_tabWidget->clear();
 
   m_locationForm = new locationForm(m_defaultPath, this);
   ui->m_tabWidget->insertTab(INDEX_LOCATION, m_locationForm,
@@ -189,6 +192,8 @@ void newProjectDialog::ResetToNewProject() {
 void newProjectDialog::ResetToProjectSettings() {
   setWindowTitle(tr("Project settings"));
   m_settings.clear();
+  m_locationForm = nullptr;
+  m_proTypeForm = nullptr;
 
   m_addSrcForm = new addSourceForm(GT_SOURCE, this);
   m_addSrcForm->SetTitle("Design Files");
@@ -297,9 +302,12 @@ void newProjectDialog::on_buttonBox_accepted() {
   }
 
   ProjectOptions opt{
-      m_locationForm->getProjectName(),
-      m_locationForm->getProjectPath(),
-      m_proTypeForm->projectType(),
+      m_locationForm ? m_locationForm->getProjectName()
+                     : m_projectManager->getProjectName(),
+      m_locationForm ? m_locationForm->getProjectPath()
+                     : m_projectManager->getProjectPath(),
+      m_proTypeForm ? m_proTypeForm->projectType()
+                    : m_projectManager->projectType(),
       {m_addSrcForm->getFileData(), m_addSrcForm->IsCopySource()},
       {m_addConstrsForm->getFileData(), m_addConstrsForm->IsCopySource()},
       {m_addSimForm->getFileData(), m_addSimForm->IsCopySource()},


### PR DESCRIPTION
### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-110
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
`ui->m_tabWidget->clear();` doesn't free memory for the widgets so it is user responsibility. 
`m_locationForm` and `m_proTypeForm` become nullptr in case Project settings so need to provide check if this objects are valid.


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: newproject
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts