### PR TITLE
[EDA-2005] Add default parameters for verilator simulation, batch mode

### DIFF
--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -101,7 +101,12 @@ Simulator::Simulator(TclInterpreter* interp, Compiler* compiler,
     : m_interp(interp),
       m_compiler(compiler),
       m_out(out),
-      m_tclInterpreterHandler(tclInterpreterHandler) {}
+      m_tclInterpreterHandler(tclInterpreterHandler) {
+  const std::string defOptions{"--main --timing --exe"};
+  for (auto level : {"rtl", "gate", "pnr", "bitstream_bd", "bitstream_fd"})
+    SetSimulatorCompileOption(level, Simulator::SimulatorType::Verilator,
+                              defOptions);
+}
 
 void Simulator::AddGateSimulationModel(const std::filesystem::path& path) {
   m_gateSimulationModels.push_back(path);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Change default compilation options for verilator simulator to `--main --timing --exe`. 
This change affects batch mode only.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [ ] Library: <Specify the library name>
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
