### PR TITLE
[RG-488] Fixed Simulate IP when module name changed and add module name validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 278)
+set(VERSION_PATCH 279)
 
 
 option(

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -600,7 +600,7 @@ std::pair<bool, std::string> IPGenerator::SimulateIpTcl(
   }
 
   std::string command = "make";
-  StringVector args{"OUT_DIR=" + artifactsPath.string()};
+  StringVector args{"OUT_DIR=" + artifactsPath.string(), "MODULE_NAME=" + name};
   if (auto ret = FileUtils::ExecuteSystemCommand(
           command, args, m_compiler->GetOutStream(), -1, path.string(),
           m_compiler->GetErrStream());

--- a/src/IpConfigurator/IPDialogBox.cpp
+++ b/src/IpConfigurator/IPDialogBox.cpp
@@ -143,6 +143,8 @@ IPDialogBox::IPDialogBox(QWidget* parent, const QString& requestedIpName,
   LoadImage();
 
   setWindowTitle("Configure IP");
+  ui->lineEditModuleName->setValidator(
+      new QRegExpValidator{QRegExp{"^[a-zA-Z0-9_]*$"}});
 }
 
 QString IPDialogBox::ModuleName() const {


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-488
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
* Fixed Simulate IP when module name changed
* Validate module name with regex `^[a-zA-Z0-9_]*$`

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: ipgenerate, ipconfigurator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts