### PR TITLE
[EDA-1199] When user run 'Clean' simulation action, perform clean step for simulation only.

### DIFF
--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -406,6 +406,12 @@ void TaskManager::resetTask(Task *t) {
 
 QVector<Task *> TaskManager::getDownstreamCleanTasks(Task *t) const {
   QVector<Task *> tasks;
+  for (auto task : m_taskQueue) {
+    if ((task->cleanTask() == t) && isSimulation(task)) {
+      tasks.append(t);
+      return tasks;
+    }
+  }
   for (auto it{m_taskQueue.rbegin()}; it != m_taskQueue.rend(); ++it) {
     if ((*it)->type() == TaskType::Clean) tasks.append(*it);
     if (*it == t) break;

--- a/src/Compiler/TaskManager.h
+++ b/src/Compiler/TaskManager.h
@@ -138,6 +138,8 @@ class TaskManager : public QObject {
   /*!
    * \brief getDownstreamClearTasks
    * \return vector of clean tasks in reverse order. Vector includes \param t.
+   * If \param t is simulation clean, return only this task since simulation
+   * doesn't trigger clean for downstream.
    */
   QVector<Task *> getDownstreamCleanTasks(Task *t) const;
   void registerReportManager(uint type, AbstractReportManager *manager);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: EDA-1199
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
In case user execute Clean for simulation, remove files for simulation only but not the downstream steps.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
