### PR TITLE
Suppress JS Console Logs from Monaco Editor

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QListView>
+#include <QLoggingCategory>
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QProgressBar>
@@ -138,6 +139,9 @@ MainWindow::MainWindow(Session* session)
    it after some time (in post showEvent period), since it doesn't play any
    specific role, except the role of having it for initialization.
   */
+  // https://doc.qt.io/qt-6/qloggingcategory.html#configuring-categories
+  // https://stackoverflow.com/questions/74499940/how-to-disable-qwebengineview-logging-with-webenginecontextlog
+  QLoggingCategory::setFilterRules("qt.webenginecontext.info=false");
   QWebEngineView* preloadWebView = new QWebEngineView(this);
   preloadWebView->resize(0, 0);
   QTimer::singleShot(1, [preloadWebView]() { preloadWebView->deleteLater(); });

--- a/src/TextEditor/CMakeLists.txt
+++ b/src/TextEditor/CMakeLists.txt
@@ -25,7 +25,7 @@ set (SRC_CPP_LIST
   text_editor.cpp
   text_editor_form.cpp)
 if (USE_MONACO_EDITOR)
-  list(APPEND SRC_CPP_LIST monaco_editor.cpp cpp_endpoint.cpp)
+  list(APPEND SRC_CPP_LIST monaco_editor_page.cpp monaco_editor.cpp cpp_endpoint.cpp)
 else()
   list(APPEND SRC_CPP_LIST search_dialog.cpp editor.cpp)
 endif()
@@ -34,7 +34,7 @@ set (SRC_H_LIST
   text_editor.h
   text_editor_form.h)
 if (USE_MONACO_EDITOR)
-  list(APPEND SRC_H_LIST monaco_editor.h cpp_endpoint.h)
+  list(APPEND SRC_H_LIST monaco_editor_page.h monaco_editor.h cpp_endpoint.h)
 else()
   list(APPEND SRC_H_LIST search_dialog.h editor.h)
 endif()

--- a/src/TextEditor/monaco_editor.cpp
+++ b/src/TextEditor/monaco_editor.cpp
@@ -16,6 +16,7 @@
 #include "Main/ToolContext.h"
 #include "MainWindow/Session.h"
 #include "cpp_endpoint.h"
+#include "monaco_editor_page.h"
 
 extern FOEDAG::Session* GlobalSession;
 
@@ -59,6 +60,9 @@ Editor::Editor(QString strFileName, int iFileType, QWidget* parent)
   // create a separate 'end-point' object to handle comms between C++ and JS
   // init it with the filepath to be opened
   m_CPPEndPointObject = new CPPEndPoint(this, m_strFileName);
+
+  m_webEngineViewPage = new MonacoEditorPage();
+  m_webEngineView->setPage(m_webEngineViewPage);
 
   m_webEngineView->page()->settings()->setAttribute(
       QWebEngineSettings::LocalContentCanAccessFileUrls, true);

--- a/src/TextEditor/monaco_editor.h
+++ b/src/TextEditor/monaco_editor.h
@@ -16,6 +16,7 @@ class QVBoxLayout;
 class QWebEngineView;
 class QWebChannel;
 class CPPEndPoint;
+class MonacoEditorPage;
 
 namespace FOEDAG {
 
@@ -61,6 +62,7 @@ class Editor : public QWidget {
   bool m_closeAfterSave;
   QString m_strFileName;
   QWebEngineView* m_webEngineView;
+  MonacoEditorPage* m_webEngineViewPage;
   QWebChannel* m_webEngineChannel;
   CPPEndPoint* m_CPPEndPointObject;
 

--- a/src/TextEditor/monaco_editor_page.cpp
+++ b/src/TextEditor/monaco_editor_page.cpp
@@ -1,0 +1,13 @@
+
+#include "monaco_editor_page.h"
+
+#include <QWebEnginePage>
+
+MonacoEditorPage::MonacoEditorPage(QObject *parent) : QWebEnginePage(parent) {}
+
+void MonacoEditorPage::javaScriptConsoleMessage(
+    JavaScriptConsoleMessageLevel level, const QString &message, int lineNumber,
+    const QString &sourceID) {
+  // do nothing, all messages from JS console are suppressed!
+  // qDebug() << message;
+}

--- a/src/TextEditor/monaco_editor_page.h
+++ b/src/TextEditor/monaco_editor_page.h
@@ -1,0 +1,15 @@
+#ifndef MONACO_EDITOR_PAGE_H
+#define MONACO_EDITOR_PAGE_H
+
+#include <QWebEnginePage>
+
+class MonacoEditorPage : public QWebEnginePage {
+  Q_OBJECT
+ public:
+  MonacoEditorPage(QObject *parent = 0);
+  virtual void javaScriptConsoleMessage(JavaScriptConsoleMessageLevel level,
+                                        const QString &message, int lineNumber,
+                                        const QString &sourceID);
+};
+
+#endif  // MONACO_EDITOR_PAGE_H


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
We see various JS logs emitted from the QWebEngineViewPage where monaco-editor is loaded, and though we can ignore them, does not give a good UX, hence adding method to suppress all JS logs.
> - [ ] Breaking new feature. If so, please describe details in the description part.


> #### What does this pull request change?
Inherit QWebEnginePage and override QWebEnginePage::javaScriptConsoleMessage()

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
