### PR TITLE
Added VHDL 2019 and EDIF languages in the drop box menu of Project settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 264)
+set(VERSION_PATCH 265)
 
 
 option(

--- a/src/NewProject/source_grid.cpp
+++ b/src/NewProject/source_grid.cpp
@@ -457,6 +457,7 @@ QComboBox *sourceGrid::CreateLanguageCombo(int projectType, GridType gType) {
     combo->addItem("VHDL 1993", Design::Language::VHDL_1993);
     combo->addItem("VHDL 2000", Design::Language::VHDL_2000);
     combo->addItem("VHDL 2008", Design::Language::VHDL_2008);
+    combo->addItem("VHDL 2019", Design::Language::VHDL_2019);
     combo->addItem("VERILOG 1995", Design::Language::VERILOG_1995);
     combo->addItem("VERILOG 2001", Design::Language::VERILOG_2001);
     combo->addItem("SV 2005", Design::Language::SYSTEMVERILOG_2005);
@@ -469,15 +470,18 @@ QComboBox *sourceGrid::CreateLanguageCombo(int projectType, GridType gType) {
     case PostSynth:
       combo->addItem("BLIF", Design::Language::BLIF);
       combo->addItem("EBLIF", Design::Language::EBLIF);
+      combo->addItem("EDIF", Design::Language::EDIF);
       combo->addItem("VERILOG NETLIST", Design::Language::VERILOG_NETLIST);
       break;
     default:
       combo->addItem("BLIF", Design::Language::BLIF);
       combo->addItem("EBLIF", Design::Language::EBLIF);
+      combo->addItem("EDIF", Design::Language::EDIF);
       combo->addItem("VHDL 1987", Design::Language::VHDL_1987);
       combo->addItem("VHDL 1993", Design::Language::VHDL_1993);
       combo->addItem("VHDL 2000", Design::Language::VHDL_2000);
       combo->addItem("VHDL 2008", Design::Language::VHDL_2008);
+      combo->addItem("VHDL 2019", Design::Language::VHDL_2019);
       combo->addItem("VERILOG 1995", Design::Language::VERILOG_1995);
       combo->addItem("VERILOG 2001", Design::Language::VERILOG_2001);
       combo->addItem("VERILOG NETLIST", Design::Language::VERILOG_NETLIST);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Added missing VHDL 2019 and EDIF languages for the drop down selection.

![image](https://github.com/os-fpga/FOEDAG/assets/95262932/35f66c65-c4dc-42d8-b494-1b0e23d21ee6)

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: newproject
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
