### PR TITLE
Fixed crash ralated to editor after application close

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ test/valgrind: run-cmake-debug
 	grep "ERROR SUMMARY: 0" valgrind_gui.log
 	$(XVFB) valgrind --tool=memcheck $(valgrind_args) dbuild/bin/projnavigator --replay tests/TestGui/gui_project_navigator.tcl
 	grep "ERROR SUMMARY: 0" valgrind_gui.log
-	#$(XVFB) valgrind --tool=memcheck $(valgrind_args) dbuild/bin/texteditor --replay tests/TestGui/gui_text_editor.tcl
-	#grep "ERROR SUMMARY: 0" valgrind_gui.log
+	$(XVFB) valgrind --tool=memcheck $(valgrind_args) dbuild/bin/texteditor --replay tests/TestGui/gui_text_editor.tcl
+	grep "ERROR SUMMARY: 0" valgrind_gui.log
 	$(XVFB) valgrind --tool=memcheck $(valgrind_args) dbuild/bin/console_test --replay tests/TestGui/gui_console.tcl
 	grep "ERROR SUMMARY: 0" valgrind_gui.log
 	$(XVFB) valgrind --tool=memcheck $(valgrind_args) dbuild/bin/foedag --replay tests/TestGui/gui_foedag.tcl
@@ -157,7 +157,7 @@ test/gui: run-cmake-debug
 	$(XVFB) ./dbuild/bin/foedag --replay tests/TestGui/gui_start_stop.tcl
 	$(XVFB) ./dbuild/bin/newproject --replay tests/TestGui/gui_new_project.tcl
 	$(XVFB) ./dbuild/bin/projnavigator --replay tests/TestGui/gui_project_navigator.tcl
-	#$(XVFB) ./dbuild/bin/texteditor --replay tests/TestGui/gui_text_editor.tcl
+	$(XVFB) ./dbuild/bin/texteditor --replay tests/TestGui/gui_text_editor.tcl
 	$(XVFB) ./dbuild/bin/newfile --replay tests/TestGui/gui_new_file.tcl
 	$(XVFB) ./dbuild/bin/foedag --replay tests/TestGui/gui_foedag.tcl
 	$(XVFB) ./dbuild/bin/foedag --replay tests/TestGui/gui_foedag_negative_test.tcl && exit 1 || (echo "PASSED: Caught negative test")

--- a/src/TextEditor/text_editor_form.cpp
+++ b/src/TextEditor/text_editor_form.cpp
@@ -6,9 +6,10 @@
 
 using namespace FOEDAG;
 
-Q_GLOBAL_STATIC(TextEditorForm, texteditor)
-
-TextEditorForm *TextEditorForm::Instance() { return texteditor(); }
+TextEditorForm *TextEditorForm::Instance() {
+  static auto textEditorForm = new TextEditorForm;
+  return textEditorForm;
+}
 
 void TextEditorForm::InitForm() {
   static bool initForm;


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: RG-505
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
https://bugreports.qt.io/browse/QTBUG-25789

This happens because TextEditorForm defined as  
 Q_GLOBAL_STATIC(TextEditorForm, texteditor)

And when application is exit it try to destroy static member. But since TextEditorForm is a part of GUI, it’s already destroyed. Normally, this case should handled by Qt but in this case, it somehow related to QWebEngineView.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: texteditor
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts
