### PR TITLE
[EDA-2432] Hide Remote URL setting for rapiggpt

### DIFF
--- a/src/rapidgpt/RapigGptSettingsWindow.cpp
+++ b/src/rapidgpt/RapigGptSettingsWindow.cpp
@@ -61,6 +61,10 @@ RapigGptSettingsWindow::RapigGptSettingsWindow(QSettings &settings,
   auto cancel = ui->buttonBox->button(QDialogButtonBox::Cancel);
   connect(ok, &QPushButton::clicked, this, &RapigGptSettingsWindow::accept);
   connect(cancel, &QPushButton::clicked, this, &RapigGptSettingsWindow::reject);
+
+  ui->lineEditRemoteUrl->hide();
+  ui->labelRemoteUrl->hide();
+  resize(100, 100);  // minimize window
 }
 
 RapidGptSettings RapigGptSettingsWindow::fromSettings(

--- a/src/rapidgpt/RapigGptSettingsWindow.ui
+++ b/src/rapidgpt/RapigGptSettingsWindow.ui
@@ -23,14 +23,14 @@
       <widget class="QComboBox" name="comboBoxInteractivity"/>
      </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="labelInteractivity">
        <property name="text">
         <string>Interactivity Rate</string>
        </property>
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="labelPrecision">
        <property name="text">
         <string>Precision</string>
        </property>
@@ -40,14 +40,14 @@
       <widget class="QComboBox" name="comboBoxPrecision"/>
      </item>
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="labelApiKey">
        <property name="text">
         <string>API Key</string>
        </property>
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="labelRemoteUrl">
        <property name="text">
         <string>Remote server URL</string>
        </property>


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: EDA-2432
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Hide Remote server URL setting of RapidGPT
 
![image](https://github.com/os-fpga/FOEDAG/assets/95262932/f7666720-41a6-4b68-9dcc-94da6ec68ced)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: rapidgpt
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
