### PR TITLE
Programmer fpga_config, flash and OTP tcl return

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 262)
+set(VERSION_PATCH 263)
 
 
 option(

--- a/src/Configuration/CFGCommon/CFGCommon.h
+++ b/src/Configuration/CFGCommon/CFGCommon.h
@@ -46,7 +46,7 @@ struct CFGCommon_ARG {
   std::filesystem::path searchPath;  // for any search path
   bool clean;
   std::string tclOutput;
-  int tclStatus = 0; // TCL_OK or TCL_ERROR
+  int tclStatus = 0;  // TCL_OK or TCL_ERROR
   std::shared_ptr<CFGArg> arg;
 };
 

--- a/src/Configuration/CFGCommon/CFGCommon.h
+++ b/src/Configuration/CFGCommon/CFGCommon.h
@@ -46,6 +46,7 @@ struct CFGCommon_ARG {
   std::filesystem::path searchPath;  // for any search path
   bool clean;
   std::string tclOutput;
+  int tclStatus = 0; // TCL_OK or TCL_ERROR
   std::shared_ptr<CFGArg> arg;
 };
 

--- a/src/Configuration/CFGCompiler/CFGCompiler.cpp
+++ b/src/Configuration/CFGCompiler/CFGCompiler.cpp
@@ -74,7 +74,9 @@ bool CFGCompiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
               cfgcompiler->m_cmdarg.tclOutput);
           cfgcompiler->m_cmdarg.tclOutput.clear();
         }
-        return result && cfgcompiler->m_cmdarg.tclStatus == TCL_OK;
+        if ((result != TCL_OK) || (cfgcompiler->m_cmdarg.tclStatus != TCL_OK))
+          return TCL_ERROR;
+        return TCL_OK;
       } else {
         return TCL_ERROR;
       }
@@ -91,7 +93,9 @@ bool CFGCompiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
               cfgcompiler->m_cmdarg.tclOutput);
           cfgcompiler->m_cmdarg.tclOutput.clear();
         }
-        return result && cfgcompiler->m_cmdarg.tclStatus == TCL_OK;
+        if ((result != TCL_OK) || (cfgcompiler->m_cmdarg.tclStatus != TCL_OK))
+          return TCL_ERROR;
+        return TCL_OK;
       } else {
         return TCL_ERROR;
       }

--- a/src/Configuration/CFGCompiler/CFGCompiler.cpp
+++ b/src/Configuration/CFGCompiler/CFGCompiler.cpp
@@ -49,6 +49,7 @@ static bool programmer_flow(CFGCompiler* cfgcompiler, int argc,
   cfgcompiler->m_cmdarg.arg = arg;
   cfgcompiler->m_cmdarg.toolPath = compiler->GetProgrammerToolExecPath();
   cfgcompiler->m_cmdarg.searchPath = compiler->GetConfigFileSearchDirectory();
+  cfgcompiler->m_cmdarg.tclStatus = TCL_OK;
   return status;
 }
 
@@ -73,7 +74,7 @@ bool CFGCompiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
               cfgcompiler->m_cmdarg.tclOutput);
           cfgcompiler->m_cmdarg.tclOutput.clear();
         }
-        return result;
+        return result && cfgcompiler->m_cmdarg.tclStatus == TCL_OK;
       } else {
         return TCL_ERROR;
       }
@@ -90,7 +91,7 @@ bool CFGCompiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
               cfgcompiler->m_cmdarg.tclOutput);
           cfgcompiler->m_cmdarg.tclOutput.clear();
         }
-        return result;
+        return result && cfgcompiler->m_cmdarg.tclStatus == TCL_OK;
       } else {
         return TCL_ERROR;
       }

--- a/src/Configuration/Programmer/Programmer.cpp
+++ b/src/Configuration/Programmer/Programmer.cpp
@@ -323,7 +323,10 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
         Gui::GuiInterface()->Status(cable, device, status);
       if (status != ProgrammerErrorCode::NoError) {
         CFG_POST_ERR("Failed to program FPGA. Error code: %d", status);
+        cmdarg->tclOutput = "0";
         return;
+      } else {
+        cmdarg->tclOutput = "1";
       }
     } else if (subCmd == "otp") {
       auto otp_arg =
@@ -374,7 +377,10 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
         Gui::GuiInterface()->Status(cable, device, status);
       if (status != ProgrammerErrorCode::NoError) {
         CFG_POST_ERR("Failed to program device OTP. Error code: %d", status);
+        cmdarg->tclOutput = "0";
         return;
+      } else {
+        cmdarg->tclOutput = "1";
       }
     } else if (subCmd == "flash") {
       auto flash_arg =
@@ -419,7 +425,10 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
         Gui::GuiInterface()->Status(cable, device, status);
       if (status != ProgrammerErrorCode::NoError) {
         CFG_POST_ERR("Failed Flash programming. Error code: %d", status);
+        cmdarg->tclOutput = "0";
         return;
+      } else {
+        cmdarg->tclOutput = "1";
       }
     }
   }

