### PR TITLE
[EDA-1876] Fixed missing ports in pin planner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 226)
+set(VERSION_PATCH 227)
 option(
   WITH_LIBCXX
   "Building with clang++ and libc++(in Linux). To enable with: -DWITH_LIBCXX=On"

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -1519,7 +1519,8 @@ void MainWindow::pinAssignmentActionTriggered() {
     data.context = GlobalSession->Context();
     data.pinMapFile =
         QString::fromStdString(m_compiler->PinmapCSVFile().string());
-    data.projectPath = m_projectManager->getProjectPath();
+    data.portsFilePath = QString::fromStdString(
+        m_compiler->FilePath(Compiler::Action::Analyze).string());
     data.target = QString::fromStdString(m_projectManager->getTargetDevice());
     data.pinFile = QString::fromStdString(m_projectManager->getConstrPinFile());
     QFile file{data.pinFile};

--- a/src/PinAssignment/PinAssignmentCreator.cpp
+++ b/src/PinAssignment/PinAssignmentCreator.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "PinAssignmentCreator.h"
 
 #include <QBoxLayout>
+#include <QDebug>
 #include <QDir>
 #include <filesystem>
 
@@ -49,7 +50,8 @@ PinAssignmentCreator::PinAssignmentCreator(const PinAssignmentData &data,
   packagePinModel->setBaseModel(m_baseModel);
 
   PortsLoader *portsLoader{FindPortsLoader(data.target)};
-  portsLoader->load(searchPortsFile(data.projectPath));
+  auto [ok, message] = portsLoader->load(searchPortsFile(data.portsFilePath));
+  if (!ok) qWarning() << message;
 
   PackagePinsLoader *loader{FindPackagePinLoader(data.target)};
   loader->loadHeader(packagePinHeaderFile(data.context));

--- a/src/PinAssignment/PinAssignmentCreator.h
+++ b/src/PinAssignment/PinAssignmentCreator.h
@@ -35,7 +35,7 @@ struct PinAssignmentData {
   QString pinMapFile{};
   QString target{};
   QStringList commands{};
-  QString projectPath{};
+  QString portsFilePath{};
   QString pinFile{};
   bool useBallId{false};
 };


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: EDA-1876
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Fixed wrong path to ports file. Additionally, add warning message if ports loading fails.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore, pinassignament
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
