### PR TITLE
Add 'format' function that gives a nice way to concatenate strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
 
-set(VERSION_PATCH 253)
+set(VERSION_PATCH 254)
 
 
 option(

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -147,6 +147,22 @@ class StringUtils final {
 
   static StringVector FromArgs(int argc, const char* argv[]);
 
+  static std::string format(const std::string& format) { return format; }
+  template <typename T, typename... Targs>
+  static std::string format(const std::string& string, T value,
+                            Targs... Fargs) {
+    static const size_t length{1};
+    auto find = string.find('%');
+    if (find != std::string::npos) {
+      std::string str = string;
+      std::stringstream sstream;
+      sstream << value;
+      str.replace(find, length, sstream.str());
+      return format(str, Fargs...);
+    }
+    return string;
+  }
+
  private:
   StringUtils() = delete;
   StringUtils(const StringUtils& orig) = delete;

--- a/tests/unittest/Utils/StringUtils_test.cpp
+++ b/tests/unittest/Utils/StringUtils_test.cpp
@@ -241,5 +241,35 @@ TEST(StringUtilsTest, FromArgsNull) {
   EXPECT_EQ(res, expected);
 }
 
+TEST(FileUtils, format) {
+  std::string formatstr{"hello %"};
+  formatstr = StringUtils::format(formatstr, "world");
+  EXPECT_EQ(formatstr, std::string{"hello world"});
+
+  formatstr = "% %";
+  formatstr = StringUtils::format(formatstr, 10, 20);
+  EXPECT_EQ(formatstr, std::string{"10 20"});
+}
+
+TEST(FileUtils, formatOneArg) {
+  std::string formatstr{"hello % %"};
+  formatstr = StringUtils::format(formatstr, "world");
+  EXPECT_EQ(formatstr, std::string{"hello world %"});
+
+  formatstr = "% % %";
+  formatstr = StringUtils::format(formatstr, 10, 20);
+  EXPECT_EQ(formatstr, std::string{"10 20 %"});
+}
+
+TEST(FileUtils, formatFewArgs) {
+  std::string formatstr{"hello"};
+  formatstr = StringUtils::format(formatstr, "world");
+  EXPECT_EQ(formatstr, std::string{"hello"});
+
+  formatstr = "%";
+  formatstr = StringUtils::format(formatstr, 10, 20);
+  EXPECT_EQ(formatstr, std::string{"10"});
+}
+
 }  // namespace
 }  // namespace FOEDAG


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
This function provides an easy way to concatenate strings. For example:
```
std::string formatstr{"hello %"};
formatstr = StringUtils::format(formatstr, "world");
EXPECT_EQ(formatstr, std::string{"hello world"});
```

This function can be replaced with similar function from the C++20

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: utils
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts