### PR TITLE
[RG-386] Sync tcl commands with gui settings

### DIFF
--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -1095,6 +1095,7 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
           compiler->ErrorMessage("Unknown optimization option: " + arg);
         }
       }
+      if (compiler->GuiTclSync()) compiler->GuiTclSync()->saveSettings();
       return compiler->Compile(Action::Synthesis) ? TCL_OK : TCL_ERROR;
     };
     interp->registerCmd("synthesize", synthesize, this, 0);
@@ -1176,6 +1177,7 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
             "No Argument passed: type random/in_define_order/free");
         return TCL_ERROR;
       }
+      if (compiler->GuiTclSync()) compiler->GuiTclSync()->saveSettings();
       return TCL_OK;
     };
     interp->registerCmd("pin_loc_assign_method", pin_loc_assign_method, this,
@@ -1213,6 +1215,7 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
           compiler->ErrorMessage("Unknown option: " + arg);
         }
       }
+      if (compiler->GuiTclSync()) compiler->GuiTclSync()->saveSettings();
       return compiler->Compile(Action::STA) ? TCL_OK : TCL_ERROR;
     };
     interp->registerCmd("sta", sta, this, 0);
@@ -1440,6 +1443,7 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
           setSynthOption(lookupVal.toStdString());
         }
       }
+      if (compiler->GuiTclSync()) compiler->GuiTclSync()->saveSettings();
       WorkerThread* wthread =
           new WorkerThread("synth_th", Action::Synthesis, compiler);
       return wthread->start() ? TCL_OK : TCL_ERROR;
@@ -1568,6 +1572,7 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
           compiler->ErrorMessage("Unknown option: " + arg);
         }
       }
+      if (compiler->GuiTclSync()) compiler->GuiTclSync()->saveSettings();
       WorkerThread* wthread = new WorkerThread("sta_th", Action::STA, compiler);
       return wthread->start() ? TCL_OK : TCL_ERROR;
     };
@@ -2446,6 +2451,10 @@ void Compiler::setGuiTclSync(TclCommandIntegration* tclCommands) {
   m_tclCmdIntegration = tclCommands;
   if (m_tclCmdIntegration)
     m_projManager = m_tclCmdIntegration->GetProjectManager();
+}
+
+TclCommandIntegration* Compiler::GuiTclSync() const {
+  return m_tclCmdIntegration;
 }
 
 bool Compiler::IPGenerate() {

--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -138,6 +138,7 @@ class Compiler {
   TaskManager* GetTaskManager() const;
   Constraints* getConstraints() { return m_constraints; }
   void setGuiTclSync(TclCommandIntegration* tclCommands);
+  TclCommandIntegration* GuiTclSync() const;
   virtual void Help(std::ostream* out);
   virtual void Version(std::ostream* out);
   virtual void Message(const std::string& message,

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -43,6 +43,7 @@
 #include "Log.h"
 #include "Main/Settings.h"
 #include "NewProject/ProjectManager/project_manager.h"
+#include "ProjNavigator/tcl_command_integration.h"
 #include "Utils/FileUtils.h"
 #include "Utils/LogUtils.h"
 #include "Utils/StringUtils.h"
@@ -558,7 +559,9 @@ bool CompilerOpenFPGA::RegisterCommands(TclInterpreter* interp,
       compiler->MaxUserBRAMCount(std::strtoul(argv[2], 0, 10));
     } else {
       compiler->ErrorMessage("Unknown limit type");
+      return TCL_ERROR;
     }
+    if (compiler->GuiTclSync()) compiler->GuiTclSync()->saveSettings();
     return TCL_OK;
   };
   interp->registerCmd("set_limits", set_limits, this, 0);
@@ -651,6 +654,7 @@ bool CompilerOpenFPGA::RegisterCommands(TclInterpreter* interp,
           "Invalid arg to netlist_type (verilog or blif), was: " + arg);
       return TCL_ERROR;
     }
+    if (compiler->GuiTclSync()) compiler->GuiTclSync()->saveSettings();
     return TCL_OK;
   };
   interp->registerCmd("pnr_netlist_lang", pnr_netlist_lang, this, 0);
@@ -742,6 +746,7 @@ bool CompilerOpenFPGA::RegisterCommands(TclInterpreter* interp,
             return TCL_ERROR;
           }
           compiler->ClbPackingOption(packing);
+          if (compiler->GuiTclSync()) compiler->GuiTclSync()->saveSettings();
           i++;
         } else {
           compiler->ErrorMessage("-clb_packing argument is missing");

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -1244,6 +1244,8 @@ void MainWindow::ReShowWindow(QString strProject) {
           &MainWindow::chatGptStatus);
   connect(tclCommandIntegration, &TclCommandIntegration::closeDesign, this,
           [this]() { closeProject(true); });
+  connect(tclCommandIntegration, &TclCommandIntegration::saveSettingsSignal,
+          this, [this]() { saveSettings(); });
 
   addDockWidget(Qt::BottomDockWidgetArea, consoleDocWidget);
 

--- a/src/ProjNavigator/tcl_command_integration.cpp
+++ b/src/ProjNavigator/tcl_command_integration.cpp
@@ -346,6 +346,8 @@ ProjectManager *TclCommandIntegration::GetProjectManager() {
   return m_projManager;
 }
 
+void TclCommandIntegration::saveSettings() { emit saveSettingsSignal(); }
+
 void TclCommandIntegration::createNewDesign(const QString &projName,
                                             int projectType) {
   ProjectOptions opt{projName,

--- a/src/ProjNavigator/tcl_command_integration.h
+++ b/src/ProjNavigator/tcl_command_integration.h
@@ -56,12 +56,14 @@ class TclCommandIntegration : public QObject {
   bool TclshowChatGpt(const std::string &request, const std::string &content);
 
   ProjectManager *GetProjectManager();
+  void saveSettings();
 
  signals:
   void newDesign(const QString &);
   void closeDesign();
   void showChatGpt(const QString &r, const QString &data);
   void chatGptStatus(bool);
+  void saveSettingsSignal();
 
  private:
   void createNewDesign(const QString &design, int projectType = 0);

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -45,6 +45,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Compiler/Compiler.h"
 #include "Compiler/Log.h"
 #include "NewProject/ProjectManager/project_manager.h"
+#include "ProjNavigator/tcl_command_integration.h"
 #include "Simulator.h"
 #include "Utils/FileUtils.h"
 #include "Utils/StringUtils.h"
@@ -244,6 +245,8 @@ bool Simulator::RegisterCommands(TclInterpreter* interp) {
       } else if (phase == "extra_options") {
         simulator->SetSimulatorExtraOption(level, sim_tool, options);
       }
+      if (simulator->m_compiler->GuiTclSync())
+        simulator->m_compiler->GuiTclSync()->saveSettings();
       return TCL_OK;
     }
     return TCL_ERROR;


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-386
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed issue when user run some tcl command that has a setting on the GUI but it is not saved.


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
