### PR TITLE
[RG-456] Fixed analyze command failed when user stop compilation

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -236,8 +236,8 @@ void MainWindow::ScriptFinished() {
   DesignFileWatcher::Instance()->updateDesignFileWatchers(m_projectManager);
   saveSettings();
 
+  if (m_compiler) m_compiler->ResetStopFlag();
   GlobalSession->CmdStack()->push_and_exec(new Command{"analyze"});
-  updateHierarchyTree();
 }
 
 void MainWindow::newFile() {


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-456
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Fixed failed analyze when user stop compile:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/8b0aff22-0e39-42df-861a-b05257b1bb45)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts