### PR TITLE
Commented the section of setting verilator root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 334)
+set(VERSION_PATCH 335)
 
 option(
   WITH_LIBCXX

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -923,10 +923,12 @@ std::string Simulator::SimulationFileList(SimulationType action,
 
 int Simulator::SimulationJob(SimulationType simulation, SimulatorType type,
                              const std::string& fileList) {
+  /*  // This is depricated.
   if (type == SimulatorType::Verilator) {
     std::string verilator_home = SimulatorExecPath(type).parent_path().string();
     m_compiler->SetEnvironmentVariable("VERILATOR_ROOT", verilator_home);
   }
+  */
   ProcessUtilization summaryUtils{};
   auto appendSumUtils = [&summaryUtils](const ProcessUtilization& utils) {
     summaryUtils.duration += utils.duration;


### PR DESCRIPTION
Now Verilator supports the relocation of binaries so no longer a need to set the VERILATOR_ROOT environment variable before invoking the verilator.