### PR TITLE
Macos qt6 issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 295)
+set(VERSION_PATCH 296)
 
 
 option(

--- a/src/Command/Command.h
+++ b/src/Command/Command.h
@@ -18,14 +18,13 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef COMMAND_H
+#define COMMAND_H
 
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
-
-#ifndef COMMAND_H
-#define COMMAND_H
 
 namespace FOEDAG {
 

--- a/src/Command/CommandStack.h
+++ b/src/Command/CommandStack.h
@@ -18,6 +18,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef COMMAND_STACK_H
+#define COMMAND_STACK_H
 
 #include <fstream>
 #include <iostream>
@@ -27,9 +29,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Command/Command.h"
 #include "Command/Logger.h"
 #include "Tcl/TclInterpreter.h"
-
-#ifndef COMMAND_STACK_H
-#define COMMAND_STACK_H
 
 namespace FOEDAG {
 

--- a/src/Command/Logger.h
+++ b/src/Command/Logger.h
@@ -18,14 +18,13 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef LOGGER_H
+#define LOGGER_H
 
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
-
-#ifndef LOGGER_H
-#define LOGGER_H
 
 namespace FOEDAG {
 

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -2387,18 +2387,21 @@ void Compiler::setTaskManager(TaskManager* newTaskManager) {
       });
     }
     m_taskManager->task(SIMULATE_RTL)
-        ->setCustomData({CustomDataType::Sim,
-                         QVariant::fromValue(Simulator::SimulationType::RTL)});
+        ->setCustomData(
+            CustomData{CustomDataType::Sim,
+                       static_cast<int>(Simulator::SimulationType::RTL)});
     m_taskManager->task(SIMULATE_PNR)
-        ->setCustomData({CustomDataType::Sim,
-                         QVariant::fromValue(Simulator::SimulationType::PNR)});
+        ->setCustomData(
+            CustomData{CustomDataType::Sim,
+                       static_cast<int>(Simulator::SimulationType::PNR)});
     m_taskManager->task(SIMULATE_GATE)
-        ->setCustomData({CustomDataType::Sim,
-                         QVariant::fromValue(Simulator::SimulationType::Gate)});
+        ->setCustomData(
+            CustomData{CustomDataType::Sim,
+                       static_cast<int>(Simulator::SimulationType::Gate)});
     m_taskManager->task(SIMULATE_BITSTREAM)
-        ->setCustomData({CustomDataType::Sim,
-                         QVariant::fromValue(
-                             Simulator::SimulationType::BitstreamBackDoor)});
+        ->setCustomData(CustomData{
+            CustomDataType::Sim,
+            static_cast<int>(Simulator::SimulationType::BitstreamBackDoor)});
   }
   SetDeviceResources();
 }

--- a/src/Compiler/CompilerDefines.cpp
+++ b/src/Compiler/CompilerDefines.cpp
@@ -60,7 +60,8 @@ TaskTableView *prepareCompilerView(Compiler *compiler,
       });
 
   QObject::connect(view, &TaskTableView::ViewWaveform, [compiler](Task *task) {
-    auto simType = task->cusomData().data.value<Simulator::SimulationType>();
+    auto simType =
+        static_cast<Simulator::SimulationType>(task->cusomData().data);
     auto fileName = compiler->GetSimulator()->WaveFile(simType);
     std::filesystem::path filePath =
         compiler->FilePath(Compiler::ToCompilerAction(simType), fileName);

--- a/src/Compiler/CompilerOpenFPGA.h
+++ b/src/Compiler/CompilerOpenFPGA.h
@@ -18,6 +18,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef COMPILER_OPENFPGA_H
+#define COMPILER_OPENFPGA_H
 
 #include <fstream>
 #include <iostream>
@@ -25,9 +27,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <vector>
 
 #include "Compiler/Compiler.h"
-
-#ifndef COMPILER_OPENFPGA_H
-#define COMPILER_OPENFPGA_H
 
 namespace FOEDAG {
 enum class SynthesisType { Yosys, QL, RS };

--- a/src/Compiler/Task.h
+++ b/src/Compiler/Task.h
@@ -49,7 +49,7 @@ enum class CustomDataType {
 
 struct CustomData {
   CustomDataType type{CustomDataType::None};
-  QVariant data;
+  int data;
 };
 
 struct ProcessUtilization {

--- a/src/Compiler/TaskGlobal.h
+++ b/src/Compiler/TaskGlobal.h
@@ -22,8 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <qnamespace.h>
 
-#include <QMetaType>
-
 namespace FOEDAG {
 
 static constexpr uint UserActionRole = Qt::UserRole + 1;
@@ -34,12 +32,4 @@ static constexpr uint TaskId = Qt::UserRole + 5;
 static constexpr uint UserActionCleanRole = Qt::UserRole + 6;
 static constexpr uint StatusRole = Qt::UserRole + 7;
 
-enum ExpandAreaAction {
-  Invert,
-  Expand,
-  Collapse,
-};
-
 }  // namespace FOEDAG
-
-Q_DECLARE_METATYPE(FOEDAG::ExpandAreaAction)

--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -52,8 +52,6 @@ static constexpr auto ParentTitle{"ParentTitle"};
 
 TaskManager::TaskManager(Compiler *compiler, QObject *parent)
     : QObject{parent}, m_compiler(compiler) {
-  qRegisterMetaType<FOEDAG::TaskStatus>("FOEDAG::TaskStatus");
-
   m_tasks.insert(IP_GENERATE, new Task{"IP Generate"});
   m_tasks.insert(ANALYSIS, new Task{"Analysis"});
   m_tasks.insert(ANALYSIS_CLEAN, new Task{"Clean", TaskType::Clean});

--- a/src/Compiler/TaskTableView.cpp
+++ b/src/Compiler/TaskTableView.cpp
@@ -291,7 +291,7 @@ void TaskTableView::addTaskViewWaveformAction(QMenu *menu, Task *task) {
   menu->addAction(view);
 
   auto compiler = m_taskManager->GetCompiler();
-  auto simType = task->cusomData().data.value<Simulator::SimulationType>();
+  auto simType = static_cast<Simulator::SimulationType>(task->cusomData().data);
   auto fileName = compiler->GetSimulator()->WaveFile(simType);
   std::filesystem::path filePath =
       compiler->FilePath(Compiler::ToCompilerAction(simType), fileName);

--- a/src/Compiler/TaskTableView.h
+++ b/src/Compiler/TaskTableView.h
@@ -57,8 +57,6 @@ class TaskTableView : public QTableView {
   void customMenuRequested(const QPoint &pos);
   void userActionHandle(const QModelIndex &index);
   void userActionCleanHandle(const QModelIndex &index);
-  void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
-                   const QVector<int> &roles) override;
 
  signals:
   void TaskDialogRequested(const QString &category, const QString &path);
@@ -67,6 +65,8 @@ class TaskTableView : public QTableView {
   void ViewWaveform(FOEDAG::Task *task);
 
  private:
+  void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
+                   const QVector<int> &roles) override;
   QRect contextArea(const QModelIndex &index) const;
   void addTaskLogAction(QMenu *menu, Task *task);
   void addTaskViewWaveformAction(QMenu *menu, Task *task);

--- a/src/Main/CommandLine.h
+++ b/src/Main/CommandLine.h
@@ -18,15 +18,14 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef COMMAND_LINE_H
+#define COMMAND_LINE_H
 
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
-
-#ifndef COMMAND_LINE_H
-#define COMMAND_LINE_H
 
 extern const char* foedag_version_str;
 

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -20,11 +20,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "main_window.h"
 
+#include <QClipboard>
+#include <QDesktopServices>
+#include <QDialogButtonBox>
 #include <QLabel>
 #include <QListView>
+#include <QMenuBar>
+#include <QMessageBox>
+#include <QProgressBar>
+#include <QStatusBar>
+#include <QTableWidget>
 #include <QTextStream>
-#include <QtWidgets>
-#include <fstream>
 
 #include "ChatGptWidget.h"
 #include "Compiler/Compiler.h"

--- a/src/NewProject/Main/registerNewProjectCommands.h
+++ b/src/NewProject/Main/registerNewProjectCommands.h
@@ -19,6 +19,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include <QApplication>
 
 #include "Main/Foedag.h"

--- a/src/Tcl/TclInterpreter.h
+++ b/src/Tcl/TclInterpreter.h
@@ -18,6 +18,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef TCL_INTERPRETER_H
+#define TCL_INTERPRETER_H
 
 #if defined(_MSC_VER)
 #include <direct.h>
@@ -39,9 +41,6 @@ extern "C" {
 #include <iostream>
 #include <string>
 #include <vector>
-
-#ifndef TCL_INTERPRETER_H
-#define TCL_INTERPRETER_H
 
 struct Tcl_Interp;
 

--- a/tests/unittest/Compiler/TaskManager_test.cpp
+++ b/tests/unittest/Compiler/TaskManager_test.cpp
@@ -32,17 +32,17 @@ TEST(TaskManager, getDownstreamCleanTasks) {
 
   taskManager.task(SIMULATE_RTL)
       ->setCustomData({CustomDataType::Sim,
-                       QVariant::fromValue(Simulator::SimulationType::RTL)});
+                       static_cast<int>(Simulator::SimulationType::RTL)});
   taskManager.task(SIMULATE_PNR)
       ->setCustomData({CustomDataType::Sim,
-                       QVariant::fromValue(Simulator::SimulationType::PNR)});
+                       static_cast<int>(Simulator::SimulationType::PNR)});
   taskManager.task(SIMULATE_GATE)
       ->setCustomData({CustomDataType::Sim,
-                       QVariant::fromValue(Simulator::SimulationType::Gate)});
+                       static_cast<int>(Simulator::SimulationType::Gate)});
   taskManager.task(SIMULATE_BITSTREAM)
       ->setCustomData(
           {CustomDataType::Sim,
-           QVariant::fromValue(Simulator::SimulationType::BitstreamBackDoor)});
+           static_cast<int>(Simulator::SimulationType::BitstreamBackDoor)});
 
   auto simulationRtl = taskManager.task(SIMULATE_RTL_CLEAN);
   auto cleanTasks = taskManager.getDownstreamCleanTasks(simulationRtl);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed MACOS build issue.
This PR fixes few different build issues:
* `#include <QtWidgets>` causes build fail
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/be4f6f8c-4e80-41be-a8e7-0ed529b586ca)

