### PR TITLE
Fixed monaco editor relative path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,8 @@ test/valgrind: run-cmake-debug
 	#grep "ERROR SUMMARY: 0" valgrind_gui.log
 	$(XVFB) valgrind --tool=memcheck $(valgrind_args) dbuild/bin/console_test --replay tests/TestGui/gui_console.tcl
 	grep "ERROR SUMMARY: 0" valgrind_gui.log
-	#$(XVFB) valgrind --tool=memcheck $(valgrind_args) dbuild/bin/foedag --replay tests/TestGui/gui_foedag.tcl
-	#grep "ERROR SUMMARY: 0" valgrind_gui.log
+	$(XVFB) valgrind --tool=memcheck $(valgrind_args) dbuild/bin/foedag --replay tests/TestGui/gui_foedag.tcl
+	grep "ERROR SUMMARY: 0" valgrind_gui.log
 	$(XVFB) valgrind --tool=memcheck $(valgrind_args) dbuild/bin/foedag --replay tests/TestGui/gui_task_dlg.tcl
 	grep "ERROR SUMMARY: 0" valgrind_gui.log
 	$(XVFB) valgrind --tool=memcheck $(valgrind_args) dbuild/bin/foedag --replay tests/TestGui/gui_top_settings_dlg.tcl
@@ -157,7 +157,7 @@ test/gui: run-cmake-debug
 	$(XVFB) ./dbuild/bin/projnavigator --replay tests/TestGui/gui_project_navigator.tcl
 	#$(XVFB) ./dbuild/bin/texteditor --replay tests/TestGui/gui_text_editor.tcl
 	$(XVFB) ./dbuild/bin/newfile --replay tests/TestGui/gui_new_file.tcl
-	#$(XVFB) ./dbuild/bin/foedag --replay tests/TestGui/gui_foedag.tcl
+	$(XVFB) ./dbuild/bin/foedag --replay tests/TestGui/gui_foedag.tcl
 	$(XVFB) ./dbuild/bin/foedag --replay tests/TestGui/gui_foedag_negative_test.tcl && exit 1 || (echo "PASSED: Caught negative test")
 	$(XVFB) ./dbuild/bin/designruns --replay tests/TestGui/design_runs.tcl
 	$(XVFB) ./dbuild/bin/foedag --replay tests/TestGui/gui_task_dlg.tcl

--- a/src/TextEditor/cpp_endpoint.cpp
+++ b/src/TextEditor/cpp_endpoint.cpp
@@ -39,6 +39,12 @@ Q_INVOKABLE void CPPEndPoint::fileLoaded() {
   emit signalToCPP_FileLoaded();
 }
 
