### PR TITLE
Update Pin Location Assign Method, replace `free` with `pin_constraint_disabled`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 285)
+set(VERSION_PATCH 286)
 
 
 option(

--- a/etc/help.txt
+++ b/etc/help.txt
@@ -163,10 +163,10 @@ Tcl commands (Available in GUI or Batch console or Batch script):
 -------------
 --- Place ---
 -------------
-   pin_loc_assign_method <method>: Algortihm for automatic pin assignment (in_define_order, random, free)
+   pin_loc_assign_method <method>: Algortihm for automatic pin assignment (in_define_order, random, pin_constraint_disabled)
        in_define_order        : Port order pin assignment (default)
        random                 : Random pin assignment
-       free                   : No automatic pin assignment
+       pin_constraint_disabled: No automatic pin assignment
    place ?clean?              : Placer
      clean                    : Deletes files generated from this task
    pnr_options <option list>  : PnR Options

--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -307,12 +307,12 @@
                 "options": [
                     "Random",
                     "In Define Order",
-                    "Free"
+                    "Pin Constraint Disabled"
                 ],
                 "optionsLookup": [
                     "random",
                     "in_define_order",
-                    "free"
+                    "pin_constraint_disabled"
                 ],
                 "layout": "horizontal",
                 "arg": "pin_assign_method"

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -1046,13 +1046,16 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       auto setPlaceOption = [compiler](const std::string& arg) {
         if (arg == "random") {
           compiler->PinAssignOpts(Compiler::PinAssignOpt::Random);
-          compiler->Message("Pin Method :" + arg);
+          compiler->Message("Pin Method: " + arg);
         } else if (arg == "in_define_order") {
           compiler->PinAssignOpts(Compiler::PinAssignOpt::In_Define_Order);
-          compiler->Message("Pin Method :" + arg);
+          compiler->Message("Pin Method: " + arg);
         } else if (arg == "free") {
           compiler->PinAssignOpts(Compiler::PinAssignOpt::Free);
-          compiler->Message("Pin Method :" + arg);
+          compiler->Message("Warning: Deprecated Pin Method: " + arg);
+        } else if (arg == "pin_constraint_disabled") {
+          compiler->PinAssignOpts(Compiler::PinAssignOpt::Free);
+          compiler->Message("Pin Method: " + arg);
         } else {
           compiler->ErrorMessage("Unknown Placement Option: " + arg);
         }
@@ -1411,13 +1414,16 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
       auto setPlaceOption = [compiler](const std::string& arg) {
         if (arg == "random") {
           compiler->PinAssignOpts(Compiler::PinAssignOpt::Random);
-          compiler->Message("Pin Method :" + arg);
+          compiler->Message("Pin Method: " + arg);
         } else if (arg == "in_define_order") {
           compiler->PinAssignOpts(Compiler::PinAssignOpt::In_Define_Order);
-          compiler->Message("Pin Method :" + arg);
+          compiler->Message("Pin Method: " + arg);
         } else if (arg == "free") {
           compiler->PinAssignOpts(Compiler::PinAssignOpt::Free);
-          compiler->Message("Pin Method :" + arg);
+          compiler->Message("Warning: Deprecated Pin Method: " + arg);
+        } else if (arg == "pin_constraint_disabled") {
+          compiler->PinAssignOpts(Compiler::PinAssignOpt::Free);
+          compiler->Message("Pin Method: " + arg);
         } else {
           compiler->ErrorMessage("Unknown Placement Option: " + arg);
         }

--- a/src/Main/Tasks.cpp
+++ b/src/Main/Tasks.cpp
@@ -152,7 +152,7 @@ static std::map<FOEDAG::SynthesisOptimization, const char*> synthOptMap = {
 static std::map<FOEDAG::Compiler::PinAssignOpt, const char*> pinOptMap = {
     {FOEDAG::Compiler::PinAssignOpt::Random, "random"},
     {FOEDAG::Compiler::PinAssignOpt::In_Define_Order, "in_define_order"},
-    {FOEDAG::Compiler::PinAssignOpt::Free, "free"}};
+    {FOEDAG::Compiler::PinAssignOpt::Free, "pin_constraint_disabled"}};
 
 // Lookup for PackingOpt values
 static std::map<FOEDAG::Compiler::NetlistType, const char*> netlistOptMap = {

--- a/src/NewProject/add_constraints_form.ui
+++ b/src/NewProject/add_constraints_form.ui
@@ -117,7 +117,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Free</string>
+             <string>Pin Constraint Disabled</string>
             </property>
            </widget>
           </item>

--- a/src/ProjNavigator/add_file_form.ui
+++ b/src/ProjNavigator/add_file_form.ui
@@ -144,7 +144,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Free</string>
+             <string>Pin Constraint Disabled</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: EDA-2250
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Update Pin Location Assign Method:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/77fe8907-924e-48cb-bf88-9f56158c3b25)
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/14e33e8c-499c-47ff-b8f4-2b573c30989e)
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/063b81bf-4ec4-4e58-ba32-17d83d8ef696)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, foedagcore, newproject, projnavigator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts