### PR TITLE
Remove Target marker for constraint file since foedag deosn't support multiple constraint files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 265)
+set(VERSION_PATCH 266)
 
 
 option(

--- a/src/ProjNavigator/sources_form.cpp
+++ b/src/ProjNavigator/sources_form.cpp
@@ -616,17 +616,12 @@ void SourcesForm::CreateFolderHierachyTree() {
   QTreeWidgetItem *parentItem{topitemCS};
   for (auto &str : listConstrFset) {
     QStringList listConstrFile = m_projManager->getConstrFiles(str);
-    QString strTarget = m_projManager->getConstrTargetFile(str);
     for (auto &strfile : listConstrFile) {
       if (parentItem) {
         QString filename =
             strfile.right(strfile.size() - (strfile.lastIndexOf("/") + 1));
         QTreeWidgetItem *itemf = new QTreeWidgetItem(parentItem);
-        if (filename == strTarget) {
-          itemf->setText(0, filename + SRC_TREE_FLG_TARGET);
-        } else {
-          itemf->setText(0, filename);
-        }
+        itemf->setText(0, filename);
         itemf->setData(0, Qt::UserRole, strfile);
         itemf->setIcon(0, QIcon(":/img/file.png"));
         itemf->setData(0, Qt::WhatsThisPropertyRole, SRC_TREE_CONSTR_FILE_ITEM);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
`Target` marker has been removed from constraint file in the gui. FOEDAG does not support multiple constraints so it doesn't make any sense and can confuse uses.

![image](https://github.com/os-fpga/FOEDAG/assets/95262932/f8d4338e-9360-494e-9482-bff21a2f7d1f)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: projnavigator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
