### PR TITLE
[RG-468] Fixed generating IP after stop compilation press.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
 
-set(VERSION_PATCH 250)
+set(VERSION_PATCH 251)
 
 
 option(

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -587,6 +587,7 @@ void MainWindow::stopCompilation() {
 void MainWindow::forceStopCompilation() {
   m_compiler->Stop();
   m_progressBar->hide();
+  QtUtils::AppendToEventQueue([this]() { m_compiler->ResetStopFlag(); });
 }
 
 void MainWindow::showMessagesTab() {


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-468
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed generate IP after compilation was canceled:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/87337440-8f1b-43af-a60b-2e49127ce3f7)
This is fixed:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/4ac17481-6b5c-420c-9ac0-20a237c60728)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts