### PR TITLE
Monaco editor cmake clean up

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   increment-patch-version:
     if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - name: Cancel previous

--- a/third_party/monaco-editor/CMakeLists.txt
+++ b/third_party/monaco-editor/CMakeLists.txt
@@ -45,7 +45,3 @@ execute_process(
     ${CMAKE_SOURCE_DIR}/etc/monaco-editor
 )
 
-
-
-
-

--- a/third_party/monaco-editor/CMakeLists.txt
+++ b/third_party/monaco-editor/CMakeLists.txt
@@ -45,18 +45,7 @@ execute_process(
     ${CMAKE_SOURCE_DIR}/etc/monaco-editor
 )
 
-#install(
-#    DIRECTORY
-#    ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor/monaco-editor
-#    DESTINATION
-#      ${CMAKE_INSTALL_DATAROOTDIR}/foedag/etc/monaco-editor/
-#)
 
-#install(
-#    FILES
-#    ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor/monaco-editor.html
-#      ${CMAKE_BINARY_DIR}/share/foedag/etc/monaco-editor/qwebchannel.js
-#    DESTINATION
-#        ${CMAKE_INSTALL_DATAROOTDIR}/foedag/etc/monaco-editor/
-#    PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
-#)
+
+
+


### PR DESCRIPTION
Remove the install section from Monaco Editor Cmake as it is no longer needed.
Move Monaco unzip content to an etc folder so that they get copied like others. 