### PR TITLE
[EDA-2021] Fix MSVC build for Programmer tool 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,6 +464,20 @@ install (
   FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${ZLIB_STATIC_LIB}
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/foedag/lib)
 
+if(MSVC)
+  set(VCPKG_LIBUSB_DIR "$ENV{VCPKG_INSTALLATION_ROOT}/packages/libusb_x64-windows")
+  file(TO_CMAKE_PATH "${VCPKG_LIBUSB_DIR}" VCPKG_LIBUSB_DIR)
+  set(libusb_dll "${VCPKG_LIBUSB_DIR}/bin/libusb-1.0.dll")
+  add_custom_target(copy_libusb_dll_to_bin
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${libusb_dll} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    DEPENDS ${libusb_dll}
+  )
+  add_dependencies(foedag-bin copy_libusb_dll_to_bin)
+
+  install(
+    FILES ${libusb_dll} 
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 if (WIN32 AND $<CONFIG:Debug>)
   if (FOEDAG_WITH_PYTHON)

--- a/src/Configuration/Programmer/CMakeLists.txt
+++ b/src/Configuration/Programmer/CMakeLists.txt
@@ -104,3 +104,23 @@ foreach(file ${SRC_H_INSTALL_LIST})
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/foedag/Programmer
   )
 endforeach()
+
+
+# Message(STATUS "## hello 1 ## CMAKE_RUNTIME_OUTPUT_DIRECTORY" : "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+# Message(STATUS "## hello 2 ## CMAKE_INSTALL_BINDIR" : "${CMAKE_INSTALL_BINDIR}")
+# Message(STATUS "## hello 3 ## CMAKE_INSTALL_INCLUDEDIR" : "${CMAKE_INSTALL_INCLUDEDIR}")
+
+# if(1)
+#   set(VCPKG_LIBUSB_DIR "$ENV{VCPKG_INSTALLATION_ROOT}/packages/libusb_x64-windows")
+#   file(TO_CMAKE_PATH "${VCPKG_LIBUSB_DIR}" VCPKG_LIBUSB_DIR)
+#   set(libusb_dll "${VCPKG_LIBUSB_DIR}/bin/libusb-1.0.dll")
+#   add_custom_target(copy_libusb_dll_to_bin
+#     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${libusb_dll} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+#     DEPENDS ${libusb_dll}
+#   )
+#   add_dependencies(${foedag_bin} copy_libusb_dll_to_bin)
+
+#   install(
+#     FILES ${libusb_dll} 
+#     DESTINATION ${CMAKE_INSTALL_BINDIR})
+# endif()

--- a/src/Configuration/Programmer/CMakeLists.txt
+++ b/src/Configuration/Programmer/CMakeLists.txt
@@ -104,23 +104,3 @@ foreach(file ${SRC_H_INSTALL_LIST})
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/foedag/Programmer
   )
 endforeach()
-
-
-# Message(STATUS "## hello 1 ## CMAKE_RUNTIME_OUTPUT_DIRECTORY" : "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
-# Message(STATUS "## hello 2 ## CMAKE_INSTALL_BINDIR" : "${CMAKE_INSTALL_BINDIR}")
-# Message(STATUS "## hello 3 ## CMAKE_INSTALL_INCLUDEDIR" : "${CMAKE_INSTALL_INCLUDEDIR}")
-
-# if(1)
-#   set(VCPKG_LIBUSB_DIR "$ENV{VCPKG_INSTALLATION_ROOT}/packages/libusb_x64-windows")
-#   file(TO_CMAKE_PATH "${VCPKG_LIBUSB_DIR}" VCPKG_LIBUSB_DIR)
-#   set(libusb_dll "${VCPKG_LIBUSB_DIR}/bin/libusb-1.0.dll")
-#   add_custom_target(copy_libusb_dll_to_bin
-#     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${libusb_dll} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-#     DEPENDS ${libusb_dll}
-#   )
-#   add_dependencies(${foedag_bin} copy_libusb_dll_to_bin)
-
-#   install(
-#     FILES ${libusb_dll} 
-#     DESTINATION ${CMAKE_INSTALL_BINDIR})
-# endif()

--- a/src/Configuration/Programmer/Programmer.cpp
+++ b/src/Configuration/Programmer/Programmer.cpp
@@ -475,9 +475,6 @@ std::string GetErrorMessage(int errorCode) {
 }
 
 int GetAvailableCables(std::vector<Cable>& cables) {
-#ifdef _MSC_VER
-  return ProgrammerErrorCode::UnsupportedFunc;
-#else
   struct libusb_context* jtagLibusbContext = nullptr; /**< Libusb context **/
   struct libusb_device** deviceList = nullptr; /**< The usb device list **/
   struct libusb_device_handle* libusbHandle = nullptr;
@@ -550,7 +547,6 @@ int GetAvailableCables(std::vector<Cable>& cables) {
   if (jtagLibusbContext != nullptr) libusb_exit(jtagLibusbContext);
 
   return ProgrammerErrorCode::NoError;
-#endif  // _MSC_VER
 }
 
 int ListDevices(const Cable& cable, std::vector<Device>& devices) {

--- a/tests/TestInstall/CMakeLists.txt
+++ b/tests/TestInstall/CMakeLists.txt
@@ -232,3 +232,10 @@ add_custom_target(RunInstallTest ALL
     DEPENDS test_hellofoedag
     COMMAND $<TARGET_FILE:test_hellofoedag> --batch --cmd \"puts Hello!\"
     WORKING_DIRECTORY $<TARGET_FILE_DIR:test_hellofoedag>)
+
+if(MSVC)
+  set(VCPKG_LIBUSB_DIR "$ENV{VCPKG_INSTALLATION_ROOT}/packages/libusb_x64-windows")
+  file(TO_CMAKE_PATH "${VCPKG_LIBUSB_DIR}" VCPKG_LIBUSB_DIR)
+  set(libusb_dll "${VCPKG_LIBUSB_DIR}/bin/libusb-1.0.dll")
+  file(COPY ${libusb_dll} DESTINATION  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+endif()

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -21,6 +21,15 @@ if(MSVC)
   target_compile_options(gtest PRIVATE /Zc:__cplusplus)
   target_compile_options(gtest_main PRIVATE /Zc:__cplusplus)
   add_compile_options(/bigobj)
+
+  set(VCPKG_LIBUSB_DIR "$ENV{VCPKG_INSTALLATION_ROOT}/packages/libusb_x64-windows")
+  file(TO_CMAKE_PATH "${VCPKG_LIBUSB_DIR}" VCPKG_LIBUSB_DIR)
+  set(libusb_dll "${VCPKG_LIBUSB_DIR}/bin/libusb-1.0.dll")
+  add_custom_target(copy_libusb_dll_to_bin
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${libusb_dll} ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${libusb_dll}
+  )
+  add_dependencies(foedag-bin copy_libusb_dll_to_bin)
 endif()
 
 if(MINGW)

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -21,15 +21,6 @@ if(MSVC)
   target_compile_options(gtest PRIVATE /Zc:__cplusplus)
   target_compile_options(gtest_main PRIVATE /Zc:__cplusplus)
   add_compile_options(/bigobj)
-
-  set(VCPKG_LIBUSB_DIR "$ENV{VCPKG_INSTALLATION_ROOT}/packages/libusb_x64-windows")
-  file(TO_CMAKE_PATH "${VCPKG_LIBUSB_DIR}" VCPKG_LIBUSB_DIR)
-  set(libusb_dll "${VCPKG_LIBUSB_DIR}/bin/libusb-1.0.dll")
-  add_custom_target(copy_libusb_dll_to_bin
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${libusb_dll} ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${libusb_dll}
-  )
-  add_dependencies(foedag-bin copy_libusb_dll_to_bin)
 endif()
 
 if(MINGW)
@@ -103,3 +94,10 @@ target_link_libraries(unittest PRIVATE
   programmer-gui)
 
 add_test(NAME unittest COMMAND unittest)
+
+if(MSVC)
+  set(VCPKG_LIBUSB_DIR "$ENV{VCPKG_INSTALLATION_ROOT}/packages/libusb_x64-windows")
+  file(TO_CMAKE_PATH "${VCPKG_LIBUSB_DIR}" VCPKG_LIBUSB_DIR)
+  set(libusb_dll "${VCPKG_LIBUSB_DIR}/bin/libusb-1.0.dll")
+  file(COPY ${libusb_dll} DESTINATION  ${CMAKE_CURRENT_BINARY_DIR})
+endif()


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: EDA-2021
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)

The programmer tool depends on libusb library dynamically. The solution is to copy the libusb.dll to be side by side with the binary

> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, FOEDAG has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
