### PR TITLE
[RG-416] Remove Balanced option from synth optimization

### DIFF
--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -141,17 +141,15 @@
                 "options": [
                     "Area",
                     "Delay",
-                    "Mixed",
-                    "None"
+                    "Mixed"
                 ],
                 "optionsLookup": [
                     "area",
                     "delay",
-                    "mixed",
-                    "none"
+                    "mixed"
                 ],
                 "arg": "_SynthOpt_",
-                "default":"None" 
+                "default":"Mixed"
             },
             "effort_dropdown": {
                 "label": "Effort",

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -949,8 +949,6 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
           compiler->SynthOpt(Compiler::SynthesisOpt::Area);
         } else if (arg == "delay") {
           compiler->SynthOpt(Compiler::SynthesisOpt::Delay);
-        } else if (arg == "none") {
-          compiler->SynthOpt(Compiler::SynthesisOpt::None);
         } else if (arg == "clean") {
           compiler->SynthOpt(Compiler::SynthesisOpt::Clean);
         } else {
@@ -1277,8 +1275,6 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
           compiler->SynthOpt(Compiler::SynthesisOpt::Area);
         } else if (arg == "delay") {
           compiler->SynthOpt(Compiler::SynthesisOpt::Delay);
-        } else if (arg == "none") {
-          compiler->SynthOpt(Compiler::SynthesisOpt::None);
         } else if (arg == "clean") {
           compiler->SynthOpt(Compiler::SynthesisOpt::Clean);
         } else {
@@ -2072,7 +2068,7 @@ bool Compiler::Synthesize() {
   if (SynthOpt() == SynthesisOpt::Clean) {
     Message("Cleaning synthesis results for " + m_projManager->projectName());
     m_state = State::IPGenerated;
-    SynthOpt(SynthesisOpt::None);
+    SynthOpt(SYNTH_OPT_DEFAULT);
     return true;
   }
   Message("Synthesizing design: " + m_projManager->projectName());

--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -96,7 +96,7 @@ class Compiler {
   enum MsgSeverity { Ignore, Info, Warning, Error };
   enum class IPGenerateOpt { None, Clean, List };
   enum class DesignAnalysisOpt { None, Clean };
-  enum class SynthesisOpt { None, Area, Delay, Mixed, Clean };
+  enum class SynthesisOpt { Area, Delay, Mixed, Clean };
   enum class PackingOpt { None, Clean, Debug };
   enum class GlobalPlacementOpt { None, Clean };
   enum class PlacementOpt { None, Clean };
@@ -279,6 +279,8 @@ class Compiler {
 
   std::string Name() const { return m_name; }
 
+  static constexpr SynthesisOpt SYNTH_OPT_DEFAULT{SynthesisOpt::Mixed};
+
  protected:
   /* Methods that can be customized for each new compiler flow */
   virtual bool IPGenerate();
@@ -351,7 +353,7 @@ class Compiler {
   // Tasks generic options
   IPGenerateOpt m_ipGenerateOpt = IPGenerateOpt::None;
   DesignAnalysisOpt m_analysisOpt = DesignAnalysisOpt::None;
-  SynthesisOpt m_synthOpt = SynthesisOpt::None;
+  SynthesisOpt m_synthOpt = SYNTH_OPT_DEFAULT;
   PackingOpt m_packingOpt = PackingOpt::None;
   GlobalPlacementOpt m_globalPlacementOpt = GlobalPlacementOpt::None;
   PlacementOpt m_placementOpt = PlacementOpt::None;

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -1159,7 +1159,7 @@ bool CompilerOpenFPGA::Synthesize() {
   if (SynthOpt() == SynthesisOpt::Clean) {
     Message("Cleaning synthesis results for " + ProjManager()->projectName());
     m_state = State::IPGenerated;
-    SynthOpt(SynthesisOpt::None);
+    SynthOpt(SYNTH_OPT_DEFAULT);
     CleanFiles(Action::Synthesis);
     return true;
   }

--- a/src/Main/Tasks.cpp
+++ b/src/Main/Tasks.cpp
@@ -140,7 +140,6 @@ auto separateArg = [](const QString& argName,
 
 // Lookup for SynthOpt values
 static std::map<FOEDAG::Compiler::SynthesisOpt, const char*> synthOptMap = {
-    {FOEDAG::Compiler::SynthesisOpt::None, "none"},
     {FOEDAG::Compiler::SynthesisOpt::Area, "area"},
     {FOEDAG::Compiler::SynthesisOpt::Delay, "delay"},
     {FOEDAG::Compiler::SynthesisOpt::Mixed, "mixed"},
@@ -172,7 +171,7 @@ auto synthStrToOpt = [](const QString& str) -> FOEDAG::Compiler::SynthesisOpt {
         return p.second == str;
       });
 
-  auto val = FOEDAG::Compiler::SynthesisOpt::None;
+  auto val = FOEDAG::Compiler::SYNTH_OPT_DEFAULT;
   if (it != synthOptMap.end()) {
     val = (*it).first;
   }


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Update list of the synthesis optimization options:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/c01a0147-3105-4fe1-a07c-4357afc365ab)

Change default value to `Mixed`

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
