### PR TITLE
[EDA-2024] [EDA-2007] Compiler error handling last error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
 
-set(VERSION_PATCH 260)
+set(VERSION_PATCH 261)
 
 
 option(

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -2022,6 +2022,12 @@ bool Compiler::HasInternalError() const {
   return false;
 }
 
+void Compiler::SetError(const std::string& message) {
+  m_errorState = ErrorState{message};
+}
+
+void Compiler::ResetError() { m_errorState = ErrorState{}; }
+
 std::filesystem::path Compiler::FilePath(Action action) const {
   if (!ProjManager()) return {};
 
@@ -2777,6 +2783,11 @@ void Compiler::SetEnvironmentVariable(const std::string variable,
 int Compiler::ExecuteAndMonitorSystemCommand(
     const std::string& command, const std::string logFile, bool appendLog,
     const std::filesystem::path& workingDir) {
+  if (m_errorState) {
+    ErrorMessage(m_errorState.message);
+    ResetError();
+    return -1;
+  }
   auto start = Time::now();
   PERF_LOG("Command: " + command);
   (*m_out) << "Command: " << command << std::endl;

--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -374,6 +374,9 @@ class Compiler {
   void AddHeadersToLogs(Action action);
   void AddErrorLink(const class Task* const current);
   bool HasInternalError() const;
+  void SetError(const std::string& message);
+  void ResetError();
+
   /* Propected members */
   TclInterpreter* m_interp = nullptr;
   Session* m_session = nullptr;
@@ -444,6 +447,7 @@ class Compiler {
   std::filesystem::path m_configFileSearchDir{};
   std::string m_name;
   ProcessUtilization m_utils;
+  struct ErrorState m_errorState;
 };
 
 }  // namespace FOEDAG

--- a/src/Compiler/CompilerDefines.cpp
+++ b/src/Compiler/CompilerDefines.cpp
@@ -216,4 +216,45 @@ int toAction(uint taskId) {
   return static_cast<int>(Compiler::Action::NoAction);
 }
 
+std::string ToString(Design::Language lang) {
+  using namespace Design;
+  switch (lang) {
+    case BLIF:
+      return "BLIF";
+    case EBLIF:
+      return "EBLIF";
+    case VHDL_1987:
+      return "VHDL 1987";
+    case VHDL_1993:
+      return "VHDL 1993";
+    case VHDL_2000:
+      return "VHDL 2000";
+    case VHDL_2008:
+      return "VHDL 2008";
+    case VERILOG_1995:
+      return "VERILOG 1995";
+    case VERILOG_2001:
+      return "VERILOG 2001";
+    case VERILOG_NETLIST:
+      return "VERILOG NETLIST";
+    case SYSTEMVERILOG_2005:
+      return "SYSTEMVERILOG 2005";
+    case SYSTEMVERILOG_2009:
+      return "SYSTEMVERILOG 2009";
+    case SYSTEMVERILOG_2012:
+      return "SYSTEMVERILOG 2012";
+    case SYSTEMVERILOG_2017:
+      return "SYSTEMVERILOG 2017";
+    case C:
+      return "C";
+    case CPP:
+      return "CPP";
+    case VHDL_2019:
+      return "VHDL 2019";
+    case EDIF:
+      return "EDIF";
+  }
+  return {};
+}
+
 }  // namespace FOEDAG

--- a/src/Compiler/CompilerDefines.h
+++ b/src/Compiler/CompilerDefines.h
@@ -52,6 +52,8 @@ enum Language {
 };
 }  // namespace Design
 
+std::string ToString(Design::Language lang);
+
 Design::Language FromFileType(const QString &type, bool postSynth = false);
 
 // ID of the tasks shouln't be changed since they save to file
@@ -142,5 +144,14 @@ int toAction(uint taskId);
  */
 [[nodiscard]] int read_sdc(const QString &file);
 bool target_device(const QString &target);
+
+struct ErrorState {
+  explicit ErrorState(const std::string &msg) : error(true), message(msg) {}
+  ErrorState() = default;
+  explicit operator bool() const { return error; }
+
+  bool error{false};
+  std::string message{};
+};
 
 }  // namespace FOEDAG

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -943,7 +943,7 @@ std::string CompilerOpenFPGA::InitAnalyzeScript() {
           case Design::Language::BLIF:
           case Design::Language::EBLIF:
             lang = "BLIF";
-            ErrorMessage("Unsupported file format:" + lang);
+            SetError("Unsupported file format: " + lang);
             return "";
         }
         if (filesIndex < commandsLibs.size()) {
@@ -1250,14 +1250,14 @@ std::string CompilerOpenFPGA::GhdlDesignParsingCommmands() {
         break;
       case Design::Language::VHDL_2000:
         lang = "vhdl2000";
-        ErrorMessage("Unsupported file format:" + lang);
+        SetError("Unsupported file format: " + lang);
         return "";
       case Design::Language::VHDL_2008:
         lang = "--std=08";
         break;
       case Design::Language::VHDL_2019:
         lang = "vhdl2019";
-        ErrorMessage("Unsupported file format:" + lang);
+        SetError("Unsupported file format: " + lang);
         return "";
       case Design::Language::VERILOG_1995:
         ++filesIndex;
@@ -1285,12 +1285,12 @@ std::string CompilerOpenFPGA::GhdlDesignParsingCommmands() {
         continue;
       case Design::Language::VERILOG_NETLIST:
         lang = "verilog";
-        ErrorMessage("Unsupported file format:" + lang);
+        SetError("Unsupported file format: " + lang);
         return "";
       case Design::Language::BLIF:
       case Design::Language::EBLIF:
         lang = "blif";
-        ErrorMessage("Unsupported file format:" + lang);
+        SetError("Unsupported file format: " + lang);
         return "";
     }
     if (filesIndex < commandsLibs.size()) {
@@ -1424,7 +1424,7 @@ std::string CompilerOpenFPGA::SurelogDesignParsingCommmands() {
       case Design::Language::VHDL_2008:
       case Design::Language::VHDL_2019:
         lang = "vhdl";
-        ErrorMessage("Unsupported file format:" + lang);
+        SetError("Unsupported file format: " + lang);
         return "";
       case Design::Language::VERILOG_1995:
         lang = "";
@@ -1455,7 +1455,7 @@ std::string CompilerOpenFPGA::SurelogDesignParsingCommmands() {
       case Design::Language::BLIF:
       case Design::Language::EBLIF:
         lang = "blif";
-        ErrorMessage("Unsupported file format:" + lang);
+        SetError("Unsupported file format: " + lang);
         return "";
     }
     if (filesIndex < commandsLibs.size()) {
@@ -1836,7 +1836,7 @@ bool CompilerOpenFPGA::Synthesize() {
           case Design::Language::BLIF:
           case Design::Language::EBLIF:
             lang = "BLIF";
-            ErrorMessage("Unsupported file format:" + lang);
+            SetError("Unsupported file format: " + lang);
             return false;
         }
         if (filesIndex < commandsLibs.size()) {

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -434,6 +434,8 @@ std::string Simulator::IncludeDirective(SimulatorType type) {
     case SimulatorType::Icarus:
       return "-I";
     case SimulatorType::GHDL:
+      m_compiler->SetError(StringUtils::format(
+          "Include directive not supported by %", ToString(type)));
       return "Invalid";
     case SimulatorType::Questa:
       return "-I";
@@ -488,6 +490,8 @@ std::string Simulator::LibraryExtDirective(SimulatorType type) {
     case SimulatorType::Icarus:
       return "-Y ";
     case SimulatorType::GHDL:
+      m_compiler->SetError(StringUtils::format(
+          "Library ext directive not supported by %", ToString(type)));
       return "Invalid";
     case SimulatorType::Questa:
       return "+libext+";
@@ -554,6 +558,8 @@ std::string Simulator::MacroDirective(SimulatorType type) {
     case SimulatorType::Icarus:
       return "-D";
     case SimulatorType::GHDL:
+      m_compiler->SetError(StringUtils::format(
+          "Macro directive not supported by %", ToString(type)));
       return "Invalid";
     case SimulatorType::Questa:
       return "-D";
@@ -607,6 +613,8 @@ std::string Simulator::LanguageDirective(SimulatorType type,
         case Design::Language::CPP:
           return "";
         default:
+          m_compiler->SetError(StringUtils::format(
+              "%: Invalid language for verilator", FOEDAG::ToString(lang)));
           return "--invalid-lang-for-verilator";
       }
       break;
@@ -631,28 +639,24 @@ std::string Simulator::LanguageDirective(SimulatorType type,
         case Design::Language::CPP:
           return "";
         default:
+          m_compiler->SetError(StringUtils::format(
+              "%: Invalid language for icarus", FOEDAG::ToString(lang)));
           return "--invalid-lang-for-icarus";
       }
       break;
     case SimulatorType::GHDL:
       switch (lang) {
         case Design::Language::VERILOG_1995:
-          return "--invalid-lang-for-ghdl";
         case Design::Language::VERILOG_2001:
-          return "--invalid-lang-for-ghdl";
         case Design::Language::SYSTEMVERILOG_2005:
-          return "--invalid-lang-for-ghdl";
         case Design::Language::SYSTEMVERILOG_2009:
-          return "--invalid-lang-for-ghdl";
         case Design::Language::SYSTEMVERILOG_2012:
-          return "--invalid-lang-for-ghdl";
         case Design::Language::SYSTEMVERILOG_2017:
-          return "--invalid-lang-for-ghdl";
         case Design::Language::VERILOG_NETLIST:
-          return "--invalid-lang-for-ghdl";
         case Design::Language::C:
-          return "--invalid-lang-for-ghdl";
         case Design::Language::CPP:
+          m_compiler->SetError(StringUtils::format(
+              "%: Invalid language for ghdl", FOEDAG::ToString(lang)));
           return "--invalid-lang-for-ghdl";
         case Design::Language::VHDL_1987:
           if (m_simType == SimulationType::Gate ||
@@ -675,8 +679,9 @@ std::string Simulator::LanguageDirective(SimulatorType type,
         case Design::Language::VHDL_2008:
           return "--std=08";
         case Design::Language::VHDL_2019:
-          return "--invalid-lang-for-ghdl";
         default:
+          m_compiler->SetError(StringUtils::format(
+              "%: Invalid language for ghdl", FOEDAG::ToString(lang)));
           return "--invalid-lang-for-ghdl";
       }
       break;
@@ -703,6 +708,8 @@ std::string Simulator::LanguageDirective(SimulatorType type,
         case Design::Language::CPP:
           return "";
         default:
+          m_compiler->SetError(StringUtils::format(
+              "%: Invalid language for vcs", FOEDAG::ToString(lang)));
           return "--invalid-lang-for-vcs";
       }
       break;

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -614,7 +614,8 @@ std::string Simulator::LanguageDirective(SimulatorType type,
           return "";
         default:
           m_compiler->SetError(StringUtils::format(
-              "%: Invalid language for verilator", FOEDAG::ToString(lang)));
+              "%: Invalid language for %", FOEDAG::ToString(lang),
+              StringUtils::toUpper(ToString(type))));
           return "--invalid-lang-for-verilator";
       }
       break;
@@ -640,7 +641,8 @@ std::string Simulator::LanguageDirective(SimulatorType type,
           return "";
         default:
           m_compiler->SetError(StringUtils::format(
-              "%: Invalid language for icarus", FOEDAG::ToString(lang)));
+              "%: Invalid language for %", FOEDAG::ToString(lang),
+              StringUtils::toUpper(ToString(type))));
           return "--invalid-lang-for-icarus";
       }
       break;
@@ -656,7 +658,8 @@ std::string Simulator::LanguageDirective(SimulatorType type,
         case Design::Language::C:
         case Design::Language::CPP:
           m_compiler->SetError(StringUtils::format(
-              "%: Invalid language for ghdl", FOEDAG::ToString(lang)));
+              "%: Invalid language for %", FOEDAG::ToString(lang),
+              StringUtils::toUpper(ToString(type))));
           return "--invalid-lang-for-ghdl";
         case Design::Language::VHDL_1987:
           if (m_simType == SimulationType::Gate ||
@@ -681,7 +684,8 @@ std::string Simulator::LanguageDirective(SimulatorType type,
         case Design::Language::VHDL_2019:
         default:
           m_compiler->SetError(StringUtils::format(
-              "%: Invalid language for ghdl", FOEDAG::ToString(lang)));
+              "%: Invalid language for %", FOEDAG::ToString(lang),
+              StringUtils::toUpper(ToString(type))));
           return "--invalid-lang-for-ghdl";
       }
       break;
@@ -709,7 +713,8 @@ std::string Simulator::LanguageDirective(SimulatorType type,
           return "";
         default:
           m_compiler->SetError(StringUtils::format(
-              "%: Invalid language for vcs", FOEDAG::ToString(lang)));
+              "%: Invalid language for %", FOEDAG::ToString(lang),
+              StringUtils::toUpper(ToString(type))));
           return "--invalid-lang-for-vcs";
       }
       break;


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: EDA-2024, EDA-2007
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Initially, we looked at using try catch to capture the exceptions raised, https://github.com/os-fpga/FOEDAG/tree/handle-errors
> Upon discussion with wider team, we decided to add a new error state for the compiler which stores that last known error (user friendly)
> #### What does this pull request change?
> Adds error state to compiler which stores both the error number and corresponding error message.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: Compiler
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continuous Integration (CI) scripts

> ### Impact of the pull request

> - [X] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
