### PR TITLE
[EDA-1199] When user run 'Clean' simulation action, perform clean step for simulation only.

### DIFF
--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -406,6 +406,12 @@ void TaskManager::resetTask(Task *t) {
 
 QVector<Task *> TaskManager::getDownstreamCleanTasks(Task *t) const {
   QVector<Task *> tasks;
+  for (auto task : m_taskQueue) {
+    if ((task->cleanTask() == t) && isSimulation(task)) {
+      tasks.append(t);
+      return tasks;
+    }
+  }
   for (auto it{m_taskQueue.rbegin()}; it != m_taskQueue.rend(); ++it) {
     if ((*it)->type() == TaskType::Clean) tasks.append(*it);
     if (*it == t) break;

--- a/src/Compiler/TaskManager.h
+++ b/src/Compiler/TaskManager.h
@@ -101,6 +101,14 @@ class TaskManager : public QObject {
   static bool isSimulation(const Task *const task);
   void setDialogProvider(const DialogProvider *const dProvider);
 
+  /*!
+   * \brief getDownstreamClearTasks
+   * \return vector of clean tasks in reverse order. Vector includes \param t.
+   * If \param t is simulation clean, return only this task since simulation
+   * doesn't trigger clean for downstream.
+   */
+  QVector<Task *> getDownstreamCleanTasks(Task *t) const;
+
  signals:
   /*!
    * \brief taskStateChanged. Emits whenever any task change its status.
@@ -134,12 +142,6 @@ class TaskManager : public QObject {
   void cleanDownStreamStatus(Task *t);
   void appendTask(Task *t);
   void resetTask(Task *t);
-
-  /*!
-   * \brief getDownstreamClearTasks
-   * \return vector of clean tasks in reverse order. Vector includes \param t.
-   */
-  QVector<Task *> getDownstreamCleanTasks(Task *t) const;
   void registerReportManager(uint type, AbstractReportManager *manager);
 
  private:

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -64,6 +64,7 @@ set(CPP_LIST
   DeviceModeling/rs_parameter_test.cpp
   DeviceModeling/device_signal_test.cpp
   DeviceModeling/device_net_test.cpp
+  Compiler/TaskManager_test.cpp
 )
 set(H_LIST
   PinAssignment/TestLoader.h

--- a/tests/unittest/Compiler/TaskManager_test.cpp
+++ b/tests/unittest/Compiler/TaskManager_test.cpp
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "Compiler/TaskManager.h"
+
+#include "Compiler/Compiler.h"
+#include "Compiler/CompilerDefines.h"
+#include "gtest/gtest.h"
+
+using namespace FOEDAG;
+
+TEST(TaskManager, getDownstreamCleanTasks) {
+  TaskManager taskManager{nullptr};
+
+  taskManager.task(SIMULATE_RTL)
+      ->setCustomData({CustomDataType::Sim,
+                       QVariant::fromValue(Simulator::SimulationType::RTL)});
+  taskManager.task(SIMULATE_PNR)
+      ->setCustomData({CustomDataType::Sim,
+                       QVariant::fromValue(Simulator::SimulationType::PNR)});
+  taskManager.task(SIMULATE_GATE)
+      ->setCustomData({CustomDataType::Sim,
+                       QVariant::fromValue(Simulator::SimulationType::Gate)});
+  taskManager.task(SIMULATE_BITSTREAM)
+      ->setCustomData(
+          {CustomDataType::Sim,
+           QVariant::fromValue(Simulator::SimulationType::BitstreamBackDoor)});
+
+  auto simulationRtl = taskManager.task(SIMULATE_RTL_CLEAN);
+  auto cleanTasks = taskManager.getDownstreamCleanTasks(simulationRtl);
+  EXPECT_EQ(cleanTasks.count(), 1);
+  EXPECT_EQ(cleanTasks.at(0), simulationRtl);
+
+  auto simulationGate = taskManager.task(SIMULATE_GATE_CLEAN);
+  cleanTasks = taskManager.getDownstreamCleanTasks(simulationGate);
+  EXPECT_EQ(cleanTasks.count(), 1);
+  EXPECT_EQ(cleanTasks.at(0), simulationGate);
+
+  auto simulationPnr = taskManager.task(SIMULATE_PNR_CLEAN);
+  cleanTasks = taskManager.getDownstreamCleanTasks(simulationPnr);
+  EXPECT_EQ(cleanTasks.count(), 1);
+  EXPECT_EQ(cleanTasks.at(0), simulationPnr);
+
+  auto simulationBitstream = taskManager.task(SIMULATE_BITSTREAM_CLEAN);
+  cleanTasks = taskManager.getDownstreamCleanTasks(simulationBitstream);
+  EXPECT_EQ(cleanTasks.count(), 1);
+  EXPECT_EQ(cleanTasks.at(0), simulationBitstream);
+
+  auto analysis = taskManager.task(ANALYSIS_CLEAN);
+  cleanTasks = taskManager.getDownstreamCleanTasks(analysis);
+  EXPECT_EQ(cleanTasks.count(), 12);
+}


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: EDA-1199
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
In case user execute Clean for simulation, remove files for simulation only but not the downstream steps.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts
