### PR TITLE
Fixed Generate IP behavior when some error occured

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 288)
+set(VERSION_PATCH 289)
 
 
 option(

--- a/src/IpConfigurator/IPDialogBox.cpp
+++ b/src/IpConfigurator/IPDialogBox.cpp
@@ -174,8 +174,8 @@ void IPDialogBox::RestoreToDefaults() {
 }
 
 void IPDialogBox::GenerateIp() {
-  Generate(true);
-  accept();
+  const bool success = Generate(true);
+  if (success) accept();
 }
 
 void IPDialogBox::handleEditorChanged(const QString& customId,
@@ -568,7 +568,7 @@ std::pair<std::string, std::string> IPDialogBox::generateNewJson(bool& ok) {
   return {newJson, executable.string()};
 }
 
-void IPDialogBox::Generate(bool addToProject, const QString& outputPath) {
+bool IPDialogBox::Generate(bool addToProject, const QString& outputPath) {
   // Find settings fields in the parameter box layout
   QLayout* fieldsLayout = m_paramsBox->layout();
   QList<QObject*> settingsObjs =
@@ -624,6 +624,7 @@ void IPDialogBox::Generate(bool addToProject, const QString& outputPath) {
   // Alert the user if one or more of the field validators is invalid
   if (invalidVals) {
     showInvalidParametersWarning();
+    return false;
   } else {
     // If all enabled fields are valid, configure and generate IP
     std::filesystem::path baseDir(getUserProjectPath());
@@ -648,12 +649,14 @@ void IPDialogBox::Generate(bool addToProject, const QString& outputPath) {
         GlobalSession->TclInterp()->evalCmd(cmd.toStdString(), &returnVal);
     if (returnVal != TCL_OK) {
       qWarning() << "Error: " << QString::fromStdString(resultStr);
+      return false;
     }
 
     if (addToProject) {
       AddIpToProject(cmd);
     }
   }
+  return true;
 }
 
 void IPDialogBox::AddIpToProject(const QString& cmd) {

--- a/src/IpConfigurator/IPDialogBox.h
+++ b/src/IpConfigurator/IPDialogBox.h
@@ -62,7 +62,7 @@ class IPDialogBox : public QDialog {
                         const std::string& filePath);
   void CreateParamFields(bool generateParameres);
   std::pair<std::string, std::string> generateNewJson(bool& ok);
-  void Generate(bool addToProject, const QString& outputPath = {});
+  bool Generate(bool addToProject, const QString& outputPath = {});
   void AddIpToProject(const QString& cmd);
   QString outPath() const;
   void LoadImage();


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed issue with Generate IP button. Now when any error occurred, Configure IP window remains until user cancel it or fix wrong parameter. 

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: ipconfigurator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