--- a/src/Configuration/Programmer/Programmer.cpp
+++ b/src/Configuration/Programmer/Programmer.cpp
@@ -323,10 +323,7 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
         Gui::GuiInterface()->Status(cable, device, status);
       if (status != ProgrammerErrorCode::NoError) {
         CFG_POST_ERR("Failed to program FPGA. Error code: %d", status);
-        cmdarg->tclOutput = "0";
         return;
-      } else {
-        cmdarg->tclOutput = "1";
       }
     } else if (subCmd == "otp") {
       auto otp_arg =
@@ -377,10 +374,7 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
         Gui::GuiInterface()->Status(cable, device, status);
       if (status != ProgrammerErrorCode::NoError) {
         CFG_POST_ERR("Failed to program device OTP. Error code: %d", status);
-        cmdarg->tclOutput = "0";
         return;
-      } else {
-        cmdarg->tclOutput = "1";
       }
     } else if (subCmd == "flash") {
       auto flash_arg =
@@ -425,10 +419,7 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
         Gui::GuiInterface()->Status(cable, device, status);
       if (status != ProgrammerErrorCode::NoError) {
         CFG_POST_ERR("Failed Flash programming. Error code: %d", status);
-        cmdarg->tclOutput = "0";
         return;
-      } else {
-        cmdarg->tclOutput = "1";
       }
     }
   }

--- a/src/Configuration/Programmer/Programmer.cpp
+++ b/src/Configuration/Programmer/Programmer.cpp
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ProgrammerGuiInterface.h"
 #include "Programmer_helper.h"
 #include "libusb.h"
-
+#include "tcl.h"
 namespace FOEDAG {
 
 // openOCDPath used by library
@@ -294,12 +294,14 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
       auto cableIterator = cableMap.find(cableInput);
       if (cableIterator == cableMap.end()) {
         CFG_POST_ERR("Cable not found: %s", cableInput.c_str());
+        cmdarg->tclStatus = TCL_ERROR;
         return;
       }
       Cable cable = cableIterator->second;
       Device device;
       if (!findDeviceFromDb(cableDeviceDb, cable, deviceIndex, device)) {
         CFG_POST_ERR("Device not found: %d", deviceIndex);
+        cmdarg->tclStatus = TCL_ERROR;
         return;
       }
       std::atomic<bool> stop = false;
@@ -323,6 +325,7 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
         Gui::GuiInterface()->Status(cable, device, status);
       if (status != ProgrammerErrorCode::NoError) {
         CFG_POST_ERR("Failed to program FPGA. Error code: %d", status);
+        cmdarg->tclStatus = TCL_ERROR;
         return;
       }
     } else if (subCmd == "otp") {
@@ -345,12 +348,14 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
       auto cableIterator = cableMap.find(cableInput);
       if (cableIterator == cableMap.end()) {
         CFG_POST_ERR("Cable not found: %s", cableInput.c_str());
+        cmdarg->tclStatus = TCL_ERROR;
         return;
       }
       Cable cable = cableIterator->second;
       Device device;
       if (!findDeviceFromDb(cableDeviceDb, cable, deviceIndex, device)) {
         CFG_POST_ERR("Device not found: %d", deviceIndex);
+        cmdarg->tclStatus = TCL_ERROR;
         return;
       }
       ProgressCallback progress = nullptr;
@@ -374,6 +379,7 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
         Gui::GuiInterface()->Status(cable, device, status);
       if (status != ProgrammerErrorCode::NoError) {
         CFG_POST_ERR("Failed to program device OTP. Error code: %d", status);
+        cmdarg->tclStatus = TCL_ERROR;
         return;
       }
     } else if (subCmd == "flash") {
@@ -389,12 +395,14 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
       auto cableIterator = cableMap.find(cableInput);
       if (cableIterator == cableMap.end()) {
         CFG_POST_ERR("Cable not found: %s", cableInput.c_str());
+        cmdarg->tclStatus = TCL_ERROR;
         return;
       }
       Cable cable = cableIterator->second;
       Device device;
       if (!findDeviceFromDb(cableDeviceDb, cable, deviceIndex, device)) {
         CFG_POST_ERR("Device not found: %d", deviceIndex);
+        cmdarg->tclStatus = TCL_ERROR;
         return;
       }
       ProgressCallback progress = nullptr;
@@ -419,6 +427,7 @@ void programmer_entry(CFGCommon_ARG* cmdarg) {
         Gui::GuiInterface()->Status(cable, device, status);
       if (status != ProgrammerErrorCode::NoError) {
         CFG_POST_ERR("Failed Flash programming. Error code: %d", status);
+        cmdarg->tclStatus = TCL_ERROR;
         return;
       }
     }


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

Added tcl status returned to programmer fpga_config, flash and otp command execution. It returns TCL_ERROR whenever the programming failed.

Whenever TCL_ERROR return from fpga_config, flash or otp command, the Programmer GUI will stop the subsequent programming task
![image](https://github.com/os-fpga/FOEDAG/assets/115125680/eb3025ef-9d37-45e7-b245-5b969ffa89dd)


> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, FOEDAG has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Library: Programmer
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
