### PR TITLE
[EDA-957] Initial implementation of Compute Usage  table which shows task duration and memory utilization

### DIFF
--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -2101,11 +2101,13 @@ bool Compiler::Compile(Action action) {
   if (task != TaskManager::invalid_id && m_taskManager) {
     m_taskManager->task(task)->setStatus(TaskStatus::InProgress);
   }
+  m_utils = {};
   res = SwitchCompileContext(
       action, [this, action]() { return RunCompileTask(action); });
   if (task != TaskManager::invalid_id && m_taskManager) {
     m_taskManager->task(task)->setStatus(res ? TaskStatus::Success
                                              : TaskStatus::Fail);
+    if (res) m_taskManager->task(task)->setUtilization(m_utils);
   }
   return res;
 }
@@ -2870,6 +2872,8 @@ int Compiler::ExecuteAndMonitorSystemCommand(
     stream << max_utiliation << " kiB";
   else
     stream << max_utiliation / 1024 << " MB";
+  m_utils.utilization = max_utiliation;
+  m_utils.duration = d.count();
   PERF_LOG(stream.str());
   return (status == QProcess::NormalExit) ? exitCode : -1;
 }

--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -32,6 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "IPGenerate/IPGenerator.h"
 #include "Main/CommandLine.h"
 #include "Simulation/Simulator.h"
+#include "Task.h"
 #include "Tcl/TclInterpreter.h"
 
 class QProcess;
@@ -411,6 +412,7 @@ class Compiler {
   std::filesystem::path m_programmerToolExecutablePath{};
   std::filesystem::path m_configFileSearchDir{};
   std::string m_name;
+  ProcessUtilization m_utils;
 };
 
 }  // namespace FOEDAG

--- a/src/Compiler/Task.cpp
+++ b/src/Compiler/Task.cpp
@@ -98,4 +98,10 @@ Task *Task::cleanTask() const { return m_clean; }
 
 void Task::setCleanTask(Task *newClean) { m_clean = newClean; }
 
+ProcessUtilization Task::utilization() const { return m_utilization; }
+
+void Task::setUtilization(const ProcessUtilization &newUtilization) {
+  m_utilization = newUtilization;
+}
+
 }  // namespace FOEDAG

--- a/src/Compiler/Task.h
+++ b/src/Compiler/Task.h
@@ -51,6 +51,11 @@ struct CustomData {
   QVariant data;
 };
 
