### PR TITLE
[RG-365] Add one more option to preferences: Show message on exit program

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -82,6 +82,7 @@ namespace {
 const QString RECENT_PROJECT_KEY{"recent/proj%1"};
 const QString SHOW_WELCOMEPAGE_KEY{"showWelcomePage"};
 const QString SHOW_STOP_COMPILATION_MESSAGE_KEY{"showStopCompilationMessage"};
+const QString SHOW_MESSAGE_ON_EXIT_KEY{"showMessageOnExit"};
 constexpr uint RECENT_PROJECT_COUNT{10};
 constexpr uint RECENT_PROJECT_COUNT_WP{5};
 constexpr const char* WELCOME_PAGE_MENU_PROP{"showOnWelcomePage"};
@@ -110,6 +111,8 @@ MainWindow::MainWindow(Session* session)
   m_showWelcomePage = m_settings.value(SHOW_WELCOMEPAGE_KEY, true).toBool();
   m_askStopCompilation =
       m_settings.value(SHOW_STOP_COMPILATION_MESSAGE_KEY, true).toBool();
+  m_askShowMessageOnExit =
+      m_settings.value(SHOW_MESSAGE_ON_EXIT_KEY, true).toBool();
 
   centerWidget(*this);
 
@@ -894,6 +897,7 @@ void MainWindow::createMenus() {
 #endif
   preferencesMenu->addAction(showWelcomePageAction);
   preferencesMenu->addAction(stopCompileMessageAction);
+  preferencesMenu->addAction(showMessageOnExitAction);
 
   helpMenu->menuAction()->setProperty(WELCOME_PAGE_MENU_PROP,
                                       WelcomePageActionVisibility::FULL);
@@ -1044,6 +1048,13 @@ void MainWindow::createActions() {
   stopCompileMessageAction->setChecked(m_askStopCompilation);
   connect(stopCompileMessageAction, &QAction::toggled, this,
           &MainWindow::onShowStopMessage);
+
+  showMessageOnExitAction =
+      new QAction(tr("Show message on exit program"), this);
+  showMessageOnExitAction->setCheckable(true);
+  showMessageOnExitAction->setChecked(m_askShowMessageOnExit);
+  connect(showMessageOnExitAction, &QAction::toggled, this,
+          &MainWindow::onShowMessageOnExit);
 
   simRtlAction = new QAction(tr("Simulate RTL"), this);
   connect(simRtlAction, &QAction::triggered, this, [this]() {
@@ -1700,6 +1711,7 @@ bool MainWindow::confirmCloseProject() {
 }
 bool MainWindow::confirmExitProgram() {
   if (!lastProjectClosed()) return false;
+  if (!m_askShowMessageOnExit) return true;
   return (QMessageBox::question(
               this, "Exit Program?",
               tr("Are you sure you want to exit the program?\n"),
@@ -1791,6 +1803,11 @@ void MainWindow::startProject(bool simulation) {
 void MainWindow::onShowStopMessage(bool showStopCompilationMsg) {
   m_askStopCompilation = showStopCompilationMsg;
   m_settings.setValue(SHOW_STOP_COMPILATION_MESSAGE_KEY, m_askStopCompilation);
+}
+
+void MainWindow::onShowMessageOnExit(bool showMessage) {
+  m_askShowMessageOnExit = showMessage;
+  m_settings.setValue(SHOW_MESSAGE_ON_EXIT_KEY, m_askShowMessageOnExit);
 }
 
 void MainWindow::onShowLicenses() {

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -1049,8 +1049,7 @@ void MainWindow::createActions() {
   connect(stopCompileMessageAction, &QAction::toggled, this,
           &MainWindow::onShowStopMessage);
 
-  showMessageOnExitAction =
-      new QAction(tr("Show message on exit program"), this);
+  showMessageOnExitAction = new QAction(tr("Show message on exit"), this);
   showMessageOnExitAction->setCheckable(true);
   showMessageOnExitAction->setChecked(m_askShowMessageOnExit);
   connect(showMessageOnExitAction, &QAction::toggled, this,
@@ -1713,8 +1712,7 @@ bool MainWindow::confirmExitProgram() {
   if (!lastProjectClosed()) return false;
   if (!m_askShowMessageOnExit) return true;
   return (QMessageBox::question(
-              this, "Exit Program?",
-              tr("Are you sure you want to exit the program?\n"),
+              this, "Exit Program?", tr("Are you sure you want to exit?\n"),
               QMessageBox::No | QMessageBox::Yes) == QMessageBox::Yes);
 }
 

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -87,6 +87,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void onRunProjectRequested(const QString& project);
   void startProject(bool simulation);
   void onShowStopMessage(bool showStopCompilationMsg);
+  void onShowMessageOnExit(bool showMessage);
   void onShowLicenses();
   void stopCompilation();
   void forceStopCompilation();
@@ -201,6 +202,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   QAction* ipConfiguratorAction = nullptr;
   QAction* showWelcomePageAction = nullptr;
   QAction* stopCompileMessageAction = nullptr;
+  QAction* showMessageOnExitAction = nullptr;
   QAction* simRtlAction = nullptr;
   QAction* simGateAction = nullptr;
   QAction* simPnrAction = nullptr;
@@ -234,6 +236,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   QSettings m_settings;
   bool m_progressVisible{false};
   bool m_askStopCompilation{true};
+  bool m_askShowMessageOnExit{true};
   bool m_blockRefereshEn{false};
   QTableView* m_taskView{nullptr};
   class TaskModel* m_taskModel{nullptr};


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
New option allow to skip message about exit program:
![image](https://user-images.githubusercontent.com/95262932/231524291-c48c3130-9eac-437d-82bc-c2942f508f23.png)

No this message when unchecked:
![image](https://user-images.githubusercontent.com/95262932/231524055-aa686522-df5a-4727-be85-a200a82033aa.png)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
