### PR TITLE
Clean up cmake for monaco editor

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,9 @@ on:
 
 jobs:
   triage:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_subdirectory(third_party/tcl_cmake EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
 if (USE_MONACO_EDITOR)
+  add_subdirectory(third_party/monaco-editor)
 else()
   add_subdirectory(third_party/QScintilla-2.13.1)
 endif()
@@ -95,10 +96,6 @@ add_subdirectory(third_party/gtkwave_cmake)
 add_subdirectory(third_party/scope_guard)
 add_subdirectory(third_party/openocd_cmake)
 add_subdirectory(third_party/openssl_cmake)
-if (USE_MONACO_EDITOR)
-  add_subdirectory(third_party/monaco-editor)
-endif()
-
 add_subdirectory(tests/tclutils)
 add_subdirectory(tests/unittest)
 add_subdirectory(src/NewProject)
@@ -558,24 +555,6 @@ install(
     DESTINATION  ${CMAKE_INSTALL_BINDIR} 
 )
 
-if (USE_MONACO_EDITOR)
-install(
-    DIRECTORY
-      ${PROJECT_SOURCE_DIR}/third_party/monaco-editor/monaco-editor
-    DESTINATION
-      ${CMAKE_INSTALL_DATAROOTDIR}/foedag/etc/monaco-editor/
-)
-
-install(
-    FILES
-      ${PROJECT_SOURCE_DIR}/third_party/monaco-editor/monaco-editor.html
-      ${PROJECT_SOURCE_DIR}/third_party/monaco-editor/qwebchannel.js
-    DESTINATION
-        ${CMAKE_INSTALL_DATAROOTDIR}/foedag/etc/monaco-editor/
-    PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
-)
-endif()
-
 if ((DEFINED ENV{MSYSTEM}) AND ("$ENV{MSYSTEM}" STREQUAL "MINGW64"))
 # permission problems in windows at this point.
 else()
@@ -614,20 +593,6 @@ add_custom_command(TARGET foedag-bin POST_BUILD
         ${PROJECT_SOURCE_DIR}/tests/Arch
         ${CMAKE_CURRENT_BINARY_DIR}/share/foedag/Arch/)
 
-if (USE_MONACO_EDITOR)
-add_custom_command(TARGET foedag-bin POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/share/foedag/etc/monaco-editor/
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/third_party/monaco-editor/monaco-editor
-        ${CMAKE_CURRENT_BINARY_DIR}/share/foedag/etc/monaco-editor/monaco-editor)
 
-add_custom_command(TARGET foedag-bin POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-        ${PROJECT_SOURCE_DIR}/third_party/monaco-editor/monaco-editor.html
-        ${CMAKE_CURRENT_BINARY_DIR}/share/foedag/etc/monaco-editor)
 
-add_custom_command(TARGET foedag-bin POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-        ${PROJECT_SOURCE_DIR}/third_party/monaco-editor/qwebchannel.js
-        ${CMAKE_CURRENT_BINARY_DIR}/share/foedag/etc/monaco-editor)
-endif()
+        

--- a/third_party/monaco-editor/CMakeLists.txt
+++ b/third_party/monaco-editor/CMakeLists.txt
@@ -3,36 +3,40 @@ cmake_minimum_required(VERSION 3.15)
 set(MONACO_EDITOR_VERSION 0.45.0)
 
 # download the monaco editor tgz, extract it, and rename the dir from 'package' to 'monaco-editor'
-if(NOT EXISTS ${CMAKE_SOURCE_DIR}/third_party/monaco-editor/monaco-editor-${MONACO_EDITOR_VERSION}.tgz)
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/monaco-editor-${MONACO_EDITOR_VERSION}.tgz)
 message("Downloading monaco-editor tgz package: " ${MONACO_EDITOR_VERSION} " ...")
 file(DOWNLOAD
     https://registry.npmjs.org/monaco-editor/-/monaco-editor-${MONACO_EDITOR_VERSION}.tgz
-    ${CMAKE_SOURCE_DIR}/third_party/monaco-editor/monaco-editor-${MONACO_EDITOR_VERSION}.tgz
+    ${CMAKE_CURRENT_SOURCE_DIR}/monaco-editor-${MONACO_EDITOR_VERSION}.tgz
 )
 endif()
 
-if(NOT EXISTS ${CMAKE_SOURCE_DIR}/third_party/monaco-editor/monaco-editor/)
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/monaco-editor/)
 message("Extracting monaco-editor tgz package: " ${MONACO_EDITOR_VERSION} " ...")
 execute_process(
     COMMAND_ECHO
         STDOUT
     COMMAND 
-        tar -xf ${CMAKE_SOURCE_DIR}/third_party/monaco-editor/monaco-editor-${MONACO_EDITOR_VERSION}.tgz
+        tar -xf ${CMAKE_CURRENT_SOURCE_DIR}/monaco-editor-${MONACO_EDITOR_VERSION}.tgz
     RESULT_VARIABLE result
     WORKING_DIRECTORY
-        ${CMAKE_SOURCE_DIR}/third_party/monaco-editor
+        ${CMAKE_CURRENT_SOURCE_DIR}
 )
 if(result AND NOT result EQUAL 0)
     message(FATAL_ERROR "monaco editor extraction failed!")
 endif()
-file(RENAME ${CMAKE_SOURCE_DIR}/third_party/monaco-editor/package ${CMAKE_SOURCE_DIR}/third_party/monaco-editor/monaco-editor)
+file(RENAME ${CMAKE_CURRENT_SOURCE_DIR}/package ${CMAKE_CURRENT_SOURCE_DIR}/monaco-editor)
 endif()
 
 execute_process(
     COMMAND ${CMAKE_COMMAND} -E make_directory  ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor/
+)
+execute_process(
     COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${CMAKE_CURRENT_SOURCE_DIR}/monaco-editor
     ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor/monaco-editor
+)
+execute_process(
     COMMAND ${CMAKE_COMMAND} -E copy
     ${CMAKE_CURRENT_SOURCE_DIR}/monaco-editor.html
     ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor

--- a/third_party/monaco-editor/CMakeLists.txt
+++ b/third_party/monaco-editor/CMakeLists.txt
@@ -27,3 +27,32 @@ if(result AND NOT result EQUAL 0)
 endif()
 file(RENAME ${CMAKE_SOURCE_DIR}/third_party/monaco-editor/package ${CMAKE_SOURCE_DIR}/third_party/monaco-editor/monaco-editor)
 endif()
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E make_directory  ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor/
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/monaco-editor
+    ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor/monaco-editor
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_CURRENT_SOURCE_DIR}/monaco-editor.html
+    ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_CURRENT_SOURCE_DIR}/qwebchannel.js
+    ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor
+)
+
+install(
+    DIRECTORY
+    ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor/monaco-editor
+    DESTINATION
+      ${CMAKE_INSTALL_DATAROOTDIR}/foedag/etc/monaco-editor/
+)
+
+install(
+    FILES
+    ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor/monaco-editor.html
+      ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor/qwebchannel.js
+    DESTINATION
+        ${CMAKE_INSTALL_DATAROOTDIR}/foedag/etc/monaco-editor/
+    PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
+)


### PR DESCRIPTION
Move the Monaco Editor-related stuff to Monaco CMake and remove it from the main CMake. Use a more precise CMake variable to perform the copy and install action