### PR TITLE
Fixed tcl simple parser to calculate commands correct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 282)
+set(VERSION_PATCH 283)
 
 
 option(

--- a/src/Main/TclSimpleParser.cpp
+++ b/src/Main/TclSimpleParser.cpp
@@ -30,20 +30,24 @@ std::pair<bool, std::string> TclSimpleParser::parse(
   QFile file{QString::fromStdString(tclFile)};
   if (!file.open(QFile::ReadOnly))
     return std::make_pair(false, "Fail to open file " + tclFile);
-  const QString content = file.readAll();
-
   int counter{0};
-  if (content.contains("ipgenerate")) counter++;
-  if (content.contains("analyze")) counter++;
-  if (content.contains("synth") || content.contains("synthesize")) counter++;
-  if (content.contains("packing")) counter++;
-  // if (content.contains("globp") || content.contains("global_placement"))
-  //   counter++;
-  if (content.contains("place")) counter++;
-  if (content.contains("route")) counter++;
-  if (content.contains("sta")) counter++;
-  if (content.contains("power")) counter++;
-  if (content.contains("bitstream")) counter++;
+  while (!file.atEnd()) {
+    QByteArray line = file.readLine();
+    line = line.simplified();
+    if (line.startsWith('#')) continue;
+    if (line.contains("ipgenerate")) counter++;
+    if (line.contains("analyze")) counter++;
+    if (line.contains("synth") || line.contains("synthesize")) counter++;
+    if (line.contains("packing")) counter++;
+    // if (content.contains("globp") || content.contains("global_placement"))
+    //   counter++;
+    if (line.contains("place")) counter++;
+    if (line.contains("route")) counter++;
+    if (line.contains("sta")) counter++;
+    if (line.contains("power")) counter++;
+    if (line.contains("bitstream")) counter++;
+    if (line.contains("simulate")) counter++;
+  }
 
   return std::make_pair(true, std::to_string(counter));
 }


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed command count for tcl script. 
This count reflect here: 
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/d96644d3-a07f-44d6-8121-d6386f101241)

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
