### PR TITLE
Open IP configuration when user select IP Reconfiguration action from context menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
 
-set(VERSION_PATCH 240)
+set(VERSION_PATCH 241)
 
 
 option(

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -1238,7 +1238,7 @@ void MainWindow::ReShowWindow(QString strProject) {
   addDockWidget(Qt::LeftDockWidgetArea, propertiesDockWidget);
   propertiesDockWidget->hide();
   connect(sourcesForm, &SourcesForm::IpReconfigRequested, this,
-          &MainWindow::handleIpReConfigRequested);
+          &MainWindow::openIpConfigurationDialog);
   connect(sourcesForm, &SourcesForm::IpRemoveRequested, this,
           &MainWindow::handleRemoveIpRequested);
   connect(sourcesForm, &SourcesForm::IpDeleteRequested, this,
@@ -1603,7 +1603,7 @@ void MainWindow::ipConfiguratorActionTriggered() {
       connect(m_ipCatalogTree, &IpCatalogTree::ipReady, this,
               &MainWindow::handleIpTreeSelectionChanged);
       connect(m_ipCatalogTree, &IpCatalogTree::openIpSettings, this,
-              &MainWindow::openIpConfigurationDialog);
+              [this]() { openIpConfigurationDialog({}, {}, {}); });
     }
 
     // update the console for input incase the IP system printed any messages
@@ -1648,10 +1648,16 @@ void MainWindow::handleIpTreeSelectionChanged() {
   }
 }
 
-void MainWindow::openIpConfigurationDialog() {
-  auto items = m_ipCatalogTree->selectedItems();
-  if (items.count() > 0) {
-    IPDialogBox ipDialogBox{this, items[0]->text(0)};
+void MainWindow::openIpConfigurationDialog(const QString& ipName,
+                                           const QString& moduleName,
+                                           const QStringList& paramList) {
+  QString name{ipName};
+  if (name.isEmpty()) {
+    auto items = m_ipCatalogTree->selectedItems();
+    if (items.count() > 0) name = items[0]->text(0);
+  }
+  if (!name.isEmpty()) {
+    IPDialogBox ipDialogBox{this, name, moduleName, paramList};
     auto result = ipDialogBox.exec();
     if (result == QDialog::Accepted) updateSourceTree();
   }

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -117,7 +117,9 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
  public slots:
   void updateSourceTree();
   void handleIpTreeSelectionChanged();
-  void openIpConfigurationDialog();
+  void openIpConfigurationDialog(const QString& ipName = {},
+                                 const QString& moduleName = {},
+                                 const QStringList& paramList = {});
   void handleIpReConfigRequested(const QString& ipName,
                                  const QString& moduleName,
                                  const QStringList& paramList);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
When user press `Reconfigure IP` action from context menu open ip configuration dialog.
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/61da3fc8-4f06-4a69-8068-ffd8fc0c28ff)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
