### PR TITLE
[EDA-1155] Change search path for *.csv file pin planner. Now it searches in device.xml

### DIFF
--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -1754,6 +1754,14 @@ void Compiler::GTKWaveSendCmd(const std::string& gtkWaveCmd,
   }
 }
 
+void Compiler::PinmapCSVFile(const std::filesystem::path& path) {
+  m_PinMapCSV = path;
+}
+
+const std::filesystem::path& Compiler::PinmapCSVFile() const {
+  return m_PinMapCSV;
+}
+
 // This will return a pointer to the current gtkwave process, if no process is
 // running, one will be started
 QProcess* Compiler::GetGTKWaveProcess() {

--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef COMPILER_H
 #define COMPILER_H
 
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <string>
@@ -219,6 +220,9 @@ class Compiler {
   void GTKWaveSendCmd(const std::string& gtkWaveCmd,
                       bool raiseGtkWindow = true);
 
+  void PinmapCSVFile(const std::filesystem::path& path);
+  const std::filesystem::path& PinmapCSVFile() const;
+
  protected:
   /* Methods that can be customized for each new compiler flow */
   virtual bool IPGenerate();
@@ -299,6 +303,7 @@ class Compiler {
   STAOpt m_staOpt = STAOpt::None;
   STAEngineOpt m_staEngineOpt = STAEngineOpt::Tatum;
   BitstreamOpt m_bitstreamOpt = BitstreamOpt::DefaultBitsOpt;
+  std::filesystem::path m_PinMapCSV{};
 
   // Compiler specific options
   std::string m_pnrOpt;

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -1853,8 +1853,8 @@ bool CompilerOpenFPGA::Placement() {
   std::string command = BaseVprCommand() + " --place";
   std::string pincommand = m_pinConvExecutablePath.string();
   if (PinConstraintEnabled() && (PinAssignOpts() != PinAssignOpt::Free) &&
-      FileUtils::FileExists(pincommand) && (!m_OpenFpgaPinMapCSV.empty())) {
-    if (!std::filesystem::is_regular_file(m_OpenFpgaPinMapCSV)) {
+      FileUtils::FileExists(pincommand) && (!m_PinMapCSV.empty())) {
+    if (!std::filesystem::is_regular_file(m_PinMapCSV)) {
       ErrorMessage(
           "No pin description csv file available for this device, required "
           "for set_pin_loc constraints");
@@ -1865,7 +1865,7 @@ bool CompilerOpenFPGA::Placement() {
         std::filesystem::is_regular_file(m_OpenFpgaPinMapXml)) {
       pincommand += " --xml " + m_OpenFpgaPinMapXml.string();
     }
-    pincommand += " --csv " + m_OpenFpgaPinMapCSV.string();
+    pincommand += " --csv " + m_PinMapCSV.string();
 
     if (userConstraint) {
       pincommand += " --pcf " +
@@ -2601,6 +2601,9 @@ bool CompilerOpenFPGA::LoadDeviceData(const std::string& deviceName) {
       QDomElement e = node.toElement();
 
       std::string name = e.attribute("name").toStdString();
+      std::string family = e.attribute("family").toStdString();
+      std::string series = e.attribute("series").toStdString();
+      std::string package = e.attribute("package").toStdString();
       if (name == deviceName) {
         foundDevice = true;
         QDomNodeList list = e.childNodes();
@@ -2642,7 +2645,7 @@ bool CompilerOpenFPGA::LoadDeviceData(const std::string& deviceName) {
               } else if (file_type == "pb_pin_fixup") {
                 PbPinFixup(name);
               } else if (file_type == "pinmap_csv") {
-                OpenFpgaPinmapCSVFile(fullPath);
+                PinmapCSVFile(fullPath);
               } else if (file_type == "plugin_lib") {
                 YosysPluginLibName(name);
               } else if (file_type == "plugin_func") {

--- a/src/Compiler/CompilerOpenFPGA.h
+++ b/src/Compiler/CompilerOpenFPGA.h
@@ -19,7 +19,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -77,9 +76,6 @@ class CompilerOpenFPGA : public Compiler {
   }
   void OpenFpgaPinmapXMLFile(const std::filesystem::path& path) {
     m_OpenFpgaPinMapXml = path;
-  }
-  void OpenFpgaPinmapCSVFile(const std::filesystem::path& path) {
-    m_OpenFpgaPinMapCSV = path;
   }
   void PbPinFixup(const std::string& name) { m_pb_pin_fixup = name; }
   void DeviceSize(const std::string& XxY) { m_deviceSize = XxY; }
@@ -170,7 +166,6 @@ class CompilerOpenFPGA : public Compiler {
   std::filesystem::path m_OpenFpgaRepackConstraintsFile = "";
   std::filesystem::path m_OpenFpgaFabricKeyFile = "";
   std::filesystem::path m_OpenFpgaPinMapXml = "";
-  std::filesystem::path m_OpenFpgaPinMapCSV = "";
   std::string m_deviceSize;
   std::string m_yosysScript;
   std::string m_openFPGAScript;

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -1271,6 +1271,8 @@ void MainWindow::pinAssignmentActionTriggered() {
 
     PinAssignmentData data;
     data.context = GlobalSession->Context();
+    data.pinMapFile =
+        QString::fromStdString(m_compiler->PinmapCSVFile().string());
     data.projectPath = m_projectManager->getProjectPath();
     data.target = QString::fromStdString(m_projectManager->getTargetDevice());
     data.pinFile = QString::fromStdString(m_projectManager->getConstrPinFile());

--- a/src/PinAssignment/PinAssignmentCreator.cpp
+++ b/src/PinAssignment/PinAssignmentCreator.cpp
@@ -42,7 +42,7 @@ PinAssignmentCreator::PinAssignmentCreator(const PinAssignmentData &data,
     : QObject(parent), m_data(data) {
   PortsModel *portsModel = new PortsModel{this};
   auto packagePinModel = new PackagePinsModel;
-  const QString fileName = searchCsvFile(data.target, data.context);
+  const QString fileName = searchCsvFile();
   m_baseModel = new PinsBaseModel;
   m_baseModel->setPackagePinModel(packagePinModel);
   m_baseModel->setPortsModel(portsModel);
@@ -102,19 +102,8 @@ QWidget *PinAssignmentCreator::CreateLayoutedWidget(QWidget *main) {
   return w;
 }
 
-QString PinAssignmentCreator::searchCsvFile(const QString &targetDevice,
-                                            ToolContext *context) const {
-  std::filesystem::path path{context->DataPath()};
-  path = path / "etc" / "devices";
-  if (!targetDevice.isEmpty()) path /= targetDevice.toLower().toStdString();
-
-  QDir dir{path.string().c_str()};
-  auto files = dir.entryList({"*.csv"}, QDir::Files);
-  if (!files.isEmpty()) return dir.filePath(files.first());
-
-  std::filesystem::path pathDefault{context->DataPath()};
-  pathDefault = pathDefault / "etc" / "templates" / "Pin_Table.csv";
-  return QString(pathDefault.string().c_str());
+QString PinAssignmentCreator::searchCsvFile() const {
+  return m_data.pinMapFile;
 }
 
 QString PinAssignmentCreator::packagePinHeaderFile(ToolContext *context) const {

--- a/src/PinAssignment/PinAssignmentCreator.h
+++ b/src/PinAssignment/PinAssignmentCreator.h
@@ -32,6 +32,7 @@ class PortsLoader;
 
 struct PinAssignmentData {
   ToolContext *context{nullptr};
+  QString pinMapFile{};
   QString target{};
   QStringList commands{};
   QString projectPath{};
@@ -73,8 +74,7 @@ class PinAssignmentCreator : public QObject {
 
  private:
   QWidget *CreateLayoutedWidget(QWidget *main);
-  QString searchCsvFile(const QString &targetDevice,
-                        ToolContext *context) const;
+  QString searchCsvFile() const;
   QString packagePinHeaderFile(ToolContext *context) const;
   PackagePinsLoader *FindPackagePinLoader(const QString &targetDevice) const;
   PortsLoader *FindPortsLoader(const QString &targetDevice) const;

--- a/src/PinAssignment/Test/PinAssignment_main.cpp
+++ b/src/PinAssignment/Test/PinAssignment_main.cpp
@@ -31,7 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 QWidget* PinAssignmentBuilder(FOEDAG::Session* session) {
   auto projectManager{session->GetCompiler()->ProjManager()};
   FOEDAG::PinAssignmentData data{
-      session->Context(), {}, {}, projectManager->getProjectPath(), {}};
+      session->Context(), {}, {}, {}, projectManager->getProjectPath(), {}};
   FOEDAG::PinAssignmentCreator* creator =
       new FOEDAG::PinAssignmentCreator{data};
   QWidget* w = new QWidget;


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: [EDA-1155]
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Search pin table data in device.xml file.

`m_OpenFpgaPinMapCSV` was renamed and moved to Compiler since this is related to common data but not only openfpga

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, pinassignment, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts


[EDA-1155]: https://rapidsilicon.atlassian.net/browse/EDA-1155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