### PR TITLE
[RG-305] Remove copy/paste code from ProjectManager::setSimulationFiles, ProjectManager::setDesignFiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 290)
+set(VERSION_PATCH 291)
 
 
 option(

--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -434,76 +434,35 @@ QString ProjectManager::getDefaulUnitName() const {
   return proFileSet->getDefaultUnitName();
 }
 
-int ProjectManager::setDesignFiles(const QString& fileNames, int lang,
-                                   const QString& grName, bool isFileCopy,
-                                   bool localToProject) {
-  return setDesignFiles({}, {}, fileNames, lang, grName, isFileCopy,
-                        localToProject);
-}
-
 int ProjectManager::setDesignFiles(const QString& commands, const QString& libs,
                                    const QString& fileNames, int lang,
                                    const QString& grName, bool isFileCopy,
                                    bool localToProject) {
   setCurrentFileSet(getDesignActiveFileSet());
   const QStringList fileList = QtUtils::StringSplit(fileNames, ' ');
-  const QStringList commandsList = QtUtils::StringSplit(commands, ' ');
-  const QStringList libsList = QtUtils::StringSplit(libs, ' ');
+  auto res = setFiles(commands, libs, fileList, lang, grName, isFileCopy,
+                      localToProject);
+  if (res != EC_Success) return res;
 
-  ProjectFileSet* proFileSet =
-      Project::Instance()->getProjectFileset(m_currentFileSet);
-  if (nullptr == proFileSet) {
-    return -1;
-  }
-
-  if (localToProject) {
-    const auto path =
-        ProjectFilesPath(Project::Instance()->projectPath(),
-                         Project::Instance()->projectName(), m_currentFileSet);
-    QStringList fullPathFileList;
-    for (const auto& file : fileList) {
-      fullPathFileList.append(QString("%1/%2").arg(path, file));
-    }
-    proFileSet->addFiles(commandsList, libsList, fullPathFileList, lang,
-                         grName);
-  } else {
-    if (isFileCopy) {
-      QStringList localFileList;
-      for (const auto& file : fileList) {
-        const QFileInfo info{file};
-        localFileList.append(
-            ProjectFilesPath(getProjectPath(), getProjectName(),
-                             m_currentFileSet, info.fileName()));
-      }
-      proFileSet->addFiles(commandsList, libsList, localFileList, lang, grName);
-    } else {
-      proFileSet->addFiles(commandsList, libsList, fileList, lang, grName);
-    }
-  }
-
-  int result{0};
+  int result{EC_Success};
   for (const auto& file : fileList) {
     int res = setDesignFile(file, isFileCopy, localToProject);
-    if (res != 0) result = res;
+    if (res != EC_Success) result = res;
   }
   return result;
 }
 
-int ProjectManager::setSimulationFiles(const QString& commands,
-                                       const QString& libs,
-                                       const QString& fileNames, int lang,
-                                       const QString& grName, bool isFileCopy,
-                                       bool localToProject) {
-  // TODO @volodymyrk RG-305
-  setCurrentFileSet(getSimulationActiveFileSet());
-  const QStringList fileList = QtUtils::StringSplit(fileNames, ' ');
+int ProjectManager::setFiles(const QString& commands, const QString& libs,
+                             const QStringList& fileList, int lang,
+                             const QString& grName, bool isFileCopy,
+                             bool localToProject) {
   const QStringList commandsList = QtUtils::StringSplit(commands, ' ');
   const QStringList libsList = QtUtils::StringSplit(libs, ' ');
 
   ProjectFileSet* proFileSet =
       Project::Instance()->getProjectFileset(m_currentFileSet);
   if (nullptr == proFileSet) {
-    return -1;
+    return EC_FileSetNotExist;
   }
 
   if (localToProject) {
@@ -530,6 +489,19 @@ int ProjectManager::setSimulationFiles(const QString& commands,
       proFileSet->addFiles(commandsList, libsList, fileList, lang, grName);
     }
   }
+  return EC_Success;
+}
+
+int ProjectManager::setSimulationFiles(const QString& commands,
+                                       const QString& libs,
+                                       const QString& fileNames, int lang,
+                                       const QString& grName, bool isFileCopy,
+                                       bool localToProject) {
+  setCurrentFileSet(getSimulationActiveFileSet());
+  const QStringList fileList = QtUtils::StringSplit(fileNames, ' ');
+  auto res = setFiles(commands, libs, fileList, lang, grName, isFileCopy,
+                      localToProject);
+  if (res != EC_Success) return res;
 
   int result{0};
   for (const auto& file : fileList) {

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -213,8 +213,6 @@ class ProjectManager : public QObject {
                                bool localToProject = true);
 
   QString getDefaulUnitName() const;
-  int setDesignFiles(const QString &fileNames, int lang, const QString &grName,
-                     bool isFileCopy = true, bool localToProject = true);
   int setDesignFiles(const QString &commands, const QString &libs,
                      const QString &fileNames, int lang, const QString &grName,
                      bool isFileCopy = true, bool localToProject = true);
@@ -434,6 +432,9 @@ class ProjectManager : public QObject {
   int CreateAndAddFile(const QString &suffix, const QString &filename,
                        const QString &filenameAdd, bool copyFile);
   void UpdateProjectInternal(const ProjectOptions &opt, bool setTargetConstr);
+  int setFiles(const QString &commands, const QString &libs,
+               const QStringList &fileList, int lang, const QString &grName,
+               bool isFileCopy = true, bool localToProject = true);
 
  private:
   QString m_currentFileSet;

--- a/src/ProjNavigator/add_file_dialog.cpp
+++ b/src/ProjNavigator/add_file_dialog.cpp
@@ -47,7 +47,7 @@ void AddFileDialog::on_m_btnOK_clicked() {
       if ("<Local to Project>" == fdata.m_filePath) {
         if (GT_SOURCE == iType) {
           // TODO RG-132 @volodymyrk. If group exists we should append to list
-          ret = m_pm->setDesignFiles(fdata.m_fileName, fdata.m_language,
+          ret = m_pm->setDesignFiles({}, {}, fdata.m_fileName, fdata.m_language,
                                      fdata.m_groupName, false, true);
         } else if (GT_CONSTRAINTS == iType) {
           ret = m_pm->setConstrsFile(fdata.m_fileName, false, true);
@@ -57,7 +57,8 @@ void AddFileDialog::on_m_btnOK_clicked() {
       } else {
         if (GT_SOURCE == iType) {
           // TODO RG-132 @volodymyrk. If group exists we should append to list
-          ret = m_pm->setDesignFiles(fdata.m_filePath + "/" + fdata.m_fileName,
+          ret = m_pm->setDesignFiles({}, {},
+                                     fdata.m_filePath + "/" + fdata.m_fileName,
                                      fdata.m_language, fdata.m_groupName,
                                      m_fileForm->IsCopySource(), false);
         } else if (GT_CONSTRAINTS == iType) {

--- a/src/ProjNavigator/tcl_command_integration.cpp
+++ b/src/ProjNavigator/tcl_command_integration.cpp
@@ -26,8 +26,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Compiler/CompilerDefines.h"
 #include "NewProject/ProjectManager/project_manager.h"
-#include "PinAssignment/PortsLoader.h"
-#include "PinAssignment/PortsModel.h"
 #include "ProjNavigator/sources_form.h"
 #include "Utils/QtUtils.h"
 #include "Utils/StringUtils.h"
@@ -115,7 +113,7 @@ bool TclCommandIntegration::TclAddOrCreateDesignFiles(int argc,
   for (int i = 1; i < argc; i++) {
     QFileInfo strFileName = QString{argv[i]};
     ret = m_projManager->setDesignFiles(
-        strFileName.fileName(), FromFileType(strFileName.suffix()),
+        {}, {}, strFileName.fileName(), FromFileType(strFileName.suffix()),
         m_projManager->getDefaulUnitName(), false);
 
     if (0 != ret) {
@@ -141,7 +139,7 @@ bool TclCommandIntegration::TclAddOrCreateDesignFiles(const QString &files,
 
   m_projManager->setCurrentFileSet(strSetName);
   int ret = m_projManager->setDesignFiles(
-      files, lang, m_projManager->getDefaulUnitName(), false);
+      {}, {}, files, lang, m_projManager->getDefaulUnitName(), false);
   if (0 != ret) {
     out << "Failed to add files: " << files.toStdString() << std::endl;
     return false;
@@ -389,7 +387,7 @@ ProjectManager *TclCommandIntegration::GetProjectManager() {
 void TclCommandIntegration::saveSettings() { emit saveSettingsSignal(); }
 
 std::vector<std::string> TclCommandIntegration::GetClockList(
-    const std::filesystem::path &path, bool &vhdl) const {
+    const std::filesystem::path &path, bool &vhdl) {
   QFile jsonFile{QString::fromStdString(path.string())};
   if (jsonFile.exists() &&
       jsonFile.open(QIODevice::ReadOnly | QIODevice::Text)) {

--- a/src/ProjNavigator/tcl_command_integration.h
+++ b/src/ProjNavigator/tcl_command_integration.h
@@ -60,8 +60,8 @@ class TclCommandIntegration : public QObject {
 
   ProjectManager *GetProjectManager();
   void saveSettings();
-  std::vector<std::string> GetClockList(const std::filesystem::path &path,
-                                        bool &vhdl) const;
+  static std::vector<std::string> GetClockList(
+      const std::filesystem::path &path, bool &vhdl);
   void updateHierarchyView();
   void updateReportsView();
 

--- a/tests/unittest/NewProject/ProjectManager_test.cpp
+++ b/tests/unittest/NewProject/ProjectManager_test.cpp
@@ -284,3 +284,15 @@ TEST(ProjectManager, AddFilesLocalToProject) {
   ProjectManager::AddFiles(data, addFilesFunction);
   EXPECT_EQ(counter, 2);
 }
+
+TEST(ProjectManager, setDesignFilesDefault) {
+  ProjectManager pManager{};
+  auto res = pManager.setDesignFiles({}, {}, {}, 0, {}, true, true);
+  EXPECT_EQ(res, ProjectManager::EC_FileSetNotExist);
+}
+
+TEST(ProjectManager, setSimulationFilesDefault) {
+  ProjectManager pManager{};
+  auto res = pManager.setSimulationFiles({}, {}, {}, 0, {}, true, true);
+  EXPECT_EQ(res, ProjectManager::EC_FileSetNotExist);
+}


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-305
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Refactoring code to avoid copy/pase from: 
* ProjectManager::setSimulationFiles
* ProjectManager::setDesignFiles

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: newproject, projnavigator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts
