### PR TITLE
Allow user to create custom device based off the existing ones

### DIFF
--- a/etc/devices/custom_layout_template.xml
+++ b/etc/devices/custom_layout_template.xml
@@ -1,0 +1,17 @@
+<fixed_layout name="${NAME}" width="${WIDTH}" height="${HEIGHT}">
+      <row type="io_top" starty="H-2" priority="90"/>
+      <row type="io_bottom" starty="1" priority="91"/>
+      <col type="io_right" startx="W-2" priority="92"/>
+      <col type="io_left" startx="1" priority="93"/>
+      <corners type="EMPTY" priority="100"/>
+      <row type="EMPTY" starty="H-1" priority="101"/>
+      <col type="EMPTY" startx="W-1" priority="102"/>
+      <row type="EMPTY" starty="0" priority="103"/>
+      <col type="EMPTY" startx="0" priority="104"/>
+      <!--Default to clb-->
+      <fill type="clb" priority="10"/>
+      <!--Insert DSP column(s)-->
+      <!--template_dsp:      <col type="dsp" startx="${STARTX}" starty="2" priority="20"/>-->
+      <!--Insert BRAM column(s)-->
+      <!--template_bram:      <col type="bram" startx="${STARTX}" starty="2" priority="20"/>-->
+</fixed_layout>

