### PR TITLE
Fixed crash when no device specified

### DIFF
--- a/src/Main/CommandLine.cpp
+++ b/src/Main/CommandLine.cpp
@@ -99,7 +99,10 @@ void CommandLine::processArgs() {
       m_mute = true;
     } else if (token == "--device") {
       i++;
-      m_device = m_argv[i];
+      if (i < m_argc)
+        m_device = m_argv[i];
+      else
+        ErrorAndExit("Specify a device");
     } else {
       std::cout << "ERROR Unknown command line option: " << m_argv[i]
                 << std::endl;


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed crash when `--device` argument is missing for command line

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
