### PR TITLE
Update CentOS CI to use Qt with OpenSSL enabled

### DIFF
--- a/.github/workflows/install_centos_dependencies_build.sh
+++ b/.github/workflows/install_centos_dependencies_build.sh
@@ -36,7 +36,7 @@ if [ -f buildqt6-centos7-gcc.tar.gz ]
 then
   echo "Found QT build artifact, untarring..."
   tar -xvzf buildqt6-centos7-gcc.tar.gz
-  mv  Qt-6.5.1 /usr/local
+  mv  Qt6.2.4 /usr/local
 else
   echo "Fail to find compiled Qt binaries"
   exit 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,7 +183,7 @@ jobs:
 
     - name: Download Qt6 artifact
       run: |
-        wget https://github.com/RapidSilicon/post_build_artifacts/releases/download/v0.1/Qt-6.5.1.tar.gz -O buildqt6-centos7-gcc.tar.gz  
+        wget https://github.com/RapidSilicon/post_build_artifacts/releases/download/v0.2/qt6.2.4_withopenssl.tar.gz -O buildqt6-centos7-gcc.tar.gz  
 
 # runs a script to install the required dependencies 
 # Qt6 using the CentOS-specific installation script
@@ -204,7 +204,7 @@ jobs:
         source /opt/rh/devtoolset-11/enable
         echo 'CC=/opt/rh/devtoolset-11/root/usr/bin/gcc' >> $GITHUB_ENV
         echo 'CXX=/opt/rh/devtoolset-11/root/usr/bin/g++' >> $GITHUB_ENV
-        echo 'PATH=/usr/local/Qt-6.5.0/bin:/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
+        echo 'PATH=/usr/local/Qt6.2.4/bin:/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
         echo 'PREFIX=/tmp/foedag-install' >> $GITHUB_ENV
         echo "$PREFIX" >> $GITHUB_PATH
         echo "ADDITIONAL_CMAKE_OPTIONS='-DMY_CXX_WARNING_FLAGS="-W -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Werror -UNDEBUG"'" >> $GITHUB_ENV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 312)
+set(VERSION_PATCH 313)
 
 option(
   WITH_LIBCXX


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ x] To address an existing issue. 

Adding Qt with OpenSSL enabled in CentOS 7 CI


> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ x] Continous Integration (CI) scripts
