### PR TITLE
[RG-469] Clean for simulation needs a separate message and disabling of some context items

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
 
-set(VERSION_PATCH 240)
+set(VERSION_PATCH 241)
 
 
 option(

--- a/src/Compiler/TaskManager.h
+++ b/src/Compiler/TaskManager.h
@@ -143,6 +143,8 @@ class TaskManager : public QObject {
   void appendTask(Task *t);
   void resetTask(Task *t);
   void registerReportManager(uint type, AbstractReportManager *manager);
+  QString cleanText(Task *t) const;
+  Task *GetCleanParent(Task *t) const;
 
  private:
   QMap<uint, Task *> m_tasks;

--- a/src/Compiler/TaskTableView.h
+++ b/src/Compiler/TaskTableView.h
@@ -66,6 +66,7 @@ class TaskTableView : public QTableView {
   QRect expandArea(const QModelIndex &index) const;
   void addTaskLogAction(QMenu *menu, Task *task);
   void addExpandCollapse(QMenu *menu);
+  void addTaskViewWaveformAction(QMenu *menu, Task *task);
 
  private:
   /*!


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-469
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Update message for clean simulation task:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/61793381-1b61-4e00-939b-ae3f11b882c4)

Disable `View waveform` action when waveform file doesn't available.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
