### PR TITLE
[RG-497] Use relative path in device.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 307)
+set(VERSION_PATCH 308)
 
 option(
   WITH_LIBCXX

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -3202,7 +3202,6 @@ bool CompilerOpenFPGA::LoadDeviceData(
     const std::string& deviceName,
     const std::filesystem::path& deviceListFile) {
   bool status = true;
-  std::filesystem::path datapath = GetSession()->Context()->DataPath();
   QFile file(deviceListFile.string().c_str());
   if (!file.open(QFile::ReadOnly)) {
     ErrorMessage("Cannot open device file: " + deviceListFile.string());
@@ -3246,8 +3245,7 @@ bool CompilerOpenFPGA::LoadDeviceData(
                 if (FileUtils::FileExists(file)) {
                   fullPath = file;  // Absolute path
                 } else {
-                  fullPath = datapath / std::string("etc") /
-                             std::string("devices") / file;
+                  fullPath = deviceListFile.parent_path() / file;
                 }
                 if (!FileUtils::FileExists(fullPath.string())) {
                   ErrorMessage("Invalid device config file: " +


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
update for loading `device.xml`. Use relative path for `file` attribute.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
