### PR TITLE
[RG-358] avoid generation of multiple IPs

### DIFF
--- a/src/IPGenerate/IPCatalog.h
+++ b/src/IPGenerate/IPCatalog.h
@@ -296,6 +296,9 @@ class IPInstance {
   const std::string& ModuleName() { return m_moduleName; }
   const std::filesystem::path OutputFile() { return m_outputFile; }
 
+  bool Generated() const { return m_generated; }
+  void Generated(bool generated) { m_generated = generated; }
+
  private:
   std::string m_ipname;
   std::string m_version;
@@ -303,6 +306,7 @@ class IPInstance {
   std::vector<SParameter> m_parameters;
   std::string m_moduleName;
   std::filesystem::path m_outputFile;
+  bool m_generated{false};
 };
 
 class IPCatalog {

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -249,9 +249,11 @@ bool IPGenerator::AddIPInstance(IPInstance* instance) {
   auto isMatch = [instance](IPInstance* targetInstance) {
     return targetInstance->ModuleName() == instance->ModuleName();
   };
-  m_instances.erase(
-      std::remove_if(m_instances.begin(), m_instances.end(), isMatch),
-      m_instances.end());
+  auto it = std::find_if(m_instances.begin(), m_instances.end(), isMatch);
+  if (it != m_instances.end()) {
+    instance->Generated((*it)->Generated());
+    m_instances.erase(it);
+  }
 
   // Check parameters
   std::set<std::string> legalParams;
@@ -496,6 +498,11 @@ bool IPGenerator::Generate() {
           std::stringstream buffer;
           newbuffer << newfile.rdbuf();
         }
+        if ((newbuffer.str() == previousbuffer.str()) && inst->Generated()) {
+          m_compiler->Message("IP Generate, reusing IP " +
+                              GetBuildDir(inst).string());
+          continue;
+        }
 
         // Find path to litex enabled python interpreter
         std::filesystem::path pythonPath = IPCatalog::getPythonPath();
@@ -522,19 +529,13 @@ bool IPGenerator::Generate() {
                               " --build --json " +
                               FileUtils::GetFullPath(jsonFile).string();
         std::ostringstream help;
-
-        if (newbuffer.str() == previousbuffer.str()) {
-          m_compiler->Message("IP Generate, reusing IP " +
-                              GetBuildDir(inst).string());
-          continue;
-        }
-
         m_compiler->Message("IP Generate, generating IP " +
                             GetBuildDir(inst).string());
         if (FileUtils::ExecuteSystemCommand(command, &help)) {
           m_compiler->ErrorMessage("IP Generate, " + help.str());
           return false;
         }
+        inst->Generated(true);
 
         break;
       }

--- a/src/ProjNavigator/sources_form.cpp
+++ b/src/ProjNavigator/sources_form.cpp
@@ -639,6 +639,7 @@ void SourcesForm::AddIpInstanceTree(QTreeWidgetItem *topItem) {
       (ipGen = compiler->GetIPGenerator())) {
     QTreeWidgetItem *ipParentItem{topitemIpInstances};
     for (auto instance : ipGen->IPInstances()) {
+      if (!instance->Generated()) continue;
       QString ipName = QString::fromStdString(instance->IPName());
       QString moduleName = QString::fromStdString(instance->ModuleName());
 


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-358
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
New flag `m_generated` for ip instance set to true when user generates the IP. Show only generated IPs in the hierarchy view.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: ipgenerate, projnavigator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