+void CPPEndPoint::fileFailedToLoad(QVariant file) {
+  m_fileLoaded = false;
+  qWarning() << "Failed to load file: " << file;
+  emit signalToCPP_FileLoaded();
+}
+
 Q_INVOKABLE void CPPEndPoint::openLink(QVariant linkURI) {
   // use Qt to open the link:
   QDesktopServices::openUrl(QUrl(linkURI.toString()));

--- a/src/TextEditor/cpp_endpoint.h
+++ b/src/TextEditor/cpp_endpoint.h
@@ -18,6 +18,7 @@ class CPPEndPoint : public QObject {
 
   // Monaco Editor JS will call this once the file has been loaded
   Q_INVOKABLE void fileLoaded();
+  Q_INVOKABLE void fileFailedToLoad(QVariant file);
 
   // Monaco Editor JS will call this to request opening any link from the editor
   // content

--- a/src/TextEditor/editor.cpp
+++ b/src/TextEditor/editor.cpp
@@ -294,7 +294,8 @@ void Editor::InitScintilla(int iFileType) {
 
 void Editor::SetScintillaText(QString strFileName) {
   QFile file(strFileName);
-  if (!file.open(QFile::ReadOnly)) {
+  m_fileLoaded = file.open(QFile::ReadOnly);
+  if (!m_fileLoaded) {
     return;
   }
 
@@ -316,3 +317,5 @@ void Editor::UpdateToolBarStates() {
   m_actCopy->setEnabled(m_scintilla->hasSelectedText());
   m_actDelete->setEnabled(m_scintilla->hasSelectedText());
 }
+
+bool Editor::fileLoaded() const { return m_fileLoaded; }

--- a/src/TextEditor/editor.h
+++ b/src/TextEditor/editor.h
@@ -43,6 +43,7 @@ class Editor : public QWidget {
   void clearMarkers();
   void reload();
   void selectLines(int lineFrom, int lineTo);
+  bool fileLoaded() const;
 
  signals:
   void EditorModificationChanged(bool m);
@@ -93,6 +94,7 @@ class Editor : public QWidget {
   static constexpr int MIN_MARGIN_WIDTH{4};
   static constexpr int MARGIN_INDEX{0};
   int m_marginWidth{MIN_MARGIN_WIDTH};
+  bool m_fileLoaded{false};
 };
 
 }  // namespace FOEDAG

--- a/src/TextEditor/monaco_editor.cpp
+++ b/src/TextEditor/monaco_editor.cpp
@@ -45,7 +45,10 @@ using namespace FOEDAG;
 
 Editor::Editor(QString strFileName, int iFileType, QWidget* parent)
     : QWidget(parent) {
-  m_strFileName = strFileName;
+  QFileInfo info{strFileName};
+  // path should be absolute since monaco editor can't open file relative to
+  // std::filesystem::current_path()
+  m_strFileName = info.absoluteFilePath();
   m_closeAfterSave = false;
 
   QVBoxLayout* monacoTextEditorVBoxLayout = new QVBoxLayout();
@@ -159,6 +162,8 @@ void Editor::markLineWarning(int line) {
 void Editor::selectLines(int lineFrom, int lineTo) {
   emit m_CPPEndPointObject->signalToJS_SetHighlightSelection(lineFrom, lineTo);
 }
+
+bool Editor::fileLoaded() const { return m_CPPEndPointObject->m_fileLoaded; }
 
 void Editor::clearMarkers() {
   emit m_CPPEndPointObject->signalToJS_ClearHighlightError();

--- a/src/TextEditor/monaco_editor.h
+++ b/src/TextEditor/monaco_editor.h
@@ -42,6 +42,7 @@ class Editor : public QWidget {
   void clearMarkers();
   void reload();
   void selectLines(int lineFrom, int lineTo);
+  bool fileLoaded() const;
 
  signals:
   void EditorModificationChanged(bool m);

--- a/src/TextEditor/text_editor.cpp
+++ b/src/TextEditor/text_editor.cpp
@@ -51,8 +51,8 @@ void FOEDAG::registerTextEditorCommands(QWidget* editor,
       Tcl_AppendResult(interp, qPrintable(msg), (char*)nullptr);
       return TCL_ERROR;
     }
-    editor->SlotOpenFile(file);
-    return TCL_OK;
+    auto res = editor->SlotOpenFile(file);
+    return (res == 0) ? TCL_OK : TCL_ERROR;
   };
   session->TclInterp()->registerCmd(
       "openfile", openfile, static_cast<void*>(editor), nullptr /*deleteProc*/);
@@ -72,8 +72,8 @@ void TextEditor::ClosetextEditor() { TextEditorForm::Instance()->hide(); }
 
 QWidget* TextEditor::GetTextEditor() { return TextEditorForm::Instance(); }
 
-void TextEditor::SlotOpenFile(const QString& strFileName) {
-  TextEditorForm::Instance()->OpenFile(strFileName);
+int TextEditor::SlotOpenFile(const QString& strFileName) {
+  return TextEditorForm::Instance()->OpenFile(strFileName);
 }
 
 void TextEditor::SlotOpenFileWithLine(const QString& strFileName, int line) {

--- a/src/TextEditor/text_editor.h
+++ b/src/TextEditor/text_editor.h
@@ -23,7 +23,7 @@ class TextEditor : public QWidget {
   void FileChanged(const QString &);
 
  public slots:
-  void SlotOpenFile(const QString &strFileName);
+  int SlotOpenFile(const QString &strFileName);
   void SlotOpenFileWithLine(const QString &strFileName, int line);
 
  private slots:

--- a/src/TextEditor/text_editor_form.cpp
+++ b/src/TextEditor/text_editor_form.cpp
@@ -108,7 +108,7 @@ int TextEditorForm::OpenFile(const QString &strFileName) {
   m_fileWatcher.addPath(strFileName);
   editor->SetFileWatcher(&m_fileWatcher);
 
-  return ret;
+  return editor->fileLoaded() ? 0 : -1;
 }
 
 int TextEditorForm::OpenFileWithLine(const QString &strFileName, int line,

--- a/third_party/monaco-editor/monaco-editor.html
+++ b/third_party/monaco-editor/monaco-editor.html
@@ -147,7 +147,10 @@
 
         setMonacoEditorModelWithFile(filepath, text);
       })
-      .catch((e) => console.error(e));
+      .catch((e) => {
+        console.error(e);
+        window.cppEndPoint.fileFailedToLoad(filepath);
+      })
     }
 
     function setMonacoEditorModelWithFile(filepath, filecontent) {

--- a/third_party/monaco-editor/monaco-editor.html
+++ b/third_party/monaco-editor/monaco-editor.html
@@ -268,8 +268,8 @@
 
       // load the file specified in the endpoint:
       if(window.cppEndPoint.qtVersion[0] >= 6 &&
-         window.cppEndPoint.qtVersion[1] >= 0 &&
-         window.cppEndPoint.qtVersion[2] >= 0) {
+         window.cppEndPoint.qtVersion[1] >= 5 &&
+         window.cppEndPoint.qtVersion[2] >= 3) {
          // Qt 6.0.0+ has support FETCH API, so use that
          readFileFromPathUsingFetch(window.cppEndPoint.filePath);
       }
@@ -284,8 +284,8 @@
         // window.cppEndPoint.log("we got the signal: signalToJS_UpdateFilePath");
 
         if(window.cppEndPoint.qtVersion[0] >= 6 &&
-           window.cppEndPoint.qtVersion[1] >= 0 &&
-           window.cppEndPoint.qtVersion[2] >= 0) {
+           window.cppEndPoint.qtVersion[1] >= 5 &&
+           window.cppEndPoint.qtVersion[2] >= 3) {
             // Qt 6.0.0+ has support FETCH API, so use that
             readFileFromPathUsingFetch(path);
            }

--- a/third_party/monaco-editor/monaco-editor.html
+++ b/third_party/monaco-editor/monaco-editor.html
@@ -132,7 +132,11 @@
             var text = rawFile.responseText;
 
             setMonacoEditorModelWithFile(filepath, text);
+          } else {
+            window.cppEndPoint.fileFailedToLoad(filepath);
           }
+        } else {
+          window.cppEndPoint.fileFailedToLoad(filepath);
         }
       }
       rawFile.send(null);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
* Switch Qt version for using Fetch API to 6.5.3 because 6.2.x does not supported it.
* Fixed using relative path for monaco editor since it will not able to open it. 
* Update `openfile` tcl command for return error when failed to open file.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: texteditor
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts