### PR TITLE
Fixed line selection number in monaco editor

### DIFF
--- a/src/MainWindow/MessagesTabWidget.cpp
+++ b/src/MainWindow/MessagesTabWidget.cpp
@@ -169,8 +169,9 @@ void MessagesTabWidget::onMessageClicked(const QTreeWidgetItem *item, int col) {
   auto filePath = item->data(0, FilePathRole).toString();
 
   auto line = item->data(col, LineNumberRole).toInt();
-  TextEditorForm::Instance()->OpenFileWithSelection(QString(filePath), line,
-                                                    line);
+  // TODO RG-215 @volodymyrk
+  TextEditorForm::Instance()->OpenFileWithSelection(QString(filePath), line + 1,
+                                                    line + 1);
 }
 
 }  // namespace FOEDAG

--- a/src/TextEditor/editor.cpp
+++ b/src/TextEditor/editor.cpp
@@ -92,13 +92,13 @@ void Editor::markLineWarning(int line) {
 }
 
 void Editor::selectLines(int lineFrom, int lineTo) {
-  m_scintilla->setSelection(lineFrom, 0, lineTo,
-                            m_scintilla->lineLength(lineTo));
+  m_scintilla->setSelection(lineFrom - 1, 0, lineTo - 1,
+                            m_scintilla->lineLength(lineTo - 1));
   // VISIBLE_STRICT policy makes sure line is in the middle of the screen.
   // VISIBLE_SLOP, on the other hand, just makess sure line is visible
   m_scintilla->SendScintilla(QsciScintilla::SCI_SETVISIBLEPOLICY,
                              QsciScintilla::VISIBLE_STRICT);
-  m_scintilla->ensureLineVisible(lineFrom);
+  m_scintilla->ensureLineVisible(lineFrom - 1);
 }
 
 void Editor::clearMarkers() { m_scintilla->markerDeleteAll(ERROR_MARKER); }

--- a/src/TextEditor/text_editor_form.cpp
+++ b/src/TextEditor/text_editor_form.cpp
@@ -133,6 +133,7 @@ int TextEditorForm::OpenFileWithSelection(const QString &strFileName,
   int res = OpenFile(strFileName);
   if (res == 0) {
     auto pair = m_map_file_tabIndex_editor.value(strFileName);
+    pair.second->clearMarkers();
     pair.second->selectLines(lineFrom, lineTo);
   } else
     return -1;


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed selection line number for monaco editor.
In the `Messages` tab user can press on warnings or errors and they are opened in the editor. 

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: texteditor, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
