### PR TITLE
Copy lib ssl and crypto to build/lib folder to provide same lib across all system

### DIFF
--- a/third_party/openssl_cmake/CMakeLists.txt
+++ b/third_party/openssl_cmake/CMakeLists.txt
@@ -97,6 +97,7 @@ add_custom_target(
   COMMAND ${TEST_EXE}
 )
 
+if(UNIX)
 add_custom_command(TARGET openssl_build POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${OPENSSL_SRC_DIR}/libcrypto.so.3 ${CMAKE_BINARY_DIR}/lib
     COMMAND ${CMAKE_COMMAND} -E create_symlink libcrypto.so.3 libcrypto.so	
@@ -119,7 +120,7 @@ install(
 install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink libssl.so.3  libssl.so WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})")
 
 install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink libcrypto.so.3 libcrypto.so WORKING_DIRECTORY  ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})")
-
+endif()
 
 
 

--- a/third_party/openssl_cmake/CMakeLists.txt
+++ b/third_party/openssl_cmake/CMakeLists.txt
@@ -97,7 +97,7 @@ add_custom_target(
   COMMAND ${TEST_EXE}
 )
 
-if(UNIX)
+if(UNIX AND CMAKE_SYSTEM_NAME MATCHES "Linux")
 add_custom_command(TARGET openssl_build POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${OPENSSL_SRC_DIR}/libcrypto.so.3 ${CMAKE_BINARY_DIR}/lib
     COMMAND ${CMAKE_COMMAND} -E create_symlink libcrypto.so.3 libcrypto.so	

--- a/third_party/openssl_cmake/CMakeLists.txt
+++ b/third_party/openssl_cmake/CMakeLists.txt
@@ -96,3 +96,33 @@ add_custom_target(
   DEPENDS openssl_build ${TEST_EXE}
   COMMAND ${TEST_EXE}
 )
+
+add_custom_command(TARGET openssl_build POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${OPENSSL_SRC_DIR}/libcrypto.so.3 ${CMAKE_BINARY_DIR}/lib
+    COMMAND ${CMAKE_COMMAND} -E create_symlink libcrypto.so.3 libcrypto.so	
+    COMMAND ${CMAKE_COMMAND} -E copy ${OPENSSL_SRC_DIR}/libssl.so.3 ${CMAKE_BINARY_DIR}/lib
+    COMMAND ${CMAKE_COMMAND} -E create_symlink libssl.so.3  libssl.so
+    COMMENT "Copying lib ssl and crypto after building the OpenSSL"
+           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+
+)
+
+install(
+    PROGRAMS
+        ${CMAKE_BINARY_DIR}/lib/libcrypto.so.3
+	${CMAKE_BINARY_DIR}/lib/libssl.so.3
+    DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}
+)
+
+
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink libssl.so.3  libssl.so WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})")
+
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink libcrypto.so.3 libcrypto.so WORKING_DIRECTORY  ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})")
+
+
+
+
+
+
+


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x ] To address an existing issue. 

RapidGPT is facing a core dump and one possible cause is not providing the correct OpenSSL lib so copying the OpenSSL to the build/lib folder along with using a bash script as an invoker to set LD_LIBRARY_PATH to this library.

The bash script is in [PR # 1466](https://github.com/os-fpga/FOEDAG/pull/1466) 