### PR TITLE
Explicitly use add_dependencies() for dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 291)
+set(VERSION_PATCH 292)
 
 
 option(

--- a/src/Configuration/CMakeLists.txt
+++ b/src/Configuration/CMakeLists.txt
@@ -105,6 +105,7 @@ foreach(SUBSYSTEM ${SUBSYSTEMS})
 	string(TOLOWER ${SUBSYSTEM} SUBSYSTEM)
 	# Level 1
 	if (NOT SUBSYSTEM STREQUAL "cfgcommon")
+		add_dependencies(${SUBSYSTEM} cfgcommon)
 		target_link_libraries(${SUBSYSTEM} INTERFACE cfgcommon)
 		# Level 2
 		if (NOT SUBSYSTEM STREQUAL "cfgcompiler")


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
Explicitly use add_dependencies() to make sure cfgcommon is compiled first within configuration subsystem
target_link_libraries() is used before this, and I have impression that with target_link_libraries, CMAKE should figure the dependency since if you need to link to a library, that library (or target) should have been compiled first. 

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
makefile change

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [x] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts
