### PR TITLE
[RG-306] Code improvement to avoid conversion from string to string list for project mananger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 304)
+set(VERSION_PATCH 305)
 
 option(
   WITH_LIBCXX

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -199,28 +199,30 @@ class ProjectManager : public QObject {
   ProjectType projectType() const;
 
   ErrorInfo addFiles(const QString &commands, const QString &libs,
-                     const QString &fileNames, int lang, const QString &grName,
-                     bool isFileCopy = true, bool localToProject = true);
+                     const QStringList &fileNames, int lang,
+                     const QString &grName, bool isFileCopy = true,
+                     bool localToProject = true);
 
   ErrorInfo addDesignFiles(const QString &commands, const QString &libs,
-                           const QString &fileNames, int lang,
+                           const QStringList &fileNames, int lang,
                            const QString &grName, bool isFileCopy = true,
                            bool localToProject = true);
 
   ErrorInfo addSimulationFiles(const QString &commands, const QString &libs,
-                               const QString &fileNames, int lang,
+                               const QStringList &fileNames, int lang,
                                const QString &grName, bool isFileCopy = true,
                                bool localToProject = true);
 
   QString getDefaulUnitName() const;
   int setDesignFiles(const QString &commands, const QString &libs,
-                     const QString &fileNames, int lang, const QString &grName,
-                     bool isFileCopy = true, bool localToProject = true);
+                     const QStringList &fileNames, int lang,
+                     const QString &grName, bool isFileCopy = true,
+                     bool localToProject = true);
   // Please set currentfileset before using this function
   int setSimulationFile(const QString &strFileName, bool isFileCopy = true,
                         bool localToProject = true);
   int setSimulationFiles(const QString &commands, const QString &libs,
-                         const QString &fileNames, int lang,
+                         const QStringList &fileNames, int lang,
                          const QString &grName, bool isFileCopy,
                          bool localToProject);
   int addConstrsFile(const QString &strFileName, bool isFileCopy = true,
@@ -403,8 +405,8 @@ class ProjectManager : public QObject {
   void addIpInstanceCmd(const std::string &ipInstanceCmd);
 
   using AddFileFunction =
-      std::function<void(const QString &, const QString &, const QString &, int,
-                         const QString &, bool, bool)>;
+      std::function<void(const QString &, const QString &, const QStringList &,
+                         int, const QString &, bool, bool)>;
   static void AddFiles(const ProjectOptions::FileData &fileData,
                        const AddFileFunction &addFileFunction);
 

--- a/src/ProjNavigator/add_file_dialog.cpp
+++ b/src/ProjNavigator/add_file_dialog.cpp
@@ -45,8 +45,9 @@ void AddFileDialog::on_m_btnOK_clicked() {
       if ("<Local to Project>" == fdata.m_filePath) {
         if (GT_SOURCE == iType) {
           // TODO RG-132 @volodymyrk. If group exists we should append to list
-          ret = m_pm->setDesignFiles({}, {}, fdata.m_fileName, fdata.m_language,
-                                     fdata.m_groupName, false, true);
+          ret =
+              m_pm->setDesignFiles({}, {}, {fdata.m_fileName}, fdata.m_language,
+                                   fdata.m_groupName, false, true);
         } else if (GT_CONSTRAINTS == iType) {
           ret = m_pm->setConstrsFile(fdata.m_fileName, false, true);
         } else if (GT_SIM == iType) {
@@ -55,10 +56,10 @@ void AddFileDialog::on_m_btnOK_clicked() {
       } else {
         if (GT_SOURCE == iType) {
           // TODO RG-132 @volodymyrk. If group exists we should append to list
-          ret = m_pm->setDesignFiles({}, {},
-                                     fdata.m_filePath + "/" + fdata.m_fileName,
-                                     fdata.m_language, fdata.m_groupName,
-                                     m_fileForm->IsCopySource(), false);
+          ret = m_pm->setDesignFiles(
+              {}, {}, {fdata.m_filePath + "/" + fdata.m_fileName},
+              fdata.m_language, fdata.m_groupName, m_fileForm->IsCopySource(),
+              false);
         } else if (GT_CONSTRAINTS == iType) {
           ret = m_pm->setConstrsFile(fdata.m_filePath + "/" + fdata.m_fileName,
                                      m_fileForm->IsCopySource(), false);

--- a/src/ProjNavigator/tcl_command_integration.h
+++ b/src/ProjNavigator/tcl_command_integration.h
@@ -35,23 +35,23 @@ class TclCommandIntegration : public QObject {
   TclCommandIntegration(ProjectManager *projManager, SourcesForm *form);
   bool TclSetTopModule(int argc, const char *argv[], std::ostream &out);
   bool TclCreateFileSet(int argc, const char *argv[], std::ostream &out);
-  bool TclCreateFileSet(const QString &name, std::ostream &out);
+  bool TclCreateFileSet(const std::string &name, std::ostream &out);
   bool TclAddOrCreateDesignFiles(int argc, const char *argv[],
                                  std::ostream &out);
-  bool TclAddOrCreateDesignFiles(const QString &files, int lang,
-                                 std::ostream &out);
-  bool TclAddDesignFiles(const QString &commands, const QString &libs,
-                         const QString &files, int lang, std::ostream &out);
-  bool TclAddSimulationFiles(const QString &commands, const QString &libs,
-                             const QString &files, int lang, std::ostream &out);
+  bool TclAddDesignFiles(const std::string &commands, const std::string &libs,
+                         const std::vector<std::string> &files, int lang,
+                         std::ostream &out);
+  bool TclAddSimulationFiles(const std::string &commands,
+                             const std::string &libs,
+                             const std::vector<std::string> &files, int lang,
+                             std::ostream &out);
   bool TclVerifySynthPorts(std::ostream &out);
-  bool TclAddOrCreateConstrFiles(const QString &file, std::ostream &out);
-  bool TclAddConstrFiles(const QString &file, std::ostream &out);
+  bool TclAddConstrFiles(const std::string &file, std::ostream &out);
   bool TclSetActive(int argc, const char *argv[], std::ostream &out);
   bool TclSetAsTarget(int argc, const char *argv[], std::ostream &out);
   bool TclCreateProject(int argc, const char *argv[], std::ostream &out);
-  bool TclCreateProject(const QString &name, const QString &type, bool cleanup,
-                        std::ostream &out);
+  bool TclCreateProject(const std::string &name, const std::string &type,
+                        bool cleanup, std::ostream &out);
   bool TclCloseProject();
   bool TclClearSimulationFiles(std::ostream &out);
 

--- a/src/Utils/QtUtils.cpp
+++ b/src/Utils/QtUtils.cpp
@@ -79,4 +79,11 @@ QString QtUtils::ToQString(const std::filesystem::path &path) {
   return QString::fromStdString(path.string());
 }
 
+QStringList QtUtils::ToQStringList(const std::vector<std::string> &strings) {
+  QStringList stringList{};
+  for (const auto &str : strings)
+    stringList.emplace_back(QString::fromStdString(str));
+  return stringList;
+}
+
 }  // namespace FOEDAG

--- a/src/Utils/QtUtils.h
+++ b/src/Utils/QtUtils.h
@@ -56,6 +56,7 @@ class QtUtils {
     return s;
   }
   static QString ToQString(const std::filesystem::path &path);
+  static QStringList ToQStringList(const std::vector<std::string> &strings);
 };
 
 using QU = QtUtils;

--- a/tests/unittest/NewProject/ProjectManager_test.cpp
+++ b/tests/unittest/NewProject/ProjectManager_test.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Compiler/CompilerDefines.h"
 #include "NewProject/ProjectManager/project_manager.h"
+#include "Utils/QtUtils.h"
 #include "gtest/gtest.h"
 using namespace FOEDAG;
 namespace fs = std::filesystem;
@@ -122,19 +123,21 @@ TEST(ProjectManager, AddFilesOneLibraryOneGroup) {
   ProjectOptions::FileData data{{data0, data1}, false};
 
   bool fileAdded{false};  // make sure addFilesFunction was call
-  auto addFilesFunction =
-      [&fileAdded](const QString& commands, const QString& libs,
-                   const QString& fileNames, int lang, const QString& grName,
-                   bool isFileCopy, bool localToProject) {
-        fileAdded = true;
-        EXPECT_EQ(commands, "-work");
-        EXPECT_EQ(libs, "lib0");
-        EXPECT_EQ(fileNames, "filepath/filename0 filepath/filename1");
-        EXPECT_EQ(lang, Design::VERILOG_2001);
-        EXPECT_EQ(grName, "gr0");
-        EXPECT_EQ(isFileCopy, false);
-        EXPECT_EQ(localToProject, false);
-      };
+  auto addFilesFunction = [&fileAdded](const QString& commands,
+                                       const QString& libs,
+                                       const QStringList& fileNames, int lang,
+                                       const QString& grName, bool isFileCopy,
+                                       bool localToProject) {
+    fileAdded = true;
+    QStringList expected = {{"filepath/filename0"}, {"filepath/filename1"}};
+    EXPECT_EQ(commands, "-work");
+    EXPECT_EQ(libs, "lib0");
+    EXPECT_EQ(fileNames, expected);
+    EXPECT_EQ(lang, Design::VERILOG_2001);
+    EXPECT_EQ(grName, "gr0");
+    EXPECT_EQ(isFileCopy, false);
+    EXPECT_EQ(localToProject, false);
+  };
   ProjectManager::AddFiles(data, addFilesFunction);
   EXPECT_EQ(fileAdded, true);
 }
@@ -147,19 +150,21 @@ TEST(ProjectManager, AddFilesTwoLibrariesOneGroup) {
   ProjectOptions::FileData data{{data0, data1}, false};
 
   bool fileAdded{false};  // make sure addFilesFunction was call
-  auto addFilesFunction =
-      [&fileAdded](const QString& commands, const QString& libs,
-                   const QString& fileNames, int lang, const QString& grName,
-                   bool isFileCopy, bool localToProject) {
-        fileAdded = true;
-        EXPECT_EQ(commands, "-work");
-        EXPECT_EQ(libs, "lib0 lib1");
-        EXPECT_EQ(fileNames, "filepath/filename0 filepath/filename1");
-        EXPECT_EQ(lang, Design::VERILOG_2001);
-        EXPECT_EQ(grName, "gr0");
-        EXPECT_EQ(isFileCopy, false);
-        EXPECT_EQ(localToProject, false);
-      };
+  auto addFilesFunction = [&fileAdded](const QString& commands,
+                                       const QString& libs,
+                                       const QStringList& fileNames, int lang,
+                                       const QString& grName, bool isFileCopy,
+                                       bool localToProject) {
+    fileAdded = true;
+    QStringList expected = {{"filepath/filename0"}, {"filepath/filename1"}};
+    EXPECT_EQ(commands, "-work");
+    EXPECT_EQ(libs, "lib0 lib1");
+    EXPECT_EQ(fileNames, expected);
+    EXPECT_EQ(lang, Design::VERILOG_2001);
+    EXPECT_EQ(grName, "gr0");
+    EXPECT_EQ(isFileCopy, false);
+    EXPECT_EQ(localToProject, false);
+  };
   ProjectManager::AddFiles(data, addFilesFunction);
   EXPECT_EQ(fileAdded, true);
 }
@@ -172,10 +177,11 @@ TEST(ProjectManager, AddFilesLanguageMismatch) {
   ProjectOptions::FileData data{{data0, data1}, false};
 
   bool fileAdded{false};
-  auto addFilesFunction =
-      [&fileAdded](const QString& commands, const QString& libs,
-                   const QString& fileNames, int lang, const QString& grName,
-                   bool isFileCopy, bool localToProject) { fileAdded = true; };
+  auto addFilesFunction = [&fileAdded](
+                              const QString& commands, const QString& libs,
+                              const QStringList& fileNames, int lang,
+                              const QString& grName, bool isFileCopy,
+                              bool localToProject) { fileAdded = true; };
   ProjectManager::AddFiles(data, addFilesFunction);
   EXPECT_EQ(fileAdded, false);
 }
@@ -190,12 +196,12 @@ TEST(ProjectManager, AddFilesOneLibraryTwoGroups) {
   uint counter{0};
   auto addFilesFunction =
       [&counter](const QString& commands, const QString& libs,
-                 const QString& fileNames, int lang, const QString& grName,
+                 const QStringList& fileNames, int lang, const QString& grName,
                  bool isFileCopy, bool localToProject) {
         if (counter == 0) {
           EXPECT_EQ(commands, QString{});
           EXPECT_EQ(libs, QString{});
-          EXPECT_EQ(fileNames, "filepath/filename0");
+          EXPECT_EQ(fileNames, QStringList{"filepath/filename0"});
           EXPECT_EQ(lang, Design::VERILOG_2001);
           EXPECT_EQ(grName, "gr0");
           EXPECT_EQ(isFileCopy, false);
@@ -203,7 +209,7 @@ TEST(ProjectManager, AddFilesOneLibraryTwoGroups) {
         } else {
           EXPECT_EQ(commands, "-work");
           EXPECT_EQ(libs, "lib0");
-          EXPECT_EQ(fileNames, "filepath/filename1");
+          EXPECT_EQ(fileNames, QStringList{"filepath/filename1"});
           EXPECT_EQ(lang, Design::VERILOG_1995);
           EXPECT_EQ(grName, "gr1");
           EXPECT_EQ(isFileCopy, false);
@@ -225,20 +231,24 @@ TEST(ProjectManager, AddFilesOneLibraryNoGroup) {
   uint counter{0};
   auto addFilesFunction =
       [&counter](const QString& commands, const QString& libs,
-                 const QString& fileNames, int lang, const QString& grName,
+                 const QStringList& fileNames, int lang, const QString& grName,
                  bool isFileCopy, bool localToProject) {
         if (counter == 0) {
+          auto expectedFiles =
+              QtUtils::CreatePath(QString{"filepath"}, QString{"filename0"});
           EXPECT_EQ(commands, "-work");
           EXPECT_EQ(libs, "lib0");
-          EXPECT_EQ(fileNames, "filepath/filename0");
+          EXPECT_EQ(fileNames, QStringList{expectedFiles});
           EXPECT_EQ(lang, Design::VERILOG_2001);
           EXPECT_EQ(grName, QString{});
           EXPECT_EQ(isFileCopy, true);
           EXPECT_EQ(localToProject, false);
         } else {
+          auto expectedFiles =
+              QtUtils::CreatePath(QString{"filepath"}, QString{"filename1"});
           EXPECT_EQ(commands, "-work");
           EXPECT_EQ(libs, "lib0");
-          EXPECT_EQ(fileNames, "filepath/filename1");
+          EXPECT_EQ(fileNames, QStringList{expectedFiles});
           EXPECT_EQ(lang, Design::VERILOG_2001);
           EXPECT_EQ(grName, QString{});
           EXPECT_EQ(isFileCopy, true);
@@ -260,12 +270,12 @@ TEST(ProjectManager, AddFilesLocalToProject) {
   uint counter{0};
   auto addFilesFunction =
       [&counter](const QString& commands, const QString& libs,
-                 const QString& fileNames, int lang, const QString& grName,
+                 const QStringList& fileNames, int lang, const QString& grName,
                  bool isFileCopy, bool localToProject) {
         if (counter == 0) {
           EXPECT_EQ(commands, "-work");
           EXPECT_EQ(libs, "lib0");
-          EXPECT_EQ(fileNames, "filename0");
+          EXPECT_EQ(fileNames, QStringList{"filename0"});
           EXPECT_EQ(lang, Design::VERILOG_2001);
           EXPECT_EQ(grName, QString{});
           EXPECT_EQ(isFileCopy, false);
@@ -273,7 +283,7 @@ TEST(ProjectManager, AddFilesLocalToProject) {
         } else {
           EXPECT_EQ(commands, "-work");
           EXPECT_EQ(libs, "lib0");
-          EXPECT_EQ(fileNames, "filename1");
+          EXPECT_EQ(fileNames, QStringList{"filename1"});
           EXPECT_EQ(lang, Design::VERILOG_2001);
           EXPECT_EQ(grName, QString{});
           EXPECT_EQ(isFileCopy, false);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-306
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
1. Use string list instead of conversion string to string list for design and simulation files. Before the change, files list was compiled into the string with space separator. Inside ProjectManager this string splits into list of strings. After changes, there is no string for files but only string list. 
2. Encapsulate conversion between `std::string` and `QString` inside `TclCommandIntegration` class. Provide interface with `std::string` only for compiler. 


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, newproject, projnavigator, utils
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts