### PR TITLE
Revert "[RG-461] Fixed crash when exit while compilation is in progress"

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -573,7 +573,6 @@ void MainWindow::stopCompilation() {
 void MainWindow::forceStopCompilation() {
   m_compiler->Stop();
   m_progressBar->hide();
-  while (isRunning()) QApplication::processEvents();
 }
 
 void MainWindow::showMessagesTab() {


### PR DESCRIPTION
Reverts os-fpga/FOEDAG#1210 due to a new bug discovery while testing.