### PR TITLE
Fixed three dot area context menu for Task table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 288)
+set(VERSION_PATCH 289)
 
 
 option(

--- a/src/Compiler/TaskTableView.cpp
+++ b/src/Compiler/TaskTableView.cpp
@@ -336,7 +336,7 @@ void TaskTableView::TasksDelegate::paint(QPainter *painter,
     QPoint globalCursorPos = QCursor::pos();
     QPoint viewportPos = m_view.viewport()->mapFromGlobal(globalCursorPos);
 
-    auto dotRect = opt.rect.adjusted(opt.rect.topRight().x() - 90, 0, 0, 0);
+    auto dotRect = m_view.contextArea(index);
     hovered = (dotRect.contains(viewportPos) && hovered);
     style->drawItemPixmap(
         painter, dotRect, Qt::AlignCenter,


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed context menu issue on CentOS, when user was not able to click on three dots.

![image](https://github.com/os-fpga/FOEDAG/assets/95262932/7c855373-be2c-470e-9ae5-90768af2c0e2)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
