### PR TITLE
Restore set_property original code

### DIFF
--- a/src/Compiler/Constraints.cpp
+++ b/src/Compiler/Constraints.cpp
@@ -581,6 +581,18 @@ void Constraints::registerCommands(TclInterpreter* interp) {
       return TCL_ERROR;
     }
     Constraints* constraints = (Constraints*)clientData;
+    if (!verifyTimingLimits(argc, argv)) {
+      Tcl_AppendResult(interp, TimingLimitErrorMessage, nullptr);
+      return TCL_ERROR;
+    }
+    constraints->addConstraint(getConstraint(argc, argv));
+    for (int i = 0; i < argc; i++) {
+      std::string arg = argv[i];
+      if (arg == "-name") {
+        i++;
+        if (std::string(argv[i]) != "{*}") constraints->addKeep(argv[i]);
+      }
+    }
     std::vector<PROPERTY> properties;
     std::vector<std::string> objects;
     if (std::string(argv[1]) == "-dict") {


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
1. Full compilation test (tested at Raptor level) was broken due to https://github.com/os-fpga/FOEDAG/pull/1461. Specifically I remove the original code and completely rewrite set_property command, thinking it was not exercised by any code. https://github.com/os-fpga/FOEDAG/pull/1461/files#diff-3008f9added136f0dc9ac2353b1282c7ef81e626257d205932ff44545aa184e4L571-L583
2. Restoring back the original code

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
