### PR TITLE
[EDA-1567] simulation options wrong arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ test/gui_mac: run-cmake-debug
 #	$(XVFB) ./dbuild/bin/newfile --replay tests/TestGui/gui_new_file.tcl
 
 test/batch: run-cmake-release
+	./build/bin/foedag --batch --script tests/TestBatch/test_simulation_options.tcl
 	./build/bin/foedag --batch --script tests/TestBatch/test_ip_generate.tcl
 	./build/bin/foedag --batch --script tests/Testcases/aes_decrypt_fpga/aes_decrypt.tcl
 	./build/bin/foedag --batch --script tests/TestGui/compiler_flow.tcl

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -245,10 +245,16 @@ bool Simulator::RegisterCommands(TclInterpreter* interp) {
       } else if (phase == "extra_options") {
         simulator->SetSimulatorExtraOption(level, sim_tool, options);
       }
-      if (simulator->m_compiler->GuiTclSync())
-        simulator->m_compiler->GuiTclSync()->saveSettings();
-      return TCL_OK;
+      if (!phase.empty()) {
+        if (simulator->m_compiler->GuiTclSync())
+          simulator->m_compiler->GuiTclSync()->saveSettings();
+        return TCL_OK;
+      }
     }
+    Tcl_AppendResult(interp,
+                     "Invalid arguments. Usage: simulation_options <simulator> "
+                     "<phase> ?<level>? <options>",
+                     nullptr);
     return TCL_ERROR;
   };
   interp->registerCmd("simulation_options", simulation_options, this, 0);

--- a/tests/TestBatch/test_simulation_options.tcl
+++ b/tests/TestBatch/test_simulation_options.tcl
@@ -1,0 +1,49 @@
+#Copyright 2022 The Foedag team
+
+#GPL License
+
+#Copyright (c) 2022 The Open-Source FPGA Foundation
+
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# The following test calls each task's clean function before calling it's main action to check for an infinite loop caused by missing clean arg handling
+# This is related to os-fpga/FOEDAG/issues/575
+
+set cmd "simulation_options asd"
+if {![catch {eval $cmd} result]} {
+  error "TEST FAILED: '$cmd' should error out"
+}
+
+if {$result eq ""} {
+  error "TEST FAILED: '$cmd' should print error message"
+}
+
+set cmd "simulation_options asd asd"
+if {![catch {eval $cmd} result]} {
+  error "TEST FAILED: '$cmd' should error out"
+}
+
+if {$result eq ""} {
+  error "TEST FAILED: '$cmd' should print error message"
+}
+
+set cmd "simulation_options elab asd asd"
+if {[catch {eval $cmd} result]} {
+  error "TEST FAILED: '$cmd' should pass"
+}
+
+if {$result ne ""} {
+  error "TEST FAILED: '$cmd' should print nothing but the output is \"$result\""
+}
+exit 0


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: EDA-1567
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Added more informative message when `simulation_options` command got failed.
Covered by tcl test.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: simulation
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts
