### PR TITLE
Add verbose flag for list_cable and list_device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
 
-set(VERSION_PATCH 246)
+set(VERSION_PATCH 247)
 
 
 option(

--- a/src/Configuration/CFGCommon/CFGArg.json
+++ b/src/Configuration/CFGCommon/CFGArg.json
@@ -78,7 +78,7 @@
             "short": "v",
             "type": "flag",
             "optional": true,
-            "default": true,
+            "default": false,
             "help": "Display additional information of list_device output"
           }
         ],
@@ -98,7 +98,7 @@
             "short": "v",
             "type": "flag",
             "optional": true,
-            "default": true,
+            "default": false,
             "help": "Display additional information of list_cable output"
           }
         ],

--- a/src/Configuration/CFGCommon/CFGArg.json
+++ b/src/Configuration/CFGCommon/CFGArg.json
@@ -72,6 +72,16 @@
   [
     {
       "list_device": {
+        "option": [
+          {
+            "name": "verbose",
+            "short": "v",
+            "type": "flag",
+            "optional": true,
+            "default": true,
+            "help": "Display additional information of list_device output"
+          }
+        ],
         "desc": "To display list of connected devices to each conneceted/detected cable.",
         "help": [ "To display list of connected devices to each conneceted/detected cable.",
                   "To display list of all connected devices on specify cable.",
@@ -82,6 +92,16 @@
     },
     {
       "list_cable": {
+        "option": [
+          {
+            "name": "verbose",
+            "short": "v",
+            "type": "flag",
+            "optional": true,
+            "default": true,
+            "help": "Display additional information of list_cable output"
+          }
+        ],
         "desc": "To display all the connected/detected cables.",
         "help": ["To display all the connected/detected cables"],
         "arg" : [0, 0]
@@ -196,9 +216,9 @@
               "optional": true,
               "default": "program",
               "help": ["Flash programming operations to perform.", 
-                      "Valid values are: erase, blankcheck, program, verify",
+                      "Valid values are: program",
                       "The values can be chained together using comma", 
-                      "e.g. erase,blankcheck,program,verify"]
+                      "e.g. program"]
             }
         ],
         "desc": "Flash programming with the specified bitstream.",

--- a/tests/unittest/CFGCommon/CFGArg_test.cpp
+++ b/tests/unittest/CFGCommon/CFGArg_test.cpp
@@ -91,7 +91,7 @@ TEST(CFGArg, test_arg) {
 TEST(CFGArg, test_list_device_ok) {
   CFGArg_PROGRAMMER_LIST_DEVICE arg;
   std::vector<std::string> errors;
-  const char* argv[] = {"1"};
+  const char* argv[] = {"1", "-v"};
   int argc = int(sizeof(argv) / sizeof(argv[0]));
   bool status = arg.parse(argc, argv, &errors);
   EXPECT_EQ(status, true);
@@ -112,8 +112,9 @@ TEST(CFGArg, test_list_device_exceed_max_arg) {
 TEST(CFGArg, test_list_cable_ok) {
   CFGArg_PROGRAMMER_LIST_CABLE arg;
   std::vector<std::string> errors;
-  int argc = 0;
-  bool status = arg.parse(argc, nullptr, &errors);
+  const char* argv[] = {"-v"};
+  int argc = int(sizeof(argv) / sizeof(argv[0]));
+  bool status = arg.parse(argc, argv, &errors);
   EXPECT_EQ(status, true);
   EXPECT_EQ(errors.size(), 0);
 }
@@ -121,7 +122,7 @@ TEST(CFGArg, test_list_cable_ok) {
 TEST(CFGArg, test_list_cable_exceed_max_arg) {
   CFGArg_PROGRAMMER_LIST_CABLE arg;
   std::vector<std::string> errors;
-  const char* argv[] = {"dummy_arg"};
+  const char* argv[] = {"dummy_arg, dummy_arg2"};
   int argc = int(sizeof(argv) / sizeof(argv[0]));
   bool status = arg.parse(argc, argv, &errors);
   EXPECT_EQ(status, false);


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details

- Added -v flag to indicate verbose output for `list_cable` and `list_device` tcl commands
- -v flag is optional. Default value false.
The implementation of the programmer tcl commands `list_cable` and `list_device` output is coming on next PR if this proposal works for everyone.


Example of list_cable output 
```
% programmer list_cable -v
INFO: Cable           
INFO: -----------------
INFO: (1) RsFtdi_1_1
INFO: (2) RsFtdi_1_2
RsFtdi_1_1 RsFtdi_1_2

% programmer list_cableRs
Ftdi_1_1 RsFtdi_1_2      <------------ these are space separated tcl output
```

```
% programmer list_device -v
Open On-Chip Debugger 0.12.0+dev-g98eac38e3 (2023-08-26-20:19)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Open On-Chip Debugger 0.12.0+dev-g98eac38e3 (2023-08-26-20:19)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
INFO: Cable               | Device
INFO: -----------------------------------------------
INFO: (1) RsFtdi_1_1        (1) gemini
(1)gemini            <------------ these are space separated tcl output

% programmer list_device 
Open On-Chip Debugger 0.12.0+dev-g98eac38e3 (2023-08-26-20:19)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Open On-Chip Debugger 0.12.0+dev-g98eac38e3 (2023-08-26-20:19)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
(1)gemini            <------------ these are space separated tcl output
```

### Note 
The `Open On-Chip Debugger 0.12.0+dev-g98eac38e3 (2023-08-26-20:19)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html` is coming from std::out of openocd command which we have no control over it.

> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, FOEDAG has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
