### PR TITLE
[EDA-2121] Fixed IP window layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 262)
+set(VERSION_PATCH 263)
 
 
 option(

--- a/src/IpConfigurator/IPDialogBox.cpp
+++ b/src/IpConfigurator/IPDialogBox.cpp
@@ -139,7 +139,7 @@ IPDialogBox::IPDialogBox(QWidget* parent, const QString& requestedIpName,
   ui->paramsBox->setLayout(new QHBoxLayout);
 
   // Fill and add Parameters box
-  CreateParamFields(true);
+  CreateParamFields(false);
 
   if (!requestedIpName.isEmpty()) handleEditorChanged({}, nullptr);
   LoadImage();
@@ -188,7 +188,7 @@ void IPDialogBox::RestoreToDefaults() {
       "Restore to default all parameters. Do you want to continue?");
   if (answer == QMessageBox::Yes) {
     const QSignalBlocker blocker{WidgetFactoryDependencyNotifier::Instance()};
-    CreateParamFields(false);
+    CreateParamFields(true);
   }
 }
 
@@ -347,10 +347,10 @@ void IPDialogBox::genarateNewPanel(const std::string& newJson,
     qWarning() << "Failed to parse new json";
     return;
   }
-  CreateParamFields(false);
+  CreateParamFields(true);
 }
 
-void IPDialogBox::CreateParamFields(bool generateMetaLabel) {
+void IPDialogBox::CreateParamFields(bool generateParameres) {
   QStringList tclArgList;
   json parentJson;
   // Loop through IPDefinitions stored in IPCatalog
@@ -433,21 +433,23 @@ void IPDialogBox::CreateParamFields(bool generateMetaLabel) {
     tclArgList = m_instanceValueArgs;
   }
 
-  ui->paramsBox->layout()->removeWidget(m_paramsBox);
-  m_paramsBox->deleteLater();
-  m_paramsBox = new QWidget{this};
+  if (generateParameres) {
+    ui->paramsBox->layout()->removeWidget(m_paramsBox);
+    m_paramsBox->deleteLater();
+    m_paramsBox = new QWidget{this};
 
-  if (parentJson.empty()) {
-    // Add a note if no parameters were available
-    QVBoxLayout* layout = new QVBoxLayout();
-    layout->addWidget(new QLabel("<em>This IP has no parameters</em>"));
-    m_paramsBox->setLayout(layout);
-  } else {
-    // Create and add the child widget to our parent container
-    auto form = createWidgetFormLayout(parentJson, tclArgList);
-    m_paramsBox->setLayout(form);
+    if (parentJson.empty()) {
+      // Add a note if no parameters were available
+      QVBoxLayout* layout = new QVBoxLayout();
+      layout->addWidget(new QLabel("<em>This IP has no parameters</em>"));
+      m_paramsBox->setLayout(layout);
+    } else {
+      // Create and add the child widget to our parent container
+      auto form = createWidgetFormLayout(parentJson, tclArgList);
+      m_paramsBox->setLayout(form);
+    }
+    ui->paramsBox->layout()->addWidget(m_paramsBox);
   }
-  ui->paramsBox->layout()->addWidget(m_paramsBox);
 
   connect(WidgetFactoryDependencyNotifier::Instance(),
           &WidgetFactoryDependencyNotifier::editorChanged, this,

--- a/src/IpConfigurator/IPDialogBox.h
+++ b/src/IpConfigurator/IPDialogBox.h
@@ -59,7 +59,7 @@ class IPDialogBox : public QDialog {
   void restoreProperties(const QMap<QVariant, QVariant>& properties);
   void genarateNewPanel(const std::string& newJson,
                         const std::string& filePath);
-  void CreateParamFields(bool generateMetaLabel);
+  void CreateParamFields(bool generateParameres);
   std::pair<std::string, std::string> generateNewJson(bool& ok);
   void Generate(bool addToProject, const QString& outputPath = {});
   void AddIpToProject(const QString& cmd);

--- a/src/IpConfigurator/IPDialogBox.ui
+++ b/src/IpConfigurator/IPDialogBox.ui
@@ -32,6 +32,9 @@
       <iconset resource="ip_resources.qrc">
        <normaloff>:/images/undo.png</normaloff>:/images/undo.png</iconset>
      </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
     </widget>
    </item>
    <item row="1" column="0" colspan="7">
@@ -50,6 +53,9 @@
           <iconset resource="ip_resources.qrc">
            <normaloff>:/images/page.png</normaloff>:/images/page.png</iconset>
          </property>
+         <property name="autoDefault">
+          <bool>false</bool>
+         </property>
         </widget>
        </item>
        <item>
@@ -60,6 +66,9 @@
          <property name="icon">
           <iconset resource="ip_resources.qrc">
            <normaloff>:/images/folder.png</normaloff>:/images/folder.png</iconset>
+         </property>
+         <property name="autoDefault">
+          <bool>false</bool>
          </property>
         </widget>
        </item>
@@ -185,12 +194,18 @@
        <property name="text">
         <string>Generate IP</string>
        </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="cancel">
        <property name="text">
         <string>Cancel</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: EDA-2121
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed layout for IPs:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/bd17f2fe-96d5-42ea-ab3b-d9b0a1160f84)

Fixed default button, when user press Enter. Now, no action for Enter.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: ipconfigurator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
