### PR TITLE
[EDA-2103] Add EBLIF to PnR netlist language setting for synthesis and placement task

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 264)
+set(VERSION_PATCH 265)
 
 
 option(

--- a/etc/help.txt
+++ b/etc/help.txt
@@ -143,7 +143,7 @@ Tcl commands (Available in GUI or Batch console or Batch script):
    packing ?clean?            : Packing, clean removes related files
      clean                    : Deletes files generated from this task
 <openfpga>
-   pnr_netlist_lang <format>  : Chooses post-synthesis netlist format, (blif, edif, verilog, vhdl)
+   pnr_netlist_lang <format>  : Chooses post-synthesis netlist format, (blif, eblif, edif, verilog, vhdl)
    packing_options <option list>: Packing options
      -clb_packing <directive> : Performance optimization flags (auto, dense, timing_driven)
        auto                   : CLB packing automatically determined (default)

--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -202,12 +202,14 @@
                 "widgetType": "dropdown",
                 "options": [
                     "Blif",
+                    "EBlif",
                     "Edif",
                     "Verilog",
                     "VHDL"
                 ],
                 "optionsLookup": [
                     "blif",
+                    "eblif",
                     "edif",
                     "verilog",
                     "vhdl"
@@ -261,12 +263,14 @@
               "widgetType": "dropdown",
               "options": [
                   "Blif",
+                  "EBlif",
                   "Edif",
                   "Verilog",
                   "VHDL"
               ],
               "optionsLookup": [
                   "blif",
+                  "eblif",
                   "edif",
                   "verilog",
                   "vhdl"

--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -432,7 +432,7 @@ class Compiler {
 
   std::map<std::string, std::string> m_environmentVariableMap;
 
-  NetlistType m_netlistType = NetlistType::Blif;
+  NetlistType m_netlistType = NetlistType::Verilog;
 
   std::string m_waveformFile;
   std::string m_chatgptConfigFile{};

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -2412,8 +2412,7 @@ bool CompilerOpenFPGA::Placement() {
                     std::string(ProjManager()->projectName() + "_openfpga.pcf");
     }
 
-    if (GetNetlistType() == NetlistType::Verilog ||
-        GetNetlistType() == NetlistType::Edif || netlistInput == true) {
+    if (GetNetlistType() == NetlistType::Edif || netlistInput == true) {
       pincommand += " --port_info ";
       pincommand += FilePath(Action::Pack, "post_synth_ports.json").string();
     } else {


### PR DESCRIPTION
> ### Motivate of the pull request
> - [X] To address an existing issue. If so, please provide a link to the issue: EDA-2103
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> Added EBLIF as lang for PnR netlist in both synthesis and packing UI task settings
> Help updated.

> #### What does this pull request change?
> Adds new PnR netlist lang, EBLIF
> Default netlist lang will still be verilog unless specified.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [X] Library: Compiler, CompilerOpenFPGA
> - [ ] Plug-in:
> - [ ] Engine
> - [X] Documentation
> - [ ] Regression tests
> - [ ] Continuous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
