### PR TITLE
Copy openssl libs in folder to handle symbolic links

### DIFF
--- a/src/.foedagenv_lin64.sh
+++ b/src/.foedagenv_lin64.sh
@@ -5,9 +5,9 @@ SCRIPT_PATH=`dirname $BASH_SOURCE`
 FOEDAG_PATH=`( cd "$SCRIPT_PATH" && pwd )`
 
 if [ -n "${LD_LIBRARY_PATH}" ]; then
-	export LD_LIBRARY_PATH=$FOEDAG_PATH/lib64/foedag/lib:$FOEDAG_PATH/lib64/tbb:$FOEDAG_PATH/lib/tbb:$FOEDAG_PATH/lib64:$FOEDAG_PATH/lib:$FOEDAG_PATH/lib/foedag/lib:$FOEDAG_PATH/bin/gtkwave/lib:$FOEDAG_PATH/external_libs/qt/lib:$FOEDAG_PATH/external_libs/lib:$LD_LIBRARY_PATH
+	export LD_LIBRARY_PATH=$FOEDAG_PATH/lib64/foedag/lib:$FOEDAG_PATH/lib64/openssl:$FOEDAG_PATH/lib64/tbb:$FOEDAG_PATH/lib/tbb:$FOEDAG_PATH/lib64:$FOEDAG_PATH/lib:$FOEDAG_PATH/lib/foedag/lib:$FOEDAG_PATH/bin/gtkwave/lib:$FOEDAG_PATH/external_libs/qt/lib:$FOEDAG_PATH/external_libs/lib:$LD_LIBRARY_PATH
 else
-	export LD_LIBRARY_PATH=$FOEDAG_PATH/lib64/foedag/lib:$FOEDAG_PATH/lib64/tbb:$FOEDAG_PATH/lib/tbb:$FOEDAG_PATH/lib64:$FOEDAG_PATH/lib:$FOEDAG_PATH/lib/foedag/lib:$FOEDAG_PATH/bin/gtkwave/lib:$FOEDAG_PATH/external_libs/qt/lib:$FOEDAG_PATH/external_libs/lib
+	export LD_LIBRARY_PATH=$FOEDAG_PATH/lib64/foedag/lib:$FOEDAG_PATH/lib64/openssl:$FOEDAG_PATH/lib64/tbb:$FOEDAG_PATH/lib/tbb:$FOEDAG_PATH/lib64:$FOEDAG_PATH/lib:$FOEDAG_PATH/lib/foedag/lib:$FOEDAG_PATH/bin/gtkwave/lib:$FOEDAG_PATH/external_libs/qt/lib:$FOEDAG_PATH/external_libs/lib
 fi
 
 if [ -n "${TCL_LIBRARY}" ]; then

--- a/third_party/openssl_cmake/CMakeLists.txt
+++ b/third_party/openssl_cmake/CMakeLists.txt
@@ -98,28 +98,25 @@ add_custom_target(
 )
 
 if(UNIX AND CMAKE_SYSTEM_NAME MATCHES "Linux")
-add_custom_command(TARGET openssl_build POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${OPENSSL_SRC_DIR}/libcrypto.so.3 ${CMAKE_BINARY_DIR}/lib
-    COMMAND ${CMAKE_COMMAND} -E create_symlink libcrypto.so.3 libcrypto.so	
-    COMMAND ${CMAKE_COMMAND} -E copy ${OPENSSL_SRC_DIR}/libssl.so.3 ${CMAKE_BINARY_DIR}/lib
-    COMMAND ${CMAKE_COMMAND} -E create_symlink libssl.so.3  libssl.so
-    COMMENT "Copying lib ssl and crypto after building the OpenSSL"
-           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+	add_custom_command(TARGET openssl_build POST_BUILD
+    		COMMAND ${CMAKE_COMMAND} -E make_directory  ${CMAKE_BINARY_DIR}/lib/openssl
+	)
 
-)
+	add_custom_command(TARGET openssl_build POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy ${OPENSSL_SRC_DIR}/libcrypto.so.3 ${CMAKE_BINARY_DIR}/lib/openssl
+		COMMAND ${CMAKE_COMMAND} -E create_symlink libcrypto.so.3 libcrypto.so	
+		COMMAND ${CMAKE_COMMAND} -E copy ${OPENSSL_SRC_DIR}/libssl.so.3 ${CMAKE_BINARY_DIR}/lib/openssl
+		COMMAND ${CMAKE_COMMAND} -E create_symlink libssl.so.3  libssl.so
+		COMMENT "Copying lib ssl and crypto after building the OpenSSL"
+           			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib/openssl
+	)
 
-install(
-    PROGRAMS
-        ${CMAKE_BINARY_DIR}/lib/libcrypto.so.3
-	${CMAKE_BINARY_DIR}/lib/libssl.so.3
-    DESTINATION
-        ${CMAKE_INSTALL_LIBDIR}
-)
-
-
-install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink libssl.so.3  libssl.so WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})")
-
-install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink libcrypto.so.3 libcrypto.so WORKING_DIRECTORY  ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})")
+	install(
+		DIRECTORY
+        		${CMAKE_BINARY_DIR}/lib/openssl
+    		DESTINATION
+        		${CMAKE_INSTALL_LIBDIR}
+	)
 endif()
 
 


### PR DESCRIPTION
Place the OpenSSL libs in the build/lib/openssl folder so that at install time we can handle symbolic links easily. 