### PR TITLE
Turn off -readability-identifier-length check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,6 +29,7 @@ Checks: >
   -readability-uppercase-literal-suffix,
   -readability-inconsistent-declaration-parameter-name,
   -readability-simplify-boolean-expr,
+  -readability-identifier-length,
   google-*,
   -google-readability-braces-around-statements,
   -google-readability-todo,


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Turn off -readability-identifier-length check since to many warnings in every file and some of them comes from Qt and some is expected like `i` in for loop, `ok` as bool flag, `ec` for error code and many other. 

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [ ] Library: <Specify the library name>
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [x] Continous Integration (CI) scripts