### PR TITLE
[EDA-1938] Enable write logs to file when --mute option set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
 
-set(VERSION_PATCH 231)
+set(VERSION_PATCH 232)
 
 option(
   WITH_LIBCXX

--- a/src/Command/CommandStack.cpp
+++ b/src/Command/CommandStack.cpp
@@ -28,26 +28,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace FOEDAG;
 
-CommandStack::CommandStack(TclInterpreter *interp, const std::string &logFile,
-                           bool mute)
+CommandStack::CommandStack(TclInterpreter *interp, const std::string &logFile)
     : m_interp(interp) {
-  if (!mute) {
-    std::string textHeader = LogUtils::GetLogHeader();
-    std::string tclHeader = LogUtils::GetLogHeader("# ");
+  std::string textHeader = LogUtils::GetLogHeader();
+  std::string tclHeader = LogUtils::GetLogHeader("# ");
 
-    m_logger = new Logger(logFile.empty() ? "cmd.tcl" : logFile + "_cmd.tcl");
-    m_logger->open();
-    (*m_logger) << tclHeader;
+  m_logger = new Logger(logFile.empty() ? "cmd.tcl" : logFile + "_cmd.tcl");
+  m_logger->open();
+  (*m_logger) << tclHeader;
 
-    m_perfLogger =
-        new Logger(logFile.empty() ? "perf.log" : logFile + "_perf.log");
-    m_perfLogger->open();
-    (*m_perfLogger) << textHeader;
+  m_perfLogger =
+      new Logger(logFile.empty() ? "perf.log" : logFile + "_perf.log");
+  m_perfLogger->open();
+  (*m_perfLogger) << textHeader;
 
-    m_outputLogger = new Logger(logFile.empty() ? "out.log" : logFile + ".log");
-    m_outputLogger->open();
-    (*m_outputLogger) << textHeader;
-  }
+  m_outputLogger = new Logger(logFile.empty() ? "out.log" : logFile + ".log");
+  m_outputLogger->open();
+  (*m_outputLogger) << textHeader;
 }
 
 bool CommandStack::push_and_exec(Command *cmd) {

--- a/src/Command/CommandStack.h
+++ b/src/Command/CommandStack.h
@@ -37,7 +37,7 @@ class CommandStack {
  private:
  public:
   CommandStack(TclInterpreter* interp,
-               const std::string& logFile = std::string{}, bool mute = false);
+               const std::string& logFile = std::string{});
   bool push_and_exec(Command* cmd);
   void push(Command* cmd);
   bool pop_and_undo();

--- a/src/Main/Foedag.cpp
+++ b/src/Main/Foedag.cpp
@@ -374,7 +374,7 @@ bool Foedag::initBatch() {
   const bool mute{m_cmdLine->Mute() && !m_cmdLine->Script().empty()};
   Config::Instance()->dataPath(m_context->DataPath());
   FOEDAG::CommandStack* commands =
-      new FOEDAG::CommandStack(interpreter, m_context->ExecutableName(), mute);
+      new FOEDAG::CommandStack(interpreter, m_context->ExecutableName());
   GlobalSession =
       new FOEDAG::Session(m_mainWin, interpreter, commands, m_cmdLine,
                           m_context, m_compiler, m_settings);
@@ -397,16 +397,14 @@ bool Foedag::initBatch() {
                                          ComponentId::Compiler);
   GlobalSession->ProjectFileLoader(m_projectFileLoader);
 
-  if (mute) {
-    std::cout.rdbuf(nullptr);
-  } else {
-    BatchModeBuffer* outBuffer = new BatchModeBuffer{commands->OutLogger()};
-    auto tmp = std::cout.rdbuf(outBuffer);
-    outBuffer->getStream().rdbuf(tmp);
+  BatchModeBuffer* outBuffer = new BatchModeBuffer{commands->OutLogger()};
+  auto tmp = std::cout.rdbuf(outBuffer);
+  outBuffer->getStream().rdbuf(mute ? nullptr : tmp);
 
-    BatchModeBuffer* errBuffer = new BatchModeBuffer{commands->OutLogger()};
-    tmp = std::cerr.rdbuf(errBuffer);
-    errBuffer->getStream().rdbuf(tmp);
+  BatchModeBuffer* errBuffer = new BatchModeBuffer{commands->OutLogger()};
+  tmp = std::cerr.rdbuf(errBuffer);
+  errBuffer->getStream().rdbuf(mute ? nullptr : tmp);
+  if (!mute) {
     m_tclChannelHandler = new FOEDAG::TclWorker(interpreter->getInterp(),
                                                 std::cout, &std::cerr, true);
   }


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
When `--mute` option is used, logs will write to the log file. Standard output still remains muted.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
