### PR TITLE
Debug CentOS storage issue

### DIFF
--- a/.github/workflows/install_centos_dependencies_build.sh
+++ b/.github/workflows/install_centos_dependencies_build.sh
@@ -37,30 +37,9 @@ then
 fi
 
 echo "Downloading QT..."
-curl -L https://download.qt.io/official_releases/qt/5.15/5.15.4/single/qt-everywhere-opensource-src-5.15.4.tar.xz --output qt-everywhere-src-5.15.4.tar.xz
-tar -xf qt-everywhere-src-5.15.4.tar.xz
-
-if [ -d "buildqt5" ] 
-then
-  echo "Installing QT..."
-  cd buildqt5  
-  make install
-  cd ..
-else
-  echo "Building QT..."
-  # work around to make it compile on GCC 11. For reference, see source (https://forum.qt.io/topic/139626/unable-to-build-static-version-of-qt-5-15-2/13)
-  sed -i '44i\#include <limits>' qt-everywhere-src-5.15.4/qtbase/src/corelib/text/qbytearraymatcher.h
-  sed -i '52i\#include <limits>' qt-everywhere-src-5.15.4/qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h
-  cat qt-everywhere-src-5.15.4/qtbase/src/corelib/text/qbytearraymatcher.h
-  mkdir buildqt5
-  cd buildqt5
-  source /opt/rh/devtoolset-11/enable
-  ../qt-everywhere-src-5.15.4/configure -opensource -confirm-license -xcb -xcb-xlib -bundled-xcb-xinput -no-compile-examples -nomake examples
-  make -j 2
-  echo "Installing QT..."
-  make install
-  cd ..
-fi
+curl -L https://github.com/RapidSilicon/post_build_artifacts/releases/download/v0.1/Qt_5.15.4.tar.gz --output qt-everywhere-src-5.15.4.tar.gz
+tar -xzf qt-everywhere-src-5.15.4.tar.gz
+mv 5.15.4 /usr/local/Qt-5.15.4
 yum clean all
-rm -rf qt-everywhere-src-5.15.4.tar.xz qt-everywhere-src-5.15.4
+rm -rf qt-everywhere-src-5.15.4.tar.gz
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,10 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
-
+    
+    - name: Show space
+      run: df -h
+      
     - name: Download workflow artifact
       if: matrix.mode == 'test'
       uses: dawidd6/action-download-artifact@v2.24.0
@@ -167,7 +170,8 @@ jobs:
         branch: main
         name: buildqt5-centos7-gcc
         skip_unpack: true
-
+    - name: show space
+      run: df -h
     - name: Install dependencies and build QT
       run: |
         bash .github/workflows/install_centos_dependencies_build.sh && df -h

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,37 +157,15 @@ jobs:
         submodules: recursive
         fetch-depth: 0
     
-    - name: Show space
+    - name: Show space before Qt install
       run: df -h
       
-    - name: Download workflow artifact
-      if: matrix.mode == 'test'
-      uses: dawidd6/action-download-artifact@v2.24.0
-      with:
-        workflow: main.yml
-        repo: ${{ github.repository }}
-        #run_number: 3912
-        branch: main
-        name: buildqt5-centos7-gcc
-        skip_unpack: true
-    - name: show space
-      run: df -h
     - name: Install dependencies and build QT
       run: |
-        bash .github/workflows/install_centos_dependencies_build.sh && df -h
+        bash .github/workflows/install_centos_dependencies_build.sh
 
-    - name: Prepare QT build artifacts
-      if: matrix.mode == 'test'
-      run: |
-        mkdir build
-        tar czvfp buildqt5-centos7-gcc.tgz buildqt5
-
-    - name: Archive QT build artifacts
-      if: matrix.mode == 'test'
-      uses: actions/upload-artifact@v3.1.0
-      with:
-        name: buildqt5-centos7-gcc
-        path: buildqt5-centos7-gcc.tgz
+    - name: show space after Qt install
+      run: du -sch *
 
     - name: Show shell configuration
       run: |
@@ -195,14 +173,6 @@ jobs:
         source /opt/rh/devtoolset-11/enable
         which gcc 
         which g++ 
-
-    - name: Remove QT tar file.
-      run: |
-        df -h
-        rm -rf buildqt5-centos7-gcc.tgz
-        rm -rf buildqt5-centos7-gcc.zip
-        rm -rf buildqt5
-        df -h
 
     - name: Configure shell
       run: |
@@ -223,6 +193,10 @@ jobs:
         make release test/batch
         make test/gui
         make regression
+
+    - name: show space after build & test
+      if: always ()
+      run: du -sch *        
 
 # Reference: https://github.com/eyllanesc/69108420/blob/main/.github/workflows/test.yml
   msys2-gcc:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,7 @@ jobs:
         bash .github/workflows/install_centos_dependencies_build.sh
 
     - name: show space after Qt install
-      run: du -sch *
+      run: du -sch * && df -h
 
     - name: Show shell configuration
       run: |
@@ -196,7 +196,7 @@ jobs:
 
     - name: show space after build & test
       if: always ()
-      run: du -sch *        
+      run: du -sch * && df -h        
 
 # Reference: https://github.com/eyllanesc/69108420/blob/main/.github/workflows/test.yml
   msys2-gcc:


### PR DESCRIPTION
Remove the download of Qt source download and compiled artifact, instead download the installable binary directly and place them at /usr/local/bin. This will save more than 14GB of space.  