--- a/src/Compiler/CompilerOpenFPGA.h
+++ b/src/Compiler/CompilerOpenFPGA.h
@@ -156,7 +156,9 @@ class CompilerOpenFPGA : public Compiler {
   virtual bool GenerateBitstream();
   virtual bool LoadDeviceData(const std::string& deviceName);
   virtual bool LoadDeviceData(const std::string& deviceName,
-                              const std::filesystem::path& deviceListFile);
+                              const std::filesystem::path& deviceListFile,
+                              const std::filesystem::path& devicesBase,
+                              bool& deviceFound);
   virtual bool LicenseDevice(const std::string& deviceName);
   virtual bool DesignChanged(const std::string& synth_script,
                              const std::filesystem::path& synth_scrypt_path,
@@ -182,6 +184,7 @@ class CompilerOpenFPGA : public Compiler {
   bool DesignChangedForAnalysis(std::string& synth_script,
                                 std::filesystem::path& synth_scrypt_path,
                                 std::filesystem::path& outputFile);
+  void processCustomLayout();
   void RenamePostSynthesisFiles(Action action);
   std::filesystem::path m_yosysExecutablePath = "yosys";
   std::filesystem::path m_analyzeExecutablePath = "analyze";

--- a/src/Main/Foedag.cpp
+++ b/src/Main/Foedag.cpp
@@ -202,6 +202,7 @@ bool Foedag::initGui() {
   FOEDAG::TclInterpreter* interpreter =
       new FOEDAG::TclInterpreter(m_cmdLine->Argv()[0]);
   Config::Instance()->dataPath(m_context->DataPath());
+  Config::Instance()->executable(m_context->ExecutableName());
   FOEDAG::CommandStack* commands =
       new FOEDAG::CommandStack(interpreter, m_context->ExecutableName());
 

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -68,6 +68,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "NewFile/new_file.h"
 #include "NewProject/Main/registerNewProjectCommands.h"
 #include "NewProject/ProjectManager/DesignFileWatcher.h"
+#include "NewProject/ProjectManager/config.h"
 #include "NewProject/new_project_dialog.h"
 #include "PathEdit.h"
 #include "PinAssignment/PinAssignmentCreator.h"
@@ -126,8 +127,17 @@ void centerWidget(QWidget& widget) {
 }
 }  // namespace
 
+QString settingsFilePath() {
+  const std::filesystem::path userSpacePath =
+      Config::Instance()->userSpacePath();
+  if (!userSpacePath.empty()) {
+    return QString::fromStdString((userSpacePath / "settings").string());
+  }
+  return QString{"settings"};
+}
+
 MainWindow::MainWindow(Session* session)
-    : m_session(session), m_settings("settings", QSettings::IniFormat) {
+    : m_session(session), m_settings(settingsFilePath(), QSettings::IniFormat) {
 #ifdef USE_MONACO_EDITOR
   /*
   ref:

--- a/src/NewProject/CMakeLists.txt
+++ b/src/NewProject/CMakeLists.txt
@@ -42,6 +42,8 @@ set (SRC_CPP_LIST
   ProjectManager/DesignFileWatcher.cpp
   newprojectmodel.cpp
   add_sim_form.cpp
+  CustomLayout.cpp
+  CustomLayoutBuilder.cpp
 )
 
 set (SRC_H_LIST
@@ -68,6 +70,8 @@ set (SRC_H_LIST
   newprojectmodel.h
   SettingsGuiInterface.h
   add_sim_form.h
+  CustomLayout.h
+  CustomLayoutBuilder.h
 )
 
 set (SRC_UI_LIST
@@ -80,6 +84,7 @@ set (SRC_UI_LIST
   summary_form.ui
   create_file_dialog.ui
   add_sim_form.ui
+  CustomLayout.ui
 )
 
 add_library(newproject STATIC

--- a/src/NewProject/CustomLayout.cpp
+++ b/src/NewProject/CustomLayout.cpp
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "CustomLayout.h"
+
+#include <QToolTip>
+
+#include "ui_CustomLayout.h"
+
+namespace FOEDAG {
+
+CustomLayout::CustomLayout(const QStringList &baseDevices,
+                           const QStringList &allDevices, QWidget *parent)
+    : QDialog(parent), ui(new Ui::CustomLayout) {
+  ui->setupUi(this);
+  setWindowTitle("Create new device...");
+  ui->comboBox->insertItems(0, baseDevices);
+  QRegularExpression numberCommaSeparated{"([0-8]+,)+"};
+  ui->lineEditDsp->setValidator(
+      new QRegularExpressionValidator{numberCommaSeparated});
+  ui->lineEditBram->setValidator(
+      new QRegularExpressionValidator{numberCommaSeparated});
+  connect(ui->buttonBox, &QDialogButtonBox::rejected, this,
+          &CustomLayout::close);
+  connect(
+      ui->buttonBox, &QDialogButtonBox::accepted, this, [this, allDevices]() {
+        if (ui->lineEditName->text().isEmpty()) {
+          QToolTip::showText(ui->lineEditName->mapToGlobal(QPoint(0, 0)),
+                             "Please specify name", ui->lineEditName);
+          return;
+        }
+        if (allDevices.contains(ui->lineEditName->text())) {
+          QToolTip::showText(ui->lineEditName->mapToGlobal(QPoint(0, 0)),
+                             "This name is already used, please choose another",
+                             ui->lineEditName);
+          return;
+        }
+        if (ui->spinBoxWidth->value() == 0) {
+          QToolTip::showText(ui->spinBoxWidth->mapToGlobal(QPoint(0, 0)),
+                             "Please specify Width", this);
+          return;
+        }
+        if (ui->spinBoxHeight->value() == 0) {
+          QToolTip::showText(ui->spinBoxHeight->mapToGlobal(QPoint(0, 0)),
+                             "Please specify Height", this);
+          return;
+        }
+        emit sendCustomLayoutData(
+            {ui->comboBox->currentText(), ui->lineEditName->text(),
+             ui->spinBoxWidth->value(), ui->spinBoxHeight->value(),
+             ui->lineEditBram->text(), ui->lineEditDsp->text()});
+        close();
+      });
+}
+
+CustomLayout::~CustomLayout() { delete ui; }
+
+}  // namespace FOEDAG

--- a/src/NewProject/CustomLayout.h
+++ b/src/NewProject/CustomLayout.h
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <QDialog>
+
+#include "CustomLayoutBuilder.h"
+
+namespace Ui {
+class CustomLayout;
+}
+
+namespace FOEDAG {
+
+class CustomLayout : public QDialog {
+  Q_OBJECT
+
+ public:
+  explicit CustomLayout(const QStringList &baseDevices,
+                        const QStringList &allDevices,
+                        QWidget *parent = nullptr);
+  ~CustomLayout() override;
+
+ signals:
+  void sendCustomLayoutData(FOEDAG::CustomLayoutData);
+
+ private:
+  Ui::CustomLayout *ui;
+};
+
+}  // namespace FOEDAG

--- a/src/NewProject/CustomLayout.ui
+++ b/src/NewProject/CustomLayout.ui
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CustomLayout</class>
+ <widget class="QWidget" name="CustomLayout">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>430</width>
+    <height>275</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Base device</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Device name</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEditName">
+       <property name="maxLength">
+        <number>50</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Width</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinBoxWidth"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Height</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinBoxHeight"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>List of DSP columns​</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEditDsp"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>List of BRAM columns​</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEditBram"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_6">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Note: Insert comma separated values for columns, e.g. 1,5,10​</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/NewProject/CustomLayoutBuilder.cpp
+++ b/src/NewProject/CustomLayoutBuilder.cpp
@@ -1,0 +1,157 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "CustomLayoutBuilder.h"
+
+#include <QDebug>
+#include <QDomDocument>
+#include <QFile>
+
+namespace FOEDAG {
+
+CustomLayoutBuilder::CustomLayoutBuilder(const CustomLayoutData &data,
+                                         const QString &templateLayout)
+    : m_data(data), m_templateLayout(templateLayout) {}
+
+std::pair<bool, QString> CustomLayoutBuilder::testTemplateFile() const {
+  QFile templateFile{m_templateLayout};
+  if (!templateFile.open(QFile::ReadOnly))
+    return {false,
+            QString{"Failed to open template layout %1"}.arg(m_templateLayout)};
+
+  return {true, {}};
+}
+
+std::pair<bool, QString> CustomLayoutBuilder::generateCustomLayout() const {
+  QFile templateFile{m_templateLayout};
+  if (!templateFile.open(QFile::ReadOnly)) {
+    return {false,
+            QString{"Failed to open template layout %1"}.arg(m_templateLayout)};
+  }
+  QStringList customLayout{};
+  auto buildLines = [](const QString &line, const QString &userInput,
+                       QStringList &customLayout) -> std::pair<bool, QString> {
+    auto separated = line.split(":");
+    if (separated.size() < 2)
+      return {false, QString{"Template file is corrupted"}};
+    QString templateLine = separated.at(1);
+    templateLine = templateLine.mid(0, templateLine.indexOf("/>") + 2);
+    auto columns = userInput.split(",", Qt::SkipEmptyParts);
+    for (const auto &startx : columns) {
+      QString newLine = templateLine;
+      newLine.replace("${STARTX}", startx);
+      customLayout.append(newLine + "\n");
+    }
+    return {true, QString{}};
+  };
+  while (!templateFile.atEnd()) {
+    QString line = templateFile.readLine();
+    if (line.contains("${NAME}")) {
+      line.replace("${NAME}", m_data.name);
+      line.replace("${WIDTH}", QString::number(m_data.width));
+      line.replace("${HEIGHT}", QString::number(m_data.height));
+    }
+    if (line.contains("template_bram")) {
+      auto res = buildLines(line, m_data.bram, customLayout);
+      if (!res.first) return res;
+    } else if (line.contains("template_dsp")) {
+      auto res = buildLines(line, m_data.dsp, customLayout);
+      if (!res.first) return res;
+    } else {
+      customLayout.append(line);
+    }
+  }
+
+  return {true, customLayout.join("")};
+}
+
+std::pair<bool, QString> CustomLayoutBuilder::generateNewDevice(
+    const QString &deviceXml, const QString &targetDeviceXml,
+    const QString &baseDevice) const {
+  if (baseDevice.isEmpty()) return {false, "No device selected"};
+  QFile file(deviceXml);
+  if (!file.open(QFile::ReadOnly)) {
+    return {false, QString{"Cannot open device file: %1"}.arg(deviceXml)};
+  }
+  QDomDocument doc;
+  if (!doc.setContent(&file)) {
+    file.close();
+    return {false, QString{"Incorrect device file: %1"}.arg(deviceXml)};
+  }
+  file.close();
+
+  QDomElement docElement = doc.documentElement();
+  QDomNode node = docElement.firstChild();
+  while (!node.isNull()) {
+    if (node.isElement()) {
+      QDomElement e = node.toElement();
+
+      auto name = e.attribute("name");
+      if (name == baseDevice) {
+        QDomDocument newDoc{};
+        QFile targetDevice{targetDeviceXml};
+        if (!targetDevice.open(QFile::ReadWrite)) {
+          return {false, "Failed to open custom_device.xml"};
+        }
+        newDoc.setContent(&targetDevice);
+        QDomElement root = newDoc.firstChildElement("device_list");
+        if (root.isNull()) {  // new file
+          root = newDoc.createElement("device_list");
+          newDoc.appendChild(root);
+        }
+        auto copy = newDoc.importNode(node, true);
+        auto element = copy.toElement();
+        element.setAttribute("name", m_data.name);
+        auto deviceData = element.childNodes();
+        for (int i = 0; i < deviceData.count(); i++) {
+          if (deviceData.at(i).nodeName() == "internal") {
+            auto attr = deviceData.at(i).attributes();
+            auto type = attr.namedItem("type");
+            if (!type.isNull() && type.toAttr().value() == "device_size") {
+              auto name = attr.namedItem("name");
+              if (!name.isNull()) name.setNodeValue(m_data.name);
+              break;
+            }
+          }
+        }
+        QDomElement deviceElem = root.lastChildElement("device");
+        if (deviceElem.isNull()) {
+          root.appendChild(element);
+        } else {
+          root.insertAfter(element, deviceElem);
+        }
+        QTextStream stream;
+        targetDevice.resize(0);
+        stream.setDevice(&targetDevice);
+        newDoc.save(stream, 4);
+        file.close();
+        break;
+      }
+    }
+    node = node.nextSibling();
+  }
+  return {true, QString{}};
+}
+
+void CustomLayoutBuilder::setCustomLayoutData(const CustomLayoutData &data) {
+  m_data = data;
+}
+
+}  // namespace FOEDAG

--- a/src/NewProject/CustomLayoutBuilder.h
+++ b/src/NewProject/CustomLayoutBuilder.h
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <QString>
+
+namespace FOEDAG {
+
+struct CustomLayoutData {
+  QString baseName{};
+  QString name{};
+  int width{};
+  int height{};
+  QString bram{};
+  QString dsp{};
+};
+
+class CustomLayoutBuilder {
+ public:
+  CustomLayoutBuilder(const CustomLayoutData &data,
+                      const QString &templateLayout);
+  std::pair<bool, QString> testTemplateFile() const;
+  std::pair<bool, QString> generateCustomLayout() const;
+
+  std::pair<bool, QString> generateNewDevice(const QString &deviceXml,
+                                             const QString &targetDeviceXml,
+                                             const QString &baseDevice) const;
+
+  void setCustomLayoutData(const CustomLayoutData &data);
+
+ private:
+  CustomLayoutData m_data{};
+  QString m_templateLayout{};
+};
+
+}  // namespace FOEDAG

--- a/src/NewProject/ProjectManager/config.h
+++ b/src/NewProject/ProjectManager/config.h
@@ -14,7 +14,8 @@ class Config : public QObject {
  public:
   static Config *Instance();
 
-  int InitConfig(const QString &devicexml);
+  int InitConfigs(const QStringList &devicexmlList);
+  void clear();
   QStringList getDeviceItem() const;
   QStringList getSerieslist() const;
   QStringList getFamilylist(const QString &series) const;
@@ -23,16 +24,21 @@ class Config : public QObject {
   QList<QStringList> getDevicelist(QString series = "", QString family = "",
                                    QString package = "") const;
   void dataPath(const std::filesystem::path &path) { m_dataPath = path; }
-  std::filesystem::path dataPath() { return m_dataPath; }
+  std::filesystem::path dataPath() const { return m_dataPath; }
+  void executable(const std::string &exe);
+  std::filesystem::path userSpacePath() const;
+  std::filesystem::path layoutsPath() const;
 
  private:
-  QString m_device_xml = "";
+  QStringList m_device_xml{};
   QStringList m_lsit_device_item;
   QMap<QString, QMap<QString, QStringList>> m_map_device;
   QMap<QString, QStringList> m_map_device_info;
 
   void MakeDeviceMap(QString series, QString family, QString package);
+  int InitConfig(const QString &devicexml);
   std::filesystem::path m_dataPath;
+  std::string m_executable{};
 };
 }  // namespace FOEDAG
 #endif  // CONFIG_H

--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -1,7 +1,6 @@
 #include "project_manager.h"
 
 #include <QDir>
-#include <QDomDocument>
 #include <QFile>
 #include <QTextStream>
 #include <QTime>

--- a/src/NewProject/device_planner_form.h
+++ b/src/NewProject/device_planner_form.h
@@ -29,6 +29,8 @@ class devicePlannerForm : public QWidget, public SettingsGuiInterface {
   void onFamilytextChanged(const QString &arg1);
   void onPackagetextChanged(const QString &arg1);
 
+  void on_pushButtonCreate_clicked();
+
  private:
   Ui::devicePlannerForm *ui;
 
@@ -43,6 +45,7 @@ class devicePlannerForm : public QWidget, public SettingsGuiInterface {
   void UpdatePackageComboBox();
   void UpdateDeviceTableView();
   void UpdateSelection(const QModelIndex &index);
+  void init();
 };
 }  // namespace FOEDAG
 #endif  // DEVICEPLANNERFORM_H

--- a/src/NewProject/device_planner_form.ui
+++ b/src/NewProject/device_planner_form.ui
@@ -54,9 +54,9 @@
     </widget>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2" stretch="15,5,80">
+    <layout class="QVBoxLayout" name="verticalLayout_2" stretch="15,0,5,80">
      <property name="spacing">
-      <number>0</number>
+      <number>10</number>
      </property>
      <property name="topMargin">
       <number>10</number>
@@ -125,6 +125,43 @@
       </widget>
      </item>
      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="pushButtonCreate">
+         <property name="text">
+          <string>Create...</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../MainWindow/main_window_resource.qrc">
+           <normaloff>:/images/add-circle.png</normaloff>:/images/add-circle.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>18</width>
+           <height>18</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Available devices:</string>
@@ -145,6 +182,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../MainWindow/main_window_resource.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
- Allow user create new device for existed:
- The custom_device.xml stores the new devices and is saved under the home directory (~/.raptor or ~/.foedag). 
- The template added is based of https://github.com/neulink-semi/Raptor/blob/a17ca1fd79c8b675b1bd4b85422ec57a4f5cd634/etc/devices/gemini_compact_62x44/gemini_vpr.xml#L2819
- It is stored under the implementation subfolder of the project and VPR will pick it up automatically if the corresponding device is selected.
- We will have to create templates for each device separately in future.
- Currently, we don't support deletion of devices from the GUI although it's possible to delete it manually from the file mentioned above.
![image](https://github.com/os-fpga/FOEDAG/assets/6624470/5d75a3e2-2164-40da-a458-0e1a7ead7148)

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/a244feb0-a8bd-4afd-b207-8b668579fe33)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, newproject, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
