### PR TITLE
Enhance cfg assert msg printing format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 268)
+set(VERSION_PATCH 269)
 
 
 option(

--- a/src/Configuration/CFGCommon/CFGCommon.cpp
+++ b/src/Configuration/CFGCommon/CFGCommon.cpp
@@ -15,6 +15,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "CFGCommon.h"
 
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <unistd.h>
+#endif
+
 #include <algorithm>
 #include <cstdarg>
 #include <cstdlib>
@@ -72,17 +78,21 @@ void CFG_assertion(const char* file, const char* func, size_t line,
                                     filepath.c_str(), func, (uint32_t)(line))
                         : CFG_print("Assertion at %s (line: %d)",
                                     filepath.c_str(), (uint32_t)(line));
-  CFG_POST_ERR(err.c_str());
+  CFG_POST_ERR_NO_APPEND(err.c_str());
+#if 0
   if (m_err_function != nullptr) {
     printf("*************************************************\n");
     printf("* %s\n", err.c_str());
   }
+#endif
   err = CFG_print("  MSG: %s", msg.c_str());
-  CFG_POST_ERR(err.c_str());
+  CFG_POST_ERR_NO_APPEND(err.c_str());
+#if 0
   if (m_err_function != nullptr) {
     printf("* %s\n", err.c_str());
     printf("*************************************************\n");
   }
+#endif
   throw CFG_Exception(msg);
 }
 
@@ -515,4 +525,12 @@ std::filesystem::path CFG_find_file(const std::filesystem::path& filePath,
       return "";
     }
   }
+}
+
+void CFG_sleep_ms(uint32_t milisecond) {
+#ifdef _WIN32
+  Sleep(milisecond);
+#else
+  usleep(milisecond * 1000);
+#endif
 }

--- a/src/Configuration/CFGCommon/CFGCommon.h
+++ b/src/Configuration/CFGCommon/CFGCommon.h
@@ -169,7 +169,7 @@ int CFG_execute_cmd_with_callback(
 std::filesystem::path CFG_find_file(const std::filesystem::path& filePath,
                                     const std::filesystem::path& defaultDir);
 
-void CFG_sleep_ms(uint32_t milisecond); 
+void CFG_sleep_ms(uint32_t milisecond);
 
 #define CFG_POST_MSG(...) \
   { CFG_post_msg(CFG_print(__VA_ARGS__)); }

--- a/src/Configuration/CFGCommon/CFGCommon.h
+++ b/src/Configuration/CFGCommon/CFGCommon.h
@@ -169,6 +169,8 @@ int CFG_execute_cmd_with_callback(
 std::filesystem::path CFG_find_file(const std::filesystem::path& filePath,
                                     const std::filesystem::path& defaultDir);
 
+void CFG_sleep_ms(uint32_t milisecond);
+
 #define CFG_POST_MSG(...) \
   { CFG_post_msg(CFG_print(__VA_ARGS__)); }
 

--- a/src/Configuration/CFGCommon/CFGCommon.h
+++ b/src/Configuration/CFGCommon/CFGCommon.h
@@ -169,7 +169,7 @@ int CFG_execute_cmd_with_callback(
 std::filesystem::path CFG_find_file(const std::filesystem::path& filePath,
                                     const std::filesystem::path& defaultDir);
 
-void CFG_sleep_ms(uint32_t milisecond);
+void CFG_sleep_ms(uint32_t milisecond); 
 
 #define CFG_POST_MSG(...) \
   { CFG_post_msg(CFG_print(__VA_ARGS__)); }


### PR DESCRIPTION
This PR enhance the cfg assert msg printing format and also added a common function CFG_sleep_ms() for Configuration applications.

Below:
![image](https://github.com/os-fpga/FOEDAG/assets/119840333/171ac675-011a-492d-8436-6d108119311c)

After:
![image](https://github.com/os-fpga/FOEDAG/assets/119840333/9fb2cbbc-eefa-4d6a-8d23-b8f7a9863a28)

> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, FOEDAG has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [X] Library: CFGCommon
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
