### PR TITLE
[RG-380] Added 3rd party editors support for project file edit

### DIFF
--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -72,6 +72,7 @@ set (SRC_CPP_LIST ../Main/Foedag.cpp
   ../MainWindow/LicenseManagerWidget.cpp
   ../Main/ReportGenerator.cpp
   ../Main/JsonReportGenerator.cpp
+  ../MainWindow/EditorSettings.cpp
 )
 
 set (SRC_H_LIST ../Main/Foedag.h
@@ -109,6 +110,7 @@ set (SRC_H_LIST ../Main/Foedag.h
   ../MainWindow/LicenseManagerWidget.h
   ../Main/ReportGenerator.h
   ../Main/JsonReportGenerator.h
+  ../MainWindow/EditorSettings.h
 )
 
 set (SRC_UI_LIST "")

--- a/src/MainWindow/EditorSettings.cpp
+++ b/src/MainWindow/EditorSettings.cpp
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "EditorSettings.h"
+
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QLabel>
+#include <QLineEdit>
+
+namespace FOEDAG {
+
+EditorSettings::EditorSettings(QWidget* parent) : QDialog(parent) {
+  QGridLayout* layout = new QGridLayout{};
+  layout->addWidget(new QLabel{"Editor Name"}, 0, 1);
+  layout->addWidget(new QLabel{"Command"}, 0, 2);
+  for (int i = 0; i < 5; i++) {
+    m_editors.push_back(std::make_pair(new QLineEdit{}, new QLineEdit{}));
+    auto label = new QLabel{QString{"%1:"}.arg(QString::number(i + 1))};
+    layout->addWidget(label, i + 1, 0);
+    layout->addWidget(m_editors.back().first, i + 1, 1);
+    layout->addWidget(m_editors.back().second, i + 1, 2);
+  }
+  auto buttons =
+      new QDialogButtonBox{QDialogButtonBox::Ok | QDialogButtonBox::Cancel};
+  connect(buttons, &QDialogButtonBox::accepted, this, &EditorSettings::accept);
+  connect(buttons, &QDialogButtonBox::rejected, this, &EditorSettings::reject);
+  layout->addWidget(buttons, 6, 0, 1, 0, Qt::AlignRight);
+
+  setLayout(layout);
+  setWindowTitle("Editors settings");
+}
+
+std::vector<std::pair<QString, QString> > EditorSettings::editor() const {
+  std::vector<std::pair<QString, QString> > e;
+  for (const auto& line : m_editors) {
+    e.push_back(std::make_pair(line.first->text().simplified(),
+                               line.second->text().simplified()));
+  }
+  return e;
+}
+
+void EditorSettings::setEditor(const std::pair<QString, QString>& data,
+                               int index) {
+  if (index >= 0 && index < m_editors.size()) {
+    m_editors[index].first->setText(data.first);
+    m_editors[index].second->setText(data.second);
+  }
+}
+
+}  // namespace FOEDAG

--- a/src/MainWindow/EditorSettings.h
+++ b/src/MainWindow/EditorSettings.h
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <QDialog>
+
+class QLineEdit;
+namespace FOEDAG {
+
+class EditorSettings : public QDialog {
+ public:
+  EditorSettings(QWidget *parent = nullptr);
+  std::vector<std::pair<QString, QString>> editor() const;
+  void setEditor(const std::pair<QString, QString> &data, int index);
+
+ private:
+  std::vector<std::pair<QLineEdit *, QLineEdit *>> m_editors{};
+};
+}  // namespace FOEDAG

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -1854,10 +1854,19 @@ void MainWindow::releaseNodesClicked() {
 void MainWindow::openFileWith(QString file, int editor) {
   auto editorStr =
       m_settings.value(EDITOR_KEY.arg(QString::number(editor))).toString();
-  StringVector args{file.toStdString()};
-  auto command = QtUtils::StringSplit(editorStr, ';').last().toStdString();
-  FileUtils::ExecuteSystemCommand(command, args, nullptr, -1, {}, nullptr,
-                                  true);
+  auto editorLine = QtUtils::StringSplit(editorStr, ';');
+  if (editorLine.count() > 1) {
+    auto command = editorLine.last();
+    auto commandArgs = QtUtils::StringSplit(command, ' ');
+    if (!commandArgs.isEmpty()) {
+      auto commandName = commandArgs.takeFirst().toStdString();
+      StringVector args{};
+      for (const auto& c : commandArgs) args.push_back(c.toStdString());
+      args.push_back(file.toStdString());
+      FileUtils::ExecuteSystemCommand(commandName, args, nullptr, -1, {},
+                                      nullptr, true);
+    }
+  }
 }
 
 void MainWindow::editorSettings() {

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -42,6 +42,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Console/TclErrorParser.h"
 #include "DesignRuns/runs_form.h"
 #include "DockWidget.h"
+#include "EditorSettings.h"
 #include "IpConfigurator/IpCatalogTree.h"
 #include "IpConfigurator/IpConfigWidget.h"
 #include "IpConfigurator/IpConfigurator.h"
@@ -70,6 +71,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "TextEditor/text_editor_form.h"
 #include "Utils/FileUtils.h"
 #include "Utils/QtUtils.h"
+#include "Utils/StringUtils.h"
 #include "WidgetFactory.h"
 #include "foedag_version.h"
 
@@ -82,6 +84,7 @@ static constexpr const char* LICENSES_DIR{"licenses"};
 
 namespace {
 const QString RECENT_PROJECT_KEY{"recent/proj%1"};
+const QString EDITOR_KEY{"editors/editor%1"};
 const QString SHOW_WELCOMEPAGE_KEY{"showWelcomePage"};
 const QString SHOW_STOP_COMPILATION_MESSAGE_KEY{"showStopCompilationMessage"};
 const QString SHOW_MESSAGE_ON_EXIT_KEY{"showMessageOnExit"};
@@ -914,6 +917,7 @@ void MainWindow::createMenus() {
 #ifndef PRODUCTION_BUILD
   preferencesMenu->addAction(pinPlannerPinNameAction);
 #endif
+  preferencesMenu->addAction(editorSettingsAction);
   preferencesMenu->addAction(showWelcomePageAction);
   preferencesMenu->addAction(stopCompileMessageAction);
   preferencesMenu->addAction(showMessageOnExitAction);
@@ -1068,6 +1072,10 @@ void MainWindow::createActions() {
   connect(pinPlannerPinNameAction, &QAction::triggered, this,
           &MainWindow::pinPlannerPinName);
 
+  editorSettingsAction = new QAction{tr("3rd party editors..."), this};
+  connect(editorSettingsAction, &QAction::triggered, this,
+          &MainWindow::editorSettings);
+
   stopCompileMessageAction =
       new QAction(tr("Show message on stop compilation"), this);
   stopCompileMessageAction->setCheckable(true);
@@ -1152,7 +1160,7 @@ void MainWindow::ReShowWindow(QString strProject) {
 
   QDockWidget* sourceDockWidget = new DockWidget(tr("Source"), this);
   sourceDockWidget->setObjectName("sourcedockwidget");
-  sourcesForm = new SourcesForm(this);
+  sourcesForm = new SourcesForm(&m_settings, this);
   connect(
       sourcesForm, &SourcesForm::CloseProject, this,
       [this]() { closeProject(); }, Qt::QueuedConnection);
@@ -1203,6 +1211,8 @@ void MainWindow::ReShowWindow(QString strProject) {
   textEditor->setObjectName("textEditor");
   connect(sourcesForm, SIGNAL(OpenFile(QString)), textEditor,
           SLOT(SlotOpenFile(QString)));
+  connect(sourcesForm, SIGNAL(OpenFileWith(QString, int)), this,
+          SLOT(openFileWith(QString, int)));
   connect(textEditor, SIGNAL(CurrentFileChanged(QString)), sourcesForm,
           SLOT(SetCurrentFileItem(QString)));
   connect(textEditor, &TextEditor::FileChanged, this,
@@ -1839,6 +1849,36 @@ void MainWindow::releaseNodesClicked() {
   auto path = GlobalSession->Context()->DataPath() / "etc" / "config.json";
   auto releaseNotes{Settings::Config(path, "general", "release-notes")};
   if (!releaseNotes.isEmpty()) QDesktopServices::openUrl(releaseNotes);
+}
+
+void MainWindow::openFileWith(QString file, int editor) {
+  auto editorStr =
+      m_settings.value(EDITOR_KEY.arg(QString::number(editor))).toString();
+  StringVector args{file.toStdString()};
+  auto command = QtUtils::StringSplit(editorStr, ';').last().toStdString();
+  FileUtils::ExecuteSystemCommand(command, args, nullptr, -1, {}, nullptr,
+                                  true);
+}
+
+void MainWindow::editorSettings() {
+  EditorSettings setting{this};
+  for (int i = 0; i < setting.editor().size(); i++) {
+    auto value =
+        m_settings.value(EDITOR_KEY.arg(QString::number(i))).toString();
+    auto valueSplitted = QtUtils::StringSplit(value, ';');
+    if (valueSplitted.size() == 2)
+      setting.setEditor(
+          std::make_pair(valueSplitted.first(), valueSplitted.last()), i);
+  }
+  auto accepted = setting.exec();
+  if (accepted) {
+    const auto& editors = setting.editor();
+    for (int i = 0; i < editors.size(); i++) {
+      m_settings.setValue(
+          EDITOR_KEY.arg(QString::number(i)),
+          QString{"%1;%2"}.arg(editors.at(i).first, editors.at(i).second));
+    }
+  }
 }
 
 void MainWindow::setEnableSaveButtons(bool enable) {

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -104,6 +104,8 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void manageLicense();
   void documentationClicked();
   void releaseNodesClicked();
+  void openFileWith(QString file, int editor);
+  void editorSettings();
 
  public slots:
   void updateSourceTree();
@@ -214,6 +216,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   QAction* defualtProjectPathAction = nullptr;
   QAction* pinPlannerPinNameAction = nullptr;
   QAction* manageLicenseAction = nullptr;
+  QAction* editorSettingsAction = nullptr;
   std::vector<std::pair<QAction*, QString>> m_recentProjectsActions;
   newProjectDialog* newProjdialog = nullptr;
   /* Tool bar objects */

--- a/src/ProjNavigator/Test/projnavigator_main.cpp
+++ b/src/ProjNavigator/Test/projnavigator_main.cpp
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "tclutils/TclUtils.h"
 
 QWidget* proNavigatorBuilder(FOEDAG::Session* session) {
-  FOEDAG::SourcesForm* srcForm = new FOEDAG::SourcesForm();
+  FOEDAG::SourcesForm* srcForm = new FOEDAG::SourcesForm(nullptr);
   if (session->CmdLine()->Argc() > 2) {
     FOEDAG::ProjectFileLoader loader(FOEDAG::Project::Instance());
     loader.registerComponent(

--- a/src/ProjNavigator/sources_form.h
+++ b/src/ProjNavigator/sources_form.h
@@ -1,6 +1,7 @@
 #ifndef SOURCES_FORM_H
 #define SOURCES_FORM_H
 #include <QAction>
+#include <QSettings>
 #include <QTreeWidget>
 #include <QWidget>
 
@@ -36,7 +37,7 @@ class SourcesForm : public QWidget {
   Q_OBJECT
 
  public:
-  explicit SourcesForm(QWidget* parent = nullptr);
+  explicit SourcesForm(QSettings* settings, QWidget* parent = nullptr);
   ~SourcesForm();
 
   void InitSourcesForm();
@@ -49,6 +50,7 @@ class SourcesForm : public QWidget {
 
  signals:
   void OpenFile(QString);
+  void OpenFileWith(QString, int);
   void ShowProperty(const QString&);
   void ShowPropertyPanel();
   void CloseProject();
@@ -70,6 +72,7 @@ class SourcesForm : public QWidget {
   void SlotCreateSimSet();
   void SlotAddFile();
   void SlotOpenFile();
+  void SlotOpenFileWith(int editor);
   void SlotRemoveFileSet();
   void SlotRemoveFile();
   void SlotSetAsTarget();
@@ -103,8 +106,10 @@ class SourcesForm : public QWidget {
   QAction* m_simulateIp;
   QAction* m_waveFormView;
   QAction* m_actProjectSettings;
+  QMenu* m_menuOpenFileWith;
 
   ProjectManager* m_projManager;
+  QSettings* m_setting{nullptr};
 
   void CreateActions();
   void CreateFolderHierachyTree();
@@ -118,6 +123,8 @@ class SourcesForm : public QWidget {
   void showAddFileDialog(GridType gridType);
   void AddIpInstanceTree(QTreeWidgetItem* topItem);
   QStringList SelectedIpModules() const;
+  QStringList SelectedFiles() const;
+  void initOpenWithMenu(QMenu* menu);
 };
 }  // namespace FOEDAG
 

--- a/src/Utils/FileUtils.h
+++ b/src/Utils/FileUtils.h
@@ -76,7 +76,8 @@ class FileUtils final {
                                      const std::vector<std::string>& args,
                                      std::ostream* out, int timeout_ms = -1,
                                      const std::string& workingDir = {},
-                                     std::ostream* err = nullptr);
+                                     std::ostream* err = nullptr,
+                                     bool startDetached = false);
 
   static time_t Mtime(const std::filesystem::path& path);
 


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Allow user select few 3rd party editors:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/eff2e87a-4cc5-4373-9fd8-9552f8ee9728)

![image](https://github.com/os-fpga/FOEDAG/assets/95262932/cc7dfaa2-b17c-45b4-867c-ddb87edde172)

Than open project files:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/c1bbe5d1-7557-4561-ac32-e372419336e3)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore, utils, projnavigator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts