### PR TITLE
[EDA-1224] Fixed ip generation, when it is fail to generate combo boxes content

### DIFF
--- a/src/IpConfigurator/IpConfigWidget.cpp
+++ b/src/IpConfigurator/IpConfigWidget.cpp
@@ -303,6 +303,7 @@ void IpConfigWidget::CreateParamFields() {
             // Use Comboboxes if "options" field exists
             childJson["widgetType"] = "combobox";
             childJson["options"] = param->GetOptions();
+            childJson["optionsLookup"] = param->GetOptions();
             childJson["addUnset"] = false;
           } else if (param->GetRange().size() > 1) {
             // Use QLineedit w/ a validator if "range" field exists

--- a/src/Main/WidgetFactory.cpp
+++ b/src/Main/WidgetFactory.cpp
@@ -1320,10 +1320,18 @@ QComboBox* FOEDAG::createComboBox(
     std::function<void(QComboBox*, const QString&)> onChange) {
   QComboBox* widget = new QComboBox();
   widget->setObjectName(objectName);
-  for (int i = 0; i < options.count() && i < lookup.count(); i++) {
+
+  QStringList lookupValues = lookup;
+  if (lookupValues.isEmpty()) {
+    // if lookup values are not provided we will take as lookup values actual
+    // text. This is equivalent to search items by text.
+    lookupValues = options;
+  }
+
+  for (int i = 0; i < options.count() && i < lookupValues.count(); i++) {
     auto text = options.at(i);
-    if (lookup.at(i) == selectedValue) text += QString{" (default)"};
-    widget->addItem(text, lookup.at(i));
+    if (lookupValues.at(i) == selectedValue) text += QString{" (default)"};
+    widget->addItem(text, lookupValues.at(i));
   }
   if (addUnset) {
     widget->addItem("<unset>", "<unset>");


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: EDA-1224
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
IP configurator failed to create combo box data:
![image](https://user-images.githubusercontent.com/95262932/219023474-f57222b5-f462-434c-968c-76bd3f5e677b.png)

because no `optionsLookup` were provided. 
This change provides `optionsLookup` for the IPs. Also it is not necessary to provide this values now. It `optionsLookup` is empty we use user text as those values.


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore, ipconfigurator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
