### PR TITLE
Restore the Netlist flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 320)
+set(VERSION_PATCH 321)
 
 option(
   WITH_LIBCXX

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -2777,6 +2777,9 @@ std::string Compiler::GetNetlistPath() const {
   for (const auto& lang_file : ProjManager()->DesignFiles()) {
     switch (lang_file.first.language) {
       case Design::Language::VERILOG_NETLIST:
+        netlistFile = ProjManager()->projectName() + "_post_synth.eblif";
+        netlistFile = FilePath(Action::Synthesis, netlistFile).string();
+        break;
       case Design::Language::BLIF:
       case Design::Language::EBLIF: {
         netlistFile = lang_file.second;


### PR DESCRIPTION
Restore the Netlist compilation flow.
The new Netlist compilation flow looks like the following in a raptor.tcl project:
```
# Gate level netlist input example

# Specifc project type "gate-level"
create_design AES_DECRYPT_GATE -type gate-level

target_device 1VG28

# Specific command to load a netlist file
read_netlist aes_decrypt.v

add_constraint_file aes_decrypt_gate.sdc

# Analyze the Verilog netlist (Hierarchy)
analyze 

# MUST: Synthesis only converts Verilog to Eblif for VPR (No optimization)
synthesize

packing
place
route
sta
power
bitstream
```