* Override virtual slot TaskTableView::dataChanged. This causes link error. 
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/9c2f6962-11d7-4921-b826-2ec34df7c907)

This issue also present on Linux but for some reason does not cause link error. Command for detect problem:
```
find dbuild/ -name mocs_compilation.cpp.o | xargs -n 1 -I % sh -c 'objdump -x % | grep registerConverterFunction'
```

Error output:
````
0000000000000000         *UND*	0000000000000000 _ZN9QMetaType27unregisterConverterFunctionES_S_
0000000000000000         *UND*	0000000000000000 _ZN9QMetaType25registerConverterFunctionERKSt8functionIFbPKvPvEES_S_
0000000000000023 R_X86_64_PLT32    _ZN9QMetaType27unregisterConverterFunctionES_S_-0x0000000000000004
0000000000000045 R_X86_64_PLT32    _ZN9QMetaType25registerConverterFunctionERKSt8functionIFbPKvPvEES_S_-0x0000000000000004
````

There are two function that are not resolved. `unregisterConverterFunction` and `registerConverterFunction`. But why this issue reproducible on MACOS only? also there are many other undefined functions but this doesn't cause any problem.  


This issues leads to link error for `test_install` target
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/c66f8f89-b73f-4f78-8234-97d6d13df461)

1. Wrong usage of header guards
2. Undefined link issue related to type conversion for QVariant::fromValue
3. qRegisterMetaType<FOEDAG::TaskStatus>("FOEDAG::TaskStatus"); 

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts