### PR TITLE
Add Gtests for nets and parameters and fix rs type name generation (across platforms)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
 
-set(VERSION_PATCH 233)
+set(VERSION_PATCH 234)
 
 option(
   WITH_LIBCXX

--- a/src/DeviceModeling/device_net.h
+++ b/src/DeviceModeling/device_net.h
@@ -17,6 +17,8 @@
 class device_block;
 class device_signal;
 
+using namespace std;
+
 /**
  * @class device_net
  * @brief Class representing a net in a device.

--- a/src/DeviceModeling/rs_parameter.h
+++ b/src/DeviceModeling/rs_parameter.h
@@ -11,10 +11,10 @@
 
 #pragma once
 
+#include <iostream>
 #include <memory>
 #include <optional>
 #include <sstream>
-#include <iostream>
 
 #include "rs_parameter_type.h"
 
@@ -184,9 +184,8 @@ class Parameter {
   std::string to_string() const {
     std::ostringstream oss;
     std::string tp;
-    std::string tn = std::string(typeid(T).name());
-    std::cout << "____DBG____ typeid " << tn << std::endl;
-    tp = (tn == "i") ? "int" : ((tn == "d") ? "double" : "string");
+    T phony;
+    tp = TypeNameMapper::GetTypeName(phony);
     oss << "Parameter " << name_ << ": " << value_ << " of type " << tp;
     if (has_address()) {
       oss << " at address " << get_address();

--- a/src/DeviceModeling/rs_parameter.h
+++ b/src/DeviceModeling/rs_parameter.h
@@ -184,8 +184,7 @@ class Parameter {
   std::string to_string() const {
     std::ostringstream oss;
     std::string tp;
-    T phony;
-    tp = TypeNameMapper::GetTypeName(phony);
+    tp = TypeNameMapper::GetTypeName(T());
     oss << "Parameter " << name_ << ": " << value_ << " of type " << tp;
     if (has_address()) {
       oss << " at address " << get_address();

--- a/src/DeviceModeling/rs_parameter.h
+++ b/src/DeviceModeling/rs_parameter.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <iostream>
 
 #include "rs_parameter_type.h"
 
@@ -184,6 +185,7 @@ class Parameter {
     std::ostringstream oss;
     std::string tp;
     std::string tn = std::string(typeid(T).name());
+    std::cout << "____DBG____ typeid " << tn << std::endl;
     tp = (tn == "i") ? "int" : ((tn == "d") ? "double" : "string");
     oss << "Parameter " << name_ << ": " << value_ << " of type " << tp;
     if (has_address()) {

--- a/src/DeviceModeling/rs_parameter.h
+++ b/src/DeviceModeling/rs_parameter.h
@@ -11,7 +11,9 @@
 
 #pragma once
 
+#include <memory>
 #include <optional>
+#include <sstream>
 
 #include "rs_parameter_type.h"
 

--- a/src/DeviceModeling/rs_parameter_type.h
+++ b/src/DeviceModeling/rs_parameter_type.h
@@ -15,6 +15,21 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+class TypeNameMapper {
+ public:
+  template <typename T>
+  static std::string GetTypeName() {
+    return "Unknown";
+  }
+
+  // Not a specialization, but a function that's always there
+  static std::string GetTypeName(int) { return "int"; }
+
+  static std::string GetTypeName(double) { return "double"; }
+
+  static std::string GetTypeName(std::string) { return "string"; }
+};
+
 /**
  * @class ParameterType
  * @brief Template class to hold type information of a parameter.

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -24,7 +24,7 @@ if(MSVC)
 endif()
 
 if(MINGW)
-    add_compile_options(-Wa,-mbig-obj)
+  add_compile_options(-Wa,-mbig-obj)
 endif()
 
 set(CPP_LIST
@@ -61,6 +61,7 @@ set(CPP_LIST
   DeviceModeling/rs_expression_test.cpp
   DeviceModeling/rs_expression_evaluator_test.cpp
   DeviceModeling/rs_parameter_type_test.cpp
+  DeviceModeling/rs_parameter_test.cpp
 )
 set(H_LIST
   PinAssignment/TestLoader.h

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -62,6 +62,7 @@ set(CPP_LIST
   DeviceModeling/rs_expression_evaluator_test.cpp
   DeviceModeling/rs_parameter_type_test.cpp
   DeviceModeling/rs_parameter_test.cpp
+  DeviceModeling/device_net_test.cpp
 )
 set(H_LIST
   PinAssignment/TestLoader.h

--- a/tests/unittest/DeviceModeling/device_net_test.cpp
+++ b/tests/unittest/DeviceModeling/device_net_test.cpp
@@ -1,0 +1,99 @@
+#include "DeviceModeling/device_net.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+// This fixture will help in setting up some common setup and teardown for each
+// test
+class DeviceNetTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Common setup if required
+  }
+
+  void TearDown() override {
+    // Common cleanup if required
+  }
+};
+
+// Testing the constructor
+TEST_F(DeviceNetTest, ConstructWithNameOnly) {
+  device_net net("test_net");
+  EXPECT_EQ(net.get_net_name(), "test_net");
+  EXPECT_EQ(net.get_signal(), nullptr);
+}
+
+// Testing the copy constructor
+TEST_F(DeviceNetTest, CopyConstructor) {
+  device_net net_original("test_net");
+  device_net net_copy(net_original);
+  EXPECT_EQ(net_copy.get_net_name(), "test_net");
+  EXPECT_EQ(net_copy.get_signal(), nullptr);
+}
+
+// Testing setter and getter of net name
+TEST_F(DeviceNetTest, SetAndGetNetName) {
+  device_net net("initial_name");
+  net.set_net_name("new_name");
+  EXPECT_EQ(net.get_net_name(), "new_name");
+}
+
+// Testing source and sink relationships
+TEST_F(DeviceNetTest, SetAndGetSource) {
+  device_net net("test_net");
+  std::shared_ptr<device_net> source_net =
+      std::make_shared<device_net>("source_net");
+  net.set_source(source_net);
+  EXPECT_EQ(net.get_source(), source_net);
+}
+
+TEST_F(DeviceNetTest, AddAndGetSinks) {
+  device_net net("test_net");
+  std::shared_ptr<device_net> sink1 = std::make_shared<device_net>("sink1");
+  std::shared_ptr<device_net> sink2 = std::make_shared<device_net>("sink2");
+
+  net.add_sink(sink1);
+  net.add_sink(sink2);
+
+  const auto& sinks = net.get_sink_set();
+  EXPECT_EQ(sinks.size(), 2);
+  EXPECT_NE(sinks.find(sink1), sinks.end());
+  EXPECT_NE(sinks.find(sink2), sinks.end());
+}
+
+// Testing equality functions
+TEST_F(DeviceNetTest, EqualityOperators) {
+  device_net net1("test_net");
+  device_net net2("test_net");
+  device_net net3("another_net");
+
+  EXPECT_FALSE(net1 == net2);  // Since your == checks for same object reference
+  EXPECT_TRUE(net1 != net2);   // Inverse
+  EXPECT_FALSE(net1 == net3);
+  EXPECT_TRUE(net1 != net3);
+}
+
+TEST_F(DeviceNetTest, CheckEqualityFunction) {
+  device_net net1("test_net");
+  device_net net2("test_net");
+  device_net net3("another_net");
+
+  EXPECT_TRUE(net1.equal(net2));  // Since they are separate instances with
+                                   // potentially separate sinks, sources etc.
+  EXPECT_FALSE(net1.equal(net3));
+}
+
+// Testing string representation functions
+TEST_F(DeviceNetTest, ToStringFunction) {
+  device_net net("test_net");
+  std::string expected_start = "Net Name: test_net";
+  EXPECT_TRUE(net.to_string().find(expected_start) != std::string::npos);
+}
+
+TEST_F(DeviceNetTest, FormattedStringFunction) {
+  device_net net("test_net");
+  std::string expected_start = "device_net: Net Name: test_net";
+  EXPECT_TRUE(net.to_formatted_string().find(expected_start) !=
+              std::string::npos);
+}

--- a/tests/unittest/DeviceModeling/rs_parameter_test.cpp
+++ b/tests/unittest/DeviceModeling/rs_parameter_test.cpp
@@ -1,0 +1,74 @@
+/**
+ * @file rs_parameter_test.cpp
+ * @author Manadher Kharroubi (manadher@rapidsilicon.com)
+ * @brief
+ * @version 0.1
+ * @date 2023-05-18
+ *
+ * @copyright Copyright (c) 2023
+ *
+ */
+
+#include "DeviceModeling/rs_parameter.h"
+
+#include <gtest/gtest.h>
+
+TEST(ParameterTest, Constructor) {
+  auto type = std::make_shared<ParameterType<int>>();
+  Parameter<int> param("test", 5, type);
+
+  EXPECT_EQ(param.get_name(), "test");
+  EXPECT_EQ(param.get_value(), 5);
+}
+
+TEST(ParameterTest, SetValue) {
+  auto type = std::make_shared<ParameterType<int>>();
+  Parameter<int> param("test", 5, type);
+  param.set_value(10);
+
+  EXPECT_EQ(param.get_value(), 10);
+}
+
+TEST(ParameterTest, InvalidValue) {
+  auto type = std::make_shared<ParameterType<int>>();
+
+  type->set_lower_bound(0);
+  type->set_upper_bound(10);
+  EXPECT_THROW(Parameter<int>("test", -1, type), std::runtime_error);
+}
+
+TEST(ParameterTest, SetAddress) {
+  auto type = std::make_shared<ParameterType<int>>();
+  Parameter<int> param("test", 5, type);
+  param.set_address(123);
+
+  EXPECT_EQ(param.get_address(), 123);
+}
+
+TEST(ParameterTest, IntToString) {
+  auto type = std::make_shared<ParameterType<int>>();
+  Parameter<int> param("test", 5, type);
+
+  EXPECT_EQ(param.to_string(), "Parameter test: 5 of type int");
+}
+
+TEST(ParameterTest, DoubleToString) {
+  auto type = std::make_shared<ParameterType<double>>();
+  Parameter<double> param("test", 5.5, type);
+
+  EXPECT_EQ(param.to_string(), "Parameter test: 5.5 of type double");
+}
+
+TEST(ParameterTest, StringToString) {
+  auto type = std::make_shared<ParameterType<std::string>>();
+  Parameter<std::string> param("test", "Test", type);
+
+  EXPECT_EQ(param.to_string(), "Parameter test: Test of type string");
+}
+
+TEST(ParameterTest, InvalidSetAddress) {
+  auto type = std::make_shared<ParameterType<double>>();
+  Parameter<double> param("test", 5.5, type);
+
+  EXPECT_THROW(param.set_address(123), std::runtime_error);
+}


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x ] To add new Gtests to Device Modeling, testing and fixing rs type names generation
> 

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, FOEDAG has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
