### PR TITLE
[RG-486] When --project switch is used, open specified project but do not start compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 274)
+set(VERSION_PATCH 275)
 
 
 option(

--- a/src/MainWindow/Session.cpp
+++ b/src/MainWindow/Session.cpp
@@ -48,7 +48,7 @@ void Session::windowShow() {
       }
       if (hasProjectFile) {
         topLevel->openProject(QString::fromStdString(cmdLine->ProjectFile()),
-                              true, true);
+                              false, false);
       } else if (hasScriptCmd) {
         int returnCode{TCL_OK};
         if (m_compiler) {


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-486
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
We do not run project when `--project` switch is used. 

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
