### PR TITLE
[EDA-2345] Add compile2bits tcl command

### DIFF
--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -322,6 +322,7 @@ class Compiler {
       const std::filesystem::path& ports_info) const;
 
   class DesignQuery* GetDesignQuery();
+  void Compile2bits(bool compile2bits);
 
  protected:
   /* Methods that can be customized for each new compiler flow */
@@ -455,6 +456,7 @@ class Compiler {
   std::string m_name;
   ProcessUtilization m_utils;
   struct ErrorState m_errorState;
+  bool m_compile2bits{false};
 };
 
 }  // namespace FOEDAG

--- a/src/Compiler/CompilerDefines.h
+++ b/src/Compiler/CompilerDefines.h
@@ -99,6 +99,7 @@ static constexpr uint SIMULATE_BITSTREAM_CLEAN{38};
 static constexpr uint SIMULATE_BITSTREAM_SETTINGS{39};
 static constexpr uint TIMING_SIGN_OFF_SETTINGS{40};
 static constexpr uint PACKING_SETTINGS{41};
+static constexpr uint BITSTREAM_COMPILE2BIT{42};
 
 static constexpr const char *IP_GENERATE_LOG{"ip_generate.rpt"};
 static constexpr const char *ANALYSIS_LOG{"analysis.rpt"};


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Implement new tcl command `compile2bits`. This command performs this actions in one shot:
* packing
* placement
* routing
* timing
* bitstream

Also new action available in Bitstream context menu:
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/745aa0d7-cd7b-40b0-8a10-e1cbe65762f1)




 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts