### PR TITLE
Fix Line Highlight Issues

### DIFF
--- a/third_party/monaco-editor/monaco-editor.html
+++ b/third_party/monaco-editor/monaco-editor.html
@@ -161,6 +161,16 @@
 
       monaco.editor.getModels().forEach(model => model.dispose());
       var model = monaco.editor.createModel(value=filecontent, language=undefined, monaco.Uri.file(filepath));
+
+      // more robust way to detect file has actually finished loading:
+      // before setting the file, listen for model changed, and inform Qt that file has been loaded
+      // we use async way to call the function (setTimeout, 0 delay) to ensure we are in main context
+      monacoEditor.onDidChangeModel((event) => {
+        setTimeout(() => {
+          window.cppEndPoint.fileLoaded();
+        }, "0");
+      });
+
       monacoEditor.setModel(model);
       var languageID = monacoEditor.getModel().getLanguageId();
       // window.cppEndPoint.log("language detected: " + languageID);
@@ -191,8 +201,6 @@
         }
       });
 
-      // signal to Qt side that the file has been loaded now.
-      window.cppEndPoint.fileLoaded();
     }
 
     function setMonacoEditorDecorationSelection(lineFrom, lineTo) {


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
Fix Line Highlight Issues when opening file from console in monaco editor
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
The fileLoaded() call from JS occurs before the file is actually ready and rendered, and causes a miss of the highlight line (marker) signal emitted from Qt the first time.

> #### What does this pull request change?
Makes the monaco editor wait until the file is actually loaded using the OnDidChangeModel event from monaco, and switch to main JS context using setTimeout to call the fileLoaded() to Qt to inform that the editor is now ready and rendered.
Now, the signals emitted for highlighting are received correctly after the editor is ready.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