+struct ProcessUtilization {
+  uint duration{};
+  uint utilization{};
+};
+
 /*!
  * \brief The Task class
  * Implements task entity.
@@ -111,6 +116,9 @@ class Task : public QObject {
   Task *cleanTask() const;
   void setCleanTask(Task *newClean);
 
+  ProcessUtilization utilization() const;
+  void setUtilization(const ProcessUtilization &newUtilization);
+
  signals:
   /*!
    * \brief statusChanged. Emits whenever status has changed.
@@ -136,6 +144,7 @@ class Task : public QObject {
   bool m_enable{true};
   bool m_enableDefault{true};
   CustomData m_customData{};
+  ProcessUtilization m_utilization;
 };
 
 }  // namespace FOEDAG

--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -385,9 +385,8 @@ void TaskManager::run() {
 }
 
 void TaskManager::reset() {
-  for (auto task = m_tasks.begin(); task != m_tasks.end(); task++) {
-    (*task)->setStatus(TaskStatus::None);
-  }
+  for (auto task = m_tasks.begin(); task != m_tasks.end(); task++)
+    resetTask(*task);
 }
 
 void TaskManager::cleanDownStreamStatus(Task *t) {
@@ -398,11 +397,11 @@ void TaskManager::cleanDownStreamStatus(Task *t) {
         it--;
       if (isSimulation(*it)) {
         // in case simulation task, we don't need to clean all downstream tasks
-        (*it)->setStatus(TaskStatus::None);
+        resetTask(*it);
         break;
       }
       for (; it != m_taskQueue.end(); ++it) {
-        (*it)->setStatus(TaskStatus::None);
+        resetTask(*it);
       }
       break;
     }
@@ -423,6 +422,11 @@ void TaskManager::setDialogProvider(const DialogProvider *const dProvider) {
 
 void TaskManager::appendTask(Task *t) {
   if (t->isEnable() && t->isValid()) m_runStack.append(t);
+}
+
+void TaskManager::resetTask(Task *t) {
+  t->setStatus(TaskStatus::None);
+  t->setUtilization({});
 }
 
 QVector<Task *> TaskManager::getDownstreamCleanTasks(Task *t) const {

--- a/src/Compiler/TaskManager.h
+++ b/src/Compiler/TaskManager.h
@@ -131,6 +131,7 @@ class TaskManager : public QObject {
   void reset();
   void cleanDownStreamStatus(Task *t);
   void appendTask(Task *t);
+  void resetTask(Task *t);
 
   /*!
    * \brief getDownstreamClearTasks

--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -75,6 +75,7 @@ set (SRC_CPP_LIST ../Main/Foedag.cpp
   ../MainWindow/EditorSettings.cpp
   ../MainWindow/Dialog.cpp
   ../MainWindow/CompressProject.cpp
+  ../MainWindow/PerfomanceTracker.cpp
 )
 
 set (SRC_H_LIST ../Main/Foedag.h
@@ -115,6 +116,7 @@ set (SRC_H_LIST ../Main/Foedag.h
   ../MainWindow/EditorSettings.h
   ../MainWindow/Dialog.h
   ../MainWindow/CompressProject.h
+  ../MainWindow/PerfomanceTracker.h
 )
 
 set (SRC_UI_LIST ../MainWindow/WelcomePageWidget.ui)
@@ -164,6 +166,7 @@ install(
           ${PROJECT_SOURCE_DIR}/../MainWindow/TopLevelInterface.h
           ${PROJECT_SOURCE_DIR}/../NewProject/newprojectmodel.h
           ${PROJECT_SOURCE_DIR}/../NewFile/newfilemodel.h
+          ${PROJECT_SOURCE_DIR}/../MainWindow/PerfomanceTracker.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/foedag/MainWindow)
   
 install(

--- a/src/MainWindow/PerfomanceTracker.cpp
+++ b/src/MainWindow/PerfomanceTracker.cpp
@@ -1,0 +1,96 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "PerfomanceTracker.h"
+
+#include <QHeaderView>
+#include <QTableWidget>
+
+#include "Compiler/CompilerDefines.h"
+#include "Compiler/TaskManager.h"
+
+namespace FOEDAG {
+
+PerfomanceTracker::PerfomanceTracker(TaskManager *tManager)
+    : m_taskManager(tManager) {
+  m_view = new QTableWidget;
+  m_view->setColumnCount(3);
+  m_view->setHorizontalHeaderLabels({"Task", "Duration, s", "Utilization, MB"});
+  m_view->verticalHeader()->hide();
+  m_view->resizeColumnsToContents();
+  m_view->setColumnWidth(0, 180);
+  buildTable();
+}
+
+void PerfomanceTracker::update() { buildTable(); }
+
+void PerfomanceTracker::setTaskManager(TaskManager *tManager) {
+  m_taskManager = tManager;
+}
+
+QTableWidget *PerfomanceTracker::widget() { return m_view; }
+
+void PerfomanceTracker::buildTable() {
+  if (!m_taskManager) return;
+  const auto taskIds = this->taskIds();
+
+  if (m_view->rowCount() != taskIds.size()) {
+    while (m_view->rowCount() != 0) m_view->removeRow(0);
+    while (m_view->rowCount() < taskIds.size()) m_view->insertRow(0);
+  }
+
+  m_view->clearContents();
+  int row = 0;
+  for (auto taskId : taskIds) {
+    auto task = m_taskManager->task(taskId);
+    if (!task) continue;
+
+    for (int i = 0; i < 3; i++) m_view->setItem(row, i, new QTableWidgetItem{});
+
+    m_view->item(row, 0)->setText(task->title());
+    m_view->item(row, 1)->setText(
+        ToString(static_cast<double>(task->utilization().duration) / 1000));
+    m_view->item(row, 2)->setText(
+        ToString(static_cast<double>(task->utilization().utilization) / 1024));
+    row++;
+  }
+}
+
+QString PerfomanceTracker::ToString(double val) {
+  if (val == 0) return "N/A";
+  return QString::number(val);
+}
+
+QVector<uint> PerfomanceTracker::taskIds() const {
+  static const auto taskIds = {ANALYSIS, SYNTHESIS,       PACKING,  PLACEMENT,
+                               ROUTING,  TIMING_SIGN_OFF, BITSTREAM};
+  static const auto taskIdsPostSynth = {PACKING, PLACEMENT, ROUTING,
+                                        TIMING_SIGN_OFF, BITSTREAM};
+  return isRtl() ? taskIds : taskIdsPostSynth;
+}
+
+bool PerfomanceTracker::isRtl() const { return m_isRtl; }
+
+void PerfomanceTracker::setIsRtl(bool newIsRtl) {
+  m_isRtl = newIsRtl;
+  update();
+}
+
+}  // namespace FOEDAG

--- a/src/MainWindow/PerfomanceTracker.cpp
+++ b/src/MainWindow/PerfomanceTracker.cpp
@@ -79,10 +79,12 @@ QString PerfomanceTracker::ToString(double val) {
 }
 
 QVector<uint> PerfomanceTracker::taskIds() const {
-  static const auto taskIds = {ANALYSIS, SYNTHESIS,       PACKING,  PLACEMENT,
-                               ROUTING,  TIMING_SIGN_OFF, BITSTREAM};
-  static const auto taskIdsPostSynth = {PACKING, PLACEMENT, ROUTING,
-                                        TIMING_SIGN_OFF, BITSTREAM};
+  static const auto taskIds = {
+      ANALYSIS,  SIMULATE_RTL, SYNTHESIS,    SIMULATE_GATE,   PACKING,
+      PLACEMENT, ROUTING,      SIMULATE_PNR, TIMING_SIGN_OFF, BITSTREAM};
+  static const auto taskIdsPostSynth = {
+      SIMULATE_GATE, PACKING,         PLACEMENT, ROUTING,
+      SIMULATE_PNR,  TIMING_SIGN_OFF, BITSTREAM};
   return isRtl() ? taskIds : taskIdsPostSynth;
 }
 

--- a/src/MainWindow/PerfomanceTracker.h
+++ b/src/MainWindow/PerfomanceTracker.h
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <QString>
+
+class QTableWidget;
+
+namespace FOEDAG {
+
+class TaskManager;
+
+class PerfomanceTracker {
+ public:
+  PerfomanceTracker(TaskManager *tManager = nullptr);
+  void update();
+
+  void setTaskManager(TaskManager *tManager);
+
+  QTableWidget *widget();
+
+  bool isRtl() const;
+  void setIsRtl(bool newIsRtl);
+
+ private:
+  void buildTable();
+  QString ToString(double val);
+  QVector<uint> taskIds() const;
+
+ private:
+  TaskManager *m_taskManager{nullptr};
+  QTableWidget *m_view{nullptr};
+  bool m_isRtl{true};
+};
+
+}  // namespace FOEDAG

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -1282,6 +1282,9 @@ void MainWindow::ReShowWindow(QString strProject) {
   console->addParser(new FileNameParser{});
   m_console = console;
 
+  QDockWidget* perfomance = new DockWidget(tr("Perfomance tracker"), this);
+  perfomance->setWidget(m_perfomanceTracker.widget());
+
   m_compiler->SetInterpreter(m_interpreter);
   m_compiler->SetOutStream(&buffer->getStream());
   m_compiler->SetErrStream(&console->getErrorBuffer()->getStream());
@@ -1303,6 +1306,8 @@ void MainWindow::ReShowWindow(QString strProject) {
           &MainWindow::updateHierarchyTree);
 
   addDockWidget(Qt::BottomDockWidgetArea, consoleDocWidget);
+  addDockWidget(Qt::BottomDockWidgetArea, perfomance);
+  tabifyDockWidget(consoleDocWidget, perfomance);
 
   // QDockWidget* runDockWidget = new DockWidget(tr("Design Runs"), this);
   // runDockWidget->setObjectName("designrundockwidget");
@@ -1322,6 +1327,7 @@ void MainWindow::ReShowWindow(QString strProject) {
   // compiler task view
   delete m_taskView;
   m_taskView = prepareCompilerView(m_compiler, &m_taskManager);
+  m_perfomanceTracker.setTaskManager(m_taskManager);
   m_taskManager->setDialogProvider(new DialogProvider{this});
   m_taskView->setObjectName("compilerTaskView");
   m_taskView->setParent(this);
@@ -1341,6 +1347,7 @@ void MainWindow::ReShowWindow(QString strProject) {
               showMessagesTab();
               showReportsTab();
             }
+            m_perfomanceTracker.update();
             m_progressBar->show();
             setStatusAndProgressText(statusMsg);
           });
@@ -1761,6 +1768,7 @@ void MainWindow::updateTaskTable() {
   m_taskManager->task(SIMULATE_BITSTREAM_CLEAN)->setValid(false);
   m_taskManager->task(POWER)->setValid(false);
   m_taskManager->task(POWER_CLEAN)->setValid(false);
+  m_perfomanceTracker.setIsRtl(!isPostSynthPure);
 }
 
 void MainWindow::slotTabChanged(int index) {

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -1282,7 +1282,7 @@ void MainWindow::ReShowWindow(QString strProject) {
   console->addParser(new FileNameParser{});
   m_console = console;
 
-  QDockWidget* perfomance = new DockWidget(tr("Perfomance tracker"), this);
+  QDockWidget* perfomance = new DockWidget(tr("Compute usage"), this);
   perfomance->setWidget(m_perfomanceTracker.widget());
 
   m_compiler->SetInterpreter(m_interpreter);

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -27,9 +27,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Main/AboutWidget.h"
 #include "NewProject/new_project_dialog.h"
+#include "PerfomanceTracker.h"
 #include "ProjNavigator/FileExplorer.h"
 #include "ProjNavigator/HierarchyView.h"
 #include "TopLevelInterface.h"
+
 class QAction;
 class QLabel;
 class QProgressBar;
@@ -259,6 +261,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   QListView* m_chatGptListView{nullptr};
   FileExplorer m_fileExplorer;
   HierarchyView m_hierarchyView{{}};
+  PerfomanceTracker m_perfomanceTracker;
 };
 
 }  // namespace FOEDAG

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -19,6 +19,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if (defined(_MSC_VER) || defined(__CYGWIN__))
+#define NOMINMAX  // prevent error with std::max
+#endif
+
 #ifdef _WIN32
 #include <Windows.h>
 #include <direct.h>

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -46,6 +46,7 @@ set (CPP_LIST
     Simulation/Simulation_test.cpp
     Utils/FileUtils_test.cpp
     CFGCommon/CFGCommon_test.cpp
+    MainWindow/PerfomanceTracker_test.cpp
 )
 set (H_LIST
     PinAssignment/TestLoader.h

--- a/tests/unittest/MainWindow/PerfomanceTracker_test.cpp
+++ b/tests/unittest/MainWindow/PerfomanceTracker_test.cpp
@@ -43,7 +43,7 @@ TEST(PerfomanceTracker, isNotRtl) {
   pTracker.setTaskManager(&mManager);
   pTracker.setIsRtl(false);
 
-  EXPECT_EQ(pTracker.widget()->rowCount(), 5);
+  EXPECT_EQ(pTracker.widget()->rowCount(), 7);
 }
 
 TEST(PerfomanceTracker, isRtl) {
@@ -53,7 +53,7 @@ TEST(PerfomanceTracker, isRtl) {
   pTracker.setTaskManager(&mManager);
   pTracker.update();
 
-  EXPECT_EQ(pTracker.widget()->rowCount(), 7);
+  EXPECT_EQ(pTracker.widget()->rowCount(), 10);
 }
 
 TEST(PerfomanceTracker, updateTable) {

--- a/tests/unittest/MainWindow/PerfomanceTracker_test.cpp
+++ b/tests/unittest/MainWindow/PerfomanceTracker_test.cpp
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "MainWindow/PerfomanceTracker.h"
+
+#include <QTableWidget>
+
+#include "Compiler/CompilerDefines.h"
+#include "Compiler/Task.h"
+#include "Compiler/TaskManager.h"
+#include "gtest/gtest.h"
+
+using namespace FOEDAG;
+
+TEST(PerfomanceTracker, Init) {
+  PerfomanceTracker pTracker{};
+  EXPECT_NE(pTracker.widget(), nullptr);
+  EXPECT_EQ(pTracker.isRtl(), true);
+}
+
+TEST(PerfomanceTracker, isNotRtl) {
+  PerfomanceTracker pTracker{};
+
+  TaskManager mManager{nullptr};
+  pTracker.setTaskManager(&mManager);
+  pTracker.setIsRtl(false);
+
+  EXPECT_EQ(pTracker.widget()->rowCount(), 5);
+}
+
+TEST(PerfomanceTracker, isRtl) {
+  PerfomanceTracker pTracker{};
+
+  TaskManager mManager{nullptr};
+  pTracker.setTaskManager(&mManager);
+  pTracker.update();
+
+  EXPECT_EQ(pTracker.widget()->rowCount(), 7);
+}
+
+TEST(PerfomanceTracker, updateTable) {
+  PerfomanceTracker pTracker{};
+
+  TaskManager mManager{nullptr};
+  pTracker.setTaskManager(&mManager);
+
+  mManager.task(ANALYSIS)->setUtilization({1000, 1024});
+  pTracker.update();
+
+  EXPECT_EQ(pTracker.widget()->item(0, 1)->text(), "1");
+  EXPECT_EQ(pTracker.widget()->item(0, 2)->text(), "1");
+}


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Add new feature - Compute Usage:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/ac43803d-6cfe-49f5-8479-a55423fb8811)

Result is available only after task successfully done.
 
Result is N/A in case:
* Task was cleaned
* Task was skipped because of no design change.
* Project was opened.

For simulation task:
* Duration is a sum of three (elaboration, compile and simulate)
* Utilization is maximum of three  (elaboration, compile and simulate)

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
