### PR TITLE
[EDA-2275] Programmer gui: change progress bar color to reflect current status.

### DIFF
--- a/src/ProgrammerGui/ProgrammerMain.cpp
+++ b/src/ProgrammerGui/ProgrammerMain.cpp
@@ -43,6 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "MainWindow/Session.h"
 #include "ProgrammerGuiIntegration.h"
 #include "ProgrammerSettingsWidget.h"
+#include "Utils/QtUtils.h"
 #include "ui_ProgrammerMain.h"
 
 inline void InitResources() {
@@ -182,6 +183,13 @@ ProgrammerMain::ProgrammerMain(QWidget *parent)
   QActionGroup *group = new QActionGroup{this};
   group->addAction(ui->actionConfigure);
   group->addAction(ui->actionProgram_OTP);
+
+  m_defaultPalette = m_mainProgress.progressBar()->palette();
+  m_failPalette = m_passPalette = m_defaultPalette;
+  m_failPalette.setColor(QPalette::ColorRole::Highlight,
+                         StatusColor(Status::Failed));
+  m_passPalette.setColor(QPalette::ColorRole::Highlight,
+                         StatusColor(Status::Done));
 }
 
 ProgrammerMain::~ProgrammerMain() { delete ui; }
@@ -275,6 +283,7 @@ void ProgrammerMain::updateStatus(const DeviceEntity &entity, int status) {
 }
 
 void ProgrammerMain::startPressed() {
+  m_mainProgress.progressBar()->setPalette(m_defaultPalette);
   ui->toolBar->removeAction(ui->actionStart);
   ui->toolBar->insertAction(m_progressAction, ui->actionStop);
   ui->actionDetect->setEnabled(false);
@@ -289,7 +298,7 @@ void ProgrammerMain::startPressed() {
 
 void ProgrammerMain::stopPressed() {
   ui->actionStop->setEnabled(false);
-  stop = true;
+  m_stop = true;
   m_guiIntegration->StopLastProcess();
   GlobalSession->GetCompiler()->ErrorMessage("Interrupted by user");
 }
@@ -424,7 +433,7 @@ bool ProgrammerMain::IsEnabled(DeviceInfo *deviceInfo) const {
   return item ? item->checkState(TITLE_COL) == Qt::Checked : false;
 }
 
-QColor ProgrammerMain::TextColor(Status status) {
+QColor ProgrammerMain::StatusColor(Status status) {
   switch (status) {
     case None:
       return Qt::black;
@@ -457,6 +466,12 @@ bool ProgrammerMain::InProgressMessageBoxAccepted(QWidget *parent) {
                          "process (Recommended)");
   question.setDefaultButton(QMessageBox::No);
   return question.exec() == QMessageBox::Yes;
+}
+
+QPalette ProgrammerMain::StatusPalette(int status) const {
+  return status == Status::Done
+             ? m_passPalette
+             : status == Status::Failed ? m_failPalette : m_defaultPalette;
 }
 
 void ProgrammerMain::GetDeviceList() {
@@ -613,7 +628,8 @@ bool ProgrammerMain::VerifyDevices() {
 
 void ProgrammerMain::start() {
   m_programmingDone = false;
-  stop = false;
+  m_stop = false;
+  m_status = None;
   QVector<DeviceInfo *> runningDevices;
   for (auto d : qAsConst(m_deviceSettings)) {
     if (IsEnabled(d)) runningDevices.push_back(d);
@@ -622,7 +638,7 @@ void ProgrammerMain::start() {
 
   cleanupStatusAndProgress();
   while (!runningDevices.isEmpty()) {
-    if (stop) break;
+    if (m_stop) break;
     auto dev = runningDevices.first();
     bool result{false};
     if (!dev->isFlash) {  // device
@@ -646,13 +662,19 @@ void ProgrammerMain::start() {
     if (!result) break;
   }
   m_programmingDone = true;
+  QtUtils::AppendToEventQueue([this]() {
+    m_mainProgress.progressBar()->setPalette(StatusPalette(m_status));
+  });
 }
 
 void ProgrammerMain::setStatus(DeviceInfo *deviceInfo, Status status) {
   auto item = m_items.key(deviceInfo);
   if (item) {
+    m_status = status;
     item->setText(STATUS_COL, ToString(status));
-    item->setForeground(STATUS_COL, QBrush{TextColor(status)});
+    item->setForeground(STATUS_COL, QBrush{StatusColor(status)});
+    ui->treeWidget->itemWidget(item, PROGRESS_COL)
+        ->setPalette(StatusPalette(status));
   }
 }
 

--- a/src/ProgrammerGui/ProgrammerMain.h
+++ b/src/ProgrammerGui/ProgrammerMain.h
@@ -99,8 +99,9 @@ class ProgrammerMain : public QMainWindow, public TopLevelInterface {
   static QString ToString(const QStringList &strList, const QString &sep);
   void loadFromSettigns();
   bool IsEnabled(DeviceInfo *deviceInfo) const;
-  static QColor TextColor(Status status);
+  static QColor StatusColor(Status status);
   static bool InProgressMessageBoxAccepted(QWidget *parent);
+  QPalette StatusPalette(int status) const;
 
  private:
   static constexpr int TITLE_COL{0};
@@ -114,7 +115,7 @@ class ProgrammerMain : public QMainWindow, public TopLevelInterface {
   QAction *m_progressAction{nullptr};
   QVector<DeviceInfo *> m_deviceSettings;
   QTreeWidgetItem *m_currentItem{nullptr};
-  std::atomic_bool stop{false};
+  bool m_stop{false};
   SummaryProgressBar m_mainProgress;
   QMap<QTreeWidgetItem *, DeviceInfo *> m_items;
   QSettings m_settings;
@@ -123,6 +124,10 @@ class ProgrammerMain : public QMainWindow, public TopLevelInterface {
   QComboBox *m_hardware;
   QComboBox *m_iface;
   sequential_map<ProgrammerCable, uint64_t> m_frequency{};
+  QPalette m_defaultPalette{};
+  QPalette m_failPalette{};
+  QPalette m_passPalette{};
+  int m_status{None};
 };
 
 }  // namespace FOEDAG


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Progress bar color changed regarding programing status:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/86d1f8e6-9fa4-4832-ad7a-f475e393e233)
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/6b3d9f71-38f2-40af-aa13-983f710eb395)



 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: programmer-gui
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts