### PR TITLE
Update reports for BRAM and DSP

### DIFF
--- a/src/Compiler/Reports/AbstractReportManager.cpp
+++ b/src/Compiler/Reports/AbstractReportManager.cpp
@@ -3,7 +3,6 @@
 #include <QFile>
 #include <QRegularExpression>
 #include <QTextStream>
-#include <set>
 
 #include "Compiler/TaskManager.h"
 #include "NewProject/ProjectManager/project.h"
@@ -238,12 +237,12 @@ IDataReport::TableData AbstractReportManager::CreateBramData() const {
   bramData.push_back({"BRAM", QString::number(usedBram),
                       QString::number(availBram), QString::number(result)});
 
-  // TODO not supported yet
-  //  result = (aBram.bram_18k == 0) ? 0 : uBram.bram_18k * 100 /
-  //  aBram.bram_18k; bramData.push_back({SPACE + "18k",
-  //  QString::number(uBram.bram_18k),
-  //                      QString::number(aBram.bram_18k),
-  //                      QString::number(result)});
+  if (supportBram18k()) {
+    result = (aBram.bram_18k == 0) ? 0 : uBram.bram_18k * 100 / aBram.bram_18k;
+    bramData.push_back({SPACE + "18k", QString::number(uBram.bram_18k),
+                        QString::number(aBram.bram_18k),
+                        QString::number(result)});
+  }
 
   result = (aBram.bram_36k == 0) ? 0 : uBram.bram_36k * 100 / aBram.bram_36k;
   bramData.push_back({SPACE + "36k", QString::number(uBram.bram_36k),
@@ -265,9 +264,12 @@ IDataReport::TableData AbstractReportManager::CreateDspData() const {
   dspData.push_back({"DSP Block", QString::number(usedDsp),
                      QString::number(availDsp), QString::number(result)});
 
-  result = (aDsp.dsp_9_10 == 0) ? 0 : uDsp.dsp_9_10 * 100 / aDsp.dsp_9_10;
-  dspData.push_back({SPACE + "9x10", QString::number(uDsp.dsp_9_10),
-                     QString::number(aDsp.dsp_9_10), QString::number(result)});
+  if (supportDsp9x10()) {
+    result = (aDsp.dsp_9_10 == 0) ? 0 : uDsp.dsp_9_10 * 100 / aDsp.dsp_9_10;
+    dspData.push_back({SPACE + "9x10", QString::number(uDsp.dsp_9_10),
+                       QString::number(aDsp.dsp_9_10),
+                       QString::number(result)});
+  }
 
   result = (aDsp.dsp_18_20 == 0)
                ? 0
@@ -758,5 +760,9 @@ void AbstractReportManager::clean() {
   m_usedRes = {};
   m_clocksIntra.clear();
 }
+
+bool AbstractReportManager::supportBram18k() const { return false; }
+
+bool AbstractReportManager::supportDsp9x10() const { return false; }
 
 }  // namespace FOEDAG

--- a/src/Compiler/Reports/AbstractReportManager.h
+++ b/src/Compiler/Reports/AbstractReportManager.h
@@ -59,6 +59,8 @@ class AbstractReportManager : public ITaskReportManager {
   // Fills parsed data into 'm_resourceColumns' and 'm_resourceData'
   virtual std::filesystem::path logFile() const = 0;
   virtual void clean();
+  virtual bool supportBram18k() const;
+  virtual bool supportDsp9x10() const;
   void parseResourceUsage(QTextStream &in, int &lineNr);
   void designStatistics();
 

--- a/src/Compiler/Reports/SynthesisReportManager.cpp
+++ b/src/Compiler/Reports/SynthesisReportManager.cpp
@@ -73,6 +73,34 @@ void SynthesisReportManager::parseLogLine(const QString &line) {
     m_usedRes.logic.lut5 = lutMatch.captured(1).toUInt();
     return;
   }
+  static const QRegularExpression bram36k{"^ +TDP_RAM36K\\D+(\\d+)",
+                                          QRegularExpression::MultilineOption};
+  auto bram36kMatch = bram36k.match(line);
+  if (bram36kMatch.hasMatch()) {
+    m_usedRes.bram.bram_36k = bram36kMatch.captured(1).toUInt();
+    return;
+  }
+  static const QRegularExpression bram18k{"^ +TDP_RAM18KX2\\D+(\\d+)",
+                                          QRegularExpression::MultilineOption};
+  auto bram18kMatch = bram18k.match(line);
+  if (bram18kMatch.hasMatch()) {
+    m_usedRes.bram.bram_18k = bram18kMatch.captured(1).toUInt();
+    return;
+  }
+  static const QRegularExpression dsp_18_20{
+      "^ +DSP38\\D+(\\d+)", QRegularExpression::MultilineOption};
+  auto dsp_18_20Match = dsp_18_20.match(line);
+  if (dsp_18_20Match.hasMatch()) {
+    m_usedRes.dsp.dsp_18_20 += dsp_18_20Match.captured(1).toUInt();
+    return;
+  }
+  static const QRegularExpression dsp_9_10{"^ +DSP19X2\\D+(\\d+)",
+                                           QRegularExpression::MultilineOption};
+  auto dsp_9_10Match = dsp_9_10.match(line);
+  if (dsp_9_10Match.hasMatch()) {
+    m_usedRes.dsp.dsp_9_10 = dsp_9_10Match.captured(1).toUInt();
+    return;
+  }
 }
 
 QStringList SynthesisReportManager::getAvailableReportIds() const {
@@ -211,6 +239,7 @@ void SynthesisReportManager::parseLogFile() {
       }
     } else if (line.contains(STATISTIC_SECTION)) {
       m_usedRes.dsp = DSP{};
+      m_usedRes.bram = Bram{};
       m_usedRes.logic.dff = 0;
       lineNr = parseStatisticsSection(in, lineNr);
     } else if (line.startsWith(INTRA_DOMAIN_PATH_DELAYS_SECTION)) {
@@ -232,6 +261,10 @@ void SynthesisReportManager::parseLogFile() {
   setFileTimeStamp(this->logFile());
   emit logFileParsed();
 }
+
+bool SynthesisReportManager::supportBram18k() const { return true; }
+
+bool SynthesisReportManager::supportDsp9x10() const { return true; }
 
 QString SynthesisReportManager::getTimingLogFileName() const {
   // Current synthesis log implementation doesn't contain timing info

--- a/src/Compiler/Reports/SynthesisReportManager.h
+++ b/src/Compiler/Reports/SynthesisReportManager.h
@@ -54,6 +54,8 @@ class SynthesisReportManager final : public AbstractReportManager {
   // Go through the log file and fills internal data collections (stats,
   // messages)
   void parseLogFile() override;
+  bool supportBram18k() const override;
+  bool supportDsp9x10() const override;
 
   // Retrieves maximum and average levels out of given line and fills into stats
   void fillLevels(const QString &line, IDataReport::TableData &stats) const;


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: EDA-2511
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Update reports for BRAM and DSP:
* Change keywords for synthesis
* Hide DSP block 9x10 for non synthesis compilation steps.
* Show BRAM 18k for synthesis only

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/0ba8683e-5f2a-40c5-9b49-c1690a6834e6)

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
