### PR TITLE
[RG-461] [RG-463] Fixed crash when exit while compilation is in progress

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -222,13 +222,13 @@ void MainWindow::ProgressVisible(bool visible) {
 }
 
 void MainWindow::closeEvent(QCloseEvent* event) {
-  if (isRunning()) {
-    m_closeRequest = true;
-    event->ignore();
-    forceStopCompilation();
-    return;
-  }
   if (confirmExitProgram()) {
+    if (isRunning()) {
+      m_closeRequest = true;
+      event->ignore();
+      forceStopCompilation();
+      return;
+    }
     forceStopCompilation();
     event->accept();
   } else {
@@ -1842,6 +1842,7 @@ bool MainWindow::confirmCloseProject() {
 bool MainWindow::confirmExitProgram() {
   if (!lastProjectClosed()) return false;
   if (!m_askShowMessageOnExit) return true;
+  if (m_closeRequest) return true;
   return (QMessageBox::question(
               this, "Exit Program?", tr("Are you sure you want to exit?\n"),
               QMessageBox::No | QMessageBox::Yes) == QMessageBox::Yes);

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -222,6 +222,12 @@ void MainWindow::ProgressVisible(bool visible) {
 }
 
 void MainWindow::closeEvent(QCloseEvent* event) {
+  if (isRunning()) {
+    m_closeRequest = true;
+    event->ignore();
+    forceStopCompilation();
+    return;
+  }
   if (confirmExitProgram()) {
     forceStopCompilation();
     event->accept();
@@ -1359,6 +1365,7 @@ void MainWindow::ReShowWindow(QString strProject) {
     m_compiler->finish();
     showMessagesTab();
     showReportsTab();
+    if (m_closeRequest) this->close();
   });
 
   connect(m_taskManager, &TaskManager::started, this,

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -263,6 +263,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   FileExplorer m_fileExplorer;
   HierarchyView m_hierarchyView{{}};
   PerfomanceTracker m_perfomanceTracker;
+  bool m_closeRequest{false};
 };
 
 }  // namespace FOEDAG


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-461, RG-463
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed two issue when exit from foedag while compilation in progress:
* Crash
* running process after close for script mode

Implementation makes sure that compilation process has finished and only after that close the application.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
