### PR TITLE
Add pin validation infra: prepare for IO_BUF_DS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 343)
+set(VERSION_PATCH 344)
 
 option(
   WITH_LIBCXX

--- a/src/Configuration/CFGCommon/CFGCommon.cpp
+++ b/src/Configuration/CFGCommon/CFGCommon.cpp
@@ -711,7 +711,7 @@ static void CFG_Python_get_result(PyObject* dict, const std::string& key,
   PyObject* value = PyDict_GetItemString(dict, key.c_str());
   if (value != nullptr) {
     if (PyBool_Check(value)) {
-      maps[key] = CFG_Python_OBJ((bool)(Py_Is(value, Py_True) != 0));
+      maps[key] = CFG_Python_OBJ(bool(value == Py_True));
     } else if (PyLong_Check(value)) {
       maps[key] = CFG_Python_OBJ((uint32_t)(PyLong_AsLong(value)));
     } else if (PyUnicode_Check(value)) {

--- a/src/Configuration/CFGCommon/CFGCommon.cpp
+++ b/src/Configuration/CFGCommon/CFGCommon.cpp
@@ -706,53 +706,256 @@ bool CFG_compare_two_binary_files(const std::string& filepath1,
          (data1.size() == 0 || memcmp(&data1[0], &data2[0], data1.size()) == 0);
 }
 
-static void CFG_Python_get_string(
-    PyObject* dict, const std::string& key,
-    std::map<std::string, std::string>& str_maps) {
+static void CFG_Python_get_result(PyObject* dict, const std::string& key,
+                                  std::map<std::string, CFG_Python_OBJ>& maps) {
   PyObject* value = PyDict_GetItemString(dict, key.c_str());
   if (value != nullptr) {
-    CFG_ASSERT_MSG(PyUnicode_Check(value),
-                   "Python Dict key=%s is expected to be string, but it is not",
-                   key.c_str());
-    str_maps[key] = std::string(PyUnicode_AsUTF8(value));
+    if (PyBool_Check(value)) {
+      maps[key] = CFG_Python_OBJ((bool)(Py_IsTrue(value) != 0));
+    } else if (PyLong_Check(value)) {
+      maps[key] = CFG_Python_OBJ((uint32_t)(PyLong_AsLong(value)));
+    } else if (PyUnicode_Check(value)) {
+      maps[key] = CFG_Python_OBJ((std::string)(PyUnicode_AsUTF8(value)));
+    } else if (PyByteArray_Check(value)) {
+      std::vector<uint8_t> bytes;
+      char* chars = PyByteArray_AsString(value);
+      for (auto i = 0; i < PyByteArray_Size(value); i++) {
+        bytes.push_back((uint8_t)(chars[i]));
+      }
+      maps[key] = CFG_Python_OBJ(bytes);
+    } else if (PyList_Check(value)) {
+      CFG_Python_OBJ::TYPE type = CFG_Python_OBJ::TYPE::UNKNOWN;
+      std::vector<uint32_t> ints;
+      std::vector<std::string> strs;
+      for (auto i = 0; i < PyList_Size(value); i++) {
+        PyObject* item = PyList_GetItem(value, i);
+        if (PyLong_Check(item)) {
+          CFG_ASSERT(type == CFG_Python_OBJ::TYPE::UNKNOWN ||
+                     type == CFG_Python_OBJ::TYPE::INTS);
+          type = CFG_Python_OBJ::TYPE::INTS;
+          ints.push_back((uint32_t)(PyLong_AsLong(item)));
+        } else if (PyUnicode_Check(item)) {
+          CFG_ASSERT(type == CFG_Python_OBJ::TYPE::UNKNOWN ||
+                     type == CFG_Python_OBJ::TYPE::STRS);
+          type = CFG_Python_OBJ::TYPE::STRS;
+          strs.push_back((std::string)(PyUnicode_AsUTF8(item)));
+        } else {
+          CFG_INTERNAL_ERROR("Unsupport Python Object \"%s\" type",
+                             key.c_str());
+        }
+      }
+      if (type == CFG_Python_OBJ::TYPE::INTS) {
+        maps[key] = CFG_Python_OBJ(ints);
+      } else if (type == CFG_Python_OBJ::TYPE::STRS) {
+        maps[key] = CFG_Python_OBJ(strs);
+      } else {
+        maps[key] = CFG_Python_OBJ(CFG_Python_OBJ::TYPE::ARRAY);
+      }
+    }
     // Py_DECREF(value);
   }
 }
 
-static void CFG_Python_get_u32(PyObject* dict, const std::string& key,
-                               std::map<std::string, uint32_t>& int_maps) {
-  PyObject* value = PyDict_GetItemString(dict, key.c_str());
-  if (value != nullptr) {
-    CFG_ASSERT_MSG(PyLong_Check(value),
-                   "Python Dict key=%s is expected to be long, but it is not",
-                   key.c_str());
-    int_maps[key] = (uint32_t)(PyLong_AsLong(value));
-    // Py_DECREF(value);
+std::map<std::string, CFG_Python_OBJ> CFG_Python(
+    std::vector<std::string> commands, std::vector<std::string> results,
+    void* dict_ptr) {
+  PyObject* dict = nullptr;
+  if (dict_ptr == nullptr) {
+    Py_Initialize();
+    dict = PyDict_New();
+  } else {
+    dict = static_cast<PyObject*>(dict_ptr);
   }
-}
-
-void CFG_Python(std::vector<std::string> commands,
-                std::vector<std::string> strs, std::vector<std::string> ints,
-                std::map<std::string, std::string>& str_maps,
-                std::map<std::string, uint32_t>& int_maps) {
-  Py_Initialize();
-  PyObject* dict = PyDict_New();
   PyObject* o = nullptr;
   for (auto& command : commands) {
 #if 0
     printf("Python Command: %s\n", command.c_str());
 #endif
     o = PyRun_String(command.c_str(), Py_single_input, dict, dict);
+    if (o != nullptr) {
+      Py_DECREF(o);
+    }
   }
-  for (auto key : strs) {
-    CFG_Python_get_string(dict, key, str_maps);
+  std::map<std::string, CFG_Python_OBJ> result_objs;
+  for (auto key : results) {
+    CFG_Python_get_result(dict, key, result_objs);
   }
-  for (auto key : ints) {
-    CFG_Python_get_u32(dict, key, int_maps);
+  if (dict_ptr == nullptr) {
+    Py_DECREF(dict);
+    Py_Finalize();
   }
-  if (o != nullptr) {
-    Py_DECREF(o);
+  return result_objs;
+}
+
+CFG_Python_OBJ::CFG_Python_OBJ(TYPE t)
+    : type(t), boolean(false), u32(0), str(""), bytes({}), u32s({}), strs({}) {}
+
+CFG_Python_OBJ::CFG_Python_OBJ(bool v)
+    : type(TYPE::BOOL),
+      boolean(v),
+      u32(0),
+      str(""),
+      bytes({}),
+      u32s({}),
+      strs({}) {}
+
+CFG_Python_OBJ::CFG_Python_OBJ(uint32_t v)
+    : type(TYPE::INT),
+      boolean(false),
+      u32(v),
+      str(""),
+      bytes({}),
+      u32s({}),
+      strs({}) {}
+
+CFG_Python_OBJ::CFG_Python_OBJ(std::string v)
+    : type(TYPE::STR),
+      boolean(false),
+      u32(0),
+      str(v),
+      bytes({}),
+      u32s({}),
+      strs({}) {}
+
+CFG_Python_OBJ::CFG_Python_OBJ(std::vector<uint8_t> v)
+    : type(TYPE::BYTES),
+      boolean(false),
+      u32(0),
+      str(""),
+      bytes(v),
+      u32s({}),
+      strs({}) {}
+
+CFG_Python_OBJ::CFG_Python_OBJ(std::vector<uint32_t> v)
+    : type(TYPE::INTS),
+      boolean(false),
+      u32(0),
+      str(""),
+      bytes({}),
+      u32s(v),
+      strs({}) {}
+
+CFG_Python_OBJ::CFG_Python_OBJ(std::vector<std::string> v)
+    : type(TYPE::STRS),
+      boolean(false),
+      u32(0),
+      str(""),
+      bytes({}),
+      u32s({}),
+      strs(v) {}
+
+bool CFG_Python_OBJ::get_bool(const std::string& name) {
+  CFG_ASSERT_MSG(
+      type == TYPE::BOOL,
+      "Expect Python Object \"%s\" to be type bool, but it is type %d",
+      name.c_str(), type);
+  return boolean;
+}
+
+uint32_t CFG_Python_OBJ::get_u32(const std::string& name) {
+  CFG_ASSERT_MSG(
+      type == TYPE::INT,
+      "Expect Python Object \"%s\" to be type uint32_t, but it is type %d",
+      name.c_str(), type);
+  return u32;
+}
+
+std::string CFG_Python_OBJ::get_str(const std::string& name) {
+  CFG_ASSERT_MSG(
+      type == TYPE::STR,
+      "Expect Python Object \"%s\" to be type string, but it is type %d",
+      name.c_str(), type);
+  return str;
+}
+
+std::vector<uint8_t> CFG_Python_OBJ::get_bytes(const std::string& name) {
+  CFG_ASSERT_MSG(
+      type == TYPE::BYTES,
+      "Expect Python Object \"%s\" to be type bytes, but it is type %d",
+      name.c_str(), type);
+  return bytes;
+}
+
+std::vector<uint32_t> CFG_Python_OBJ::get_u32s(const std::string& name) {
+  CFG_ASSERT_MSG(
+      type == TYPE::INTS,
+      "Expect Python Object \"%s\" to be type uint32_t(s), but it is type %d",
+      name.c_str(), type);
+  return u32s;
+}
+
+std::vector<std::string> CFG_Python_OBJ::get_strs(const std::string& name) {
+  CFG_ASSERT_MSG(
+      type == TYPE::STRS,
+      "Expect Python Object \"%s\" to be type string(s), but it is type %d",
+      name.c_str(), type);
+  return strs;
+}
+
+CFG_Python_MGR::CFG_Python_MGR() {
+  Py_Initialize();
+  PyObject* dict = PyDict_New();
+  dict_ptr = dict;
+}
+
+CFG_Python_MGR::~CFG_Python_MGR() {
+  if (dict_ptr != nullptr) {
+    PyObject* dict = static_cast<PyObject*>(dict_ptr);
+    Py_DECREF(dict);
+    dict_ptr = nullptr;
   }
-  Py_DECREF(dict);
   Py_Finalize();
+}
+
+void CFG_Python_MGR::run(std::vector<std::string> commands,
+                         std::vector<std::string> results) {
+  CFG_ASSERT(dict_ptr != nullptr);
+  result_objs = CFG_Python(commands, results, dict_ptr);
+}
+
+const std::map<std::string, CFG_Python_OBJ>& CFG_Python_MGR::results() {
+  return result_objs;
+}
+
+bool CFG_Python_MGR::result_bool(const std::string& result) {
+  CFG_ASSERT_MSG(result_objs.find(result) != result_objs.end(),
+                 "Result \"%s\" does not exists in Python Object Map",
+                 result.c_str());
+  return result_objs.at(result).get_bool(result);
+}
+
+uint32_t CFG_Python_MGR::result_u32(const std::string& result) {
+  CFG_ASSERT_MSG(result_objs.find(result) != result_objs.end(),
+                 "Result \"%s\" does not exists in Python Object Map",
+                 result.c_str());
+  return result_objs.at(result).get_u32(result);
+}
+
+std::string CFG_Python_MGR::result_str(const std::string& result) {
+  CFG_ASSERT_MSG(result_objs.find(result) != result_objs.end(),
+                 "Result \"%s\" does not exists in Python Object Map",
+                 result.c_str());
+  return result_objs.at(result).get_str(result);
+}
+
+std::vector<uint8_t> CFG_Python_MGR::result_bytes(const std::string& result) {
+  CFG_ASSERT_MSG(result_objs.find(result) != result_objs.end(),
+                 "Result \"%s\" does not exists in Python Object Map",
+                 result.c_str());
+  return result_objs.at(result).get_bytes(result);
+}
+
+std::vector<uint32_t> CFG_Python_MGR::result_u32s(const std::string& result) {
+  CFG_ASSERT_MSG(result_objs.find(result) != result_objs.end(),
+                 "Result \"%s\" does not exists in Python Object Map",
+                 result.c_str());
+  return result_objs.at(result).get_u32s(result);
+}
+
+std::vector<std::string> CFG_Python_MGR::result_strs(
+    const std::string& result) {
+  CFG_ASSERT_MSG(result_objs.find(result) != result_objs.end(),
+                 "Result \"%s\" does not exists in Python Object Map",
+                 result.c_str());
+  return result_objs.at(result).get_strs(result);
 }

--- a/src/Configuration/CFGCommon/CFGCommon.cpp
+++ b/src/Configuration/CFGCommon/CFGCommon.cpp
@@ -711,7 +711,7 @@ static void CFG_Python_get_result(PyObject* dict, const std::string& key,
   PyObject* value = PyDict_GetItemString(dict, key.c_str());
   if (value != nullptr) {
     if (PyBool_Check(value)) {
-      maps[key] = CFG_Python_OBJ((bool)(Py_IsTrue(value) != 0));
+      maps[key] = CFG_Python_OBJ((bool)(Py_Is(value, Py_True) != 0));
     } else if (PyLong_Check(value)) {
       maps[key] = CFG_Python_OBJ((uint32_t)(PyLong_AsLong(value)));
     } else if (PyUnicode_Check(value)) {

--- a/src/Configuration/CFGCommon/CFGCommon.h
+++ b/src/Configuration/CFGCommon/CFGCommon.h
@@ -53,6 +53,50 @@ struct CFGCommon_ARG {
   std::vector<std::string> raws;
 };
 
+struct CFG_Python_OBJ {
+  enum TYPE { BOOL, INT, STR, BYTES, INTS, STRS, UNKNOWN, ARRAY };
+  CFG_Python_OBJ(TYPE t = TYPE::UNKNOWN);
+  CFG_Python_OBJ(bool v);
+  CFG_Python_OBJ(uint32_t v);
+  CFG_Python_OBJ(std::string v);
+  CFG_Python_OBJ(std::vector<uint8_t> v);
+  CFG_Python_OBJ(std::vector<uint32_t> v);
+  CFG_Python_OBJ(std::vector<std::string> v);
+  bool get_bool(const std::string& name);
+  uint32_t get_u32(const std::string& name);
+  std::string get_str(const std::string& name);
+  std::vector<uint8_t> get_bytes(const std::string& name);
+  std::vector<uint32_t> get_u32s(const std::string& name);
+  std::vector<std::string> get_strs(const std::string& name);
+
+ private:
+  TYPE type = TYPE::UNKNOWN;
+  bool boolean = false;
+  uint32_t u32 = 0;
+  std::string str = "";
+  std::vector<uint8_t> bytes = {};
+  std::vector<uint32_t> u32s = {};
+  std::vector<std::string> strs = {};
+};
+
+class CFG_Python_MGR {
+ public:
+  CFG_Python_MGR();
+  ~CFG_Python_MGR();
+  void run(std::vector<std::string> commands, std::vector<std::string> results);
+  const std::map<std::string, CFG_Python_OBJ>& results();
+  bool result_bool(const std::string& result);
+  uint32_t result_u32(const std::string& result);
+  std::string result_str(const std::string& result);
+  std::vector<uint8_t> result_bytes(const std::string& result);
+  std::vector<uint32_t> result_u32s(const std::string& result);
+  std::vector<std::string> result_strs(const std::string& result);
+
+ private:
+  void* dict_ptr = nullptr;
+  std::map<std::string, CFG_Python_OBJ> result_objs;
+};
+
 std::string CFG_print(const char* format_string, ...);
 
 void CFG_assertion(const char* file, const char* func, size_t line,
@@ -194,10 +238,9 @@ bool CFG_compare_two_text_files(const std::string& filepath1,
 bool CFG_compare_two_binary_files(const std::string& filepath1,
                                   const std::string& filepath2);
 
-void CFG_Python(std::vector<std::string> commands,
-                std::vector<std::string> strs, std::vector<std::string> ints,
-                std::map<std::string, std::string>& str_maps,
-                std::map<std::string, uint32_t>& int_maps);
+std::map<std::string, CFG_Python_OBJ> CFG_Python(
+    std::vector<std::string> commands, std::vector<std::string> results,
+    void* dict_ptr = nullptr);
 
 #define CFG_POST_MSG(...) \
   { CFG_post_msg(CFG_print(__VA_ARGS__)); }

--- a/src/Configuration/ModelConfig/ModelConfig.h
+++ b/src/Configuration/ModelConfig/ModelConfig.h
@@ -22,6 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef MODEL_CONFIG_H
 #define MODEL_CONFIG_H
 
+#include <Configuration/CFGCommon/CFGCommon.h>
+
 #include <map>
 #include <string>
 #include <vector>
@@ -41,7 +43,8 @@ class ModelConfig_IO {
   static void gen_ppdb(CFGCommon_ARG* cmdarg,
                        const std::map<std::string, std::string>& options,
                        const std::string& output);
-  static void validate_instance(nlohmann::json& instance);
+  static void validate_instance(nlohmann::json& instance,
+                                bool is_final = false);
 
  private:
   static void assign_json_object(nlohmann::json& object, const std::string& key,
@@ -54,24 +57,37 @@ class ModelConfig_IO {
                                       nlohmann::json property_instances);
   static void locate_instances(nlohmann::json& instances);
   static void locate_instance(nlohmann::json& instance);
-  static void set_config_attributes(nlohmann::json& instances,
-                                    nlohmann::json mapping);
+  static void prepare_validate_location(
+      nlohmann::json mapping, std::map<std::string, std::string>& args,
+      CFG_Python_MGR& python);
+  static bool validate_location(const std::string& module,
+                                const std::string& name,
+                                nlohmann::json& linked_objects,
+                                nlohmann::json mapping,
+                                std::map<std::string, std::string>& args,
+                                CFG_Python_MGR& python);
+  static void set_config_attributes(
+      nlohmann::json& instances, nlohmann::json mapping,
+      std::map<std::string, std::string> global_agrs, CFG_Python_MGR& python);
   static void set_config_attribute(nlohmann::json& config_attributes,
                                    const std::string& module,
                                    nlohmann::json inputs,
                                    nlohmann::json mapping,
                                    std::map<std::string, std::string>& args,
-                                   nlohmann::json define);
+                                   nlohmann::json define,
+                                   CFG_Python_MGR& python);
   static void set_config_attribute(nlohmann::json& config_attributes,
                                    nlohmann::json inputs, nlohmann::json rules,
                                    nlohmann::json results,
                                    nlohmann::json neg_results,
                                    std::map<std::string, std::string>& args,
-                                   nlohmann::json define);
+                                   nlohmann::json define,
+                                   CFG_Python_MGR& python);
   static void set_config_attribute(nlohmann::json& config_attributes,
                                    nlohmann::json& results,
                                    std::map<std::string, std::string>& args,
-                                   nlohmann::json define);
+                                   nlohmann::json define,
+                                   CFG_Python_MGR& python);
   static void set_config_attribute(nlohmann::json& config_attributes,
                                    std::map<std::string, std::string>& args,
                                    nlohmann::json object, std::string key,
@@ -80,9 +96,18 @@ class ModelConfig_IO {
       nlohmann::json inputs, const std::string& input, nlohmann::json options,
       std::map<std::string, std::string>& args);
   static void define_args(nlohmann::json define,
-                          std::map<std::string, std::string>& args);
+                          std::map<std::string, std::string>& args,
+                          CFG_Python_MGR& python);
   static ARG_PROPERTY get_arg_info(std::string str, std::string& name,
                                    std::string& value);
+  static void write_json(nlohmann::json& instances, const std::string& file);
+  static void write_json_instance(nlohmann::json& instance,
+                                  std::ofstream& json);
+  static void write_json_map(nlohmann::json& map, std::ofstream& json,
+                             uint32_t space = 4);
+  static void write_json_object(uint32_t space, const std::string& key,
+                                const std::string& value, std::ofstream& json);
+  static void write_json_data(const std::string& str, std::ofstream& json);
 };
 
 }  // namespace FOEDAG

--- a/tests/unittest/ModelConfig/apis/config_attributes.mapping.json
+++ b/tests/unittest/ModelConfig/apis/config_attributes.mapping.json
@@ -121,15 +121,71 @@
       }
     }
   },
+  "__location_validation__" : {
+    "__once__" : {
+      "__args__" : [],
+      "__equation__" : [
+        "hp_banks = ['HP_%d' % i for i in [1, 2]]",
+        "hr_banks = ['HR_%d' % i for i in [1, 2, 3, 5]]",
+        "all_banks = hp_banks + hr_banks",
+        "pin_list = ['%d_%d%c' % (i, i//2, 'N' if i%2 else 'P') for i in range(40)]",
+        "cc_pin_list = ['%d_%d%c' % (i, i//2, 'N' if i%2 else 'P') for i in [10, 11, 28, 29]]",
+        "all_pins = ['%s_%s%s' % (i, 'CC_' if j in cc_pin_list else '', j) for i in all_banks for j in pin_list]",
+        "all_clock_pins = ['%s_CC_%s' % (i, j) for i in all_banks for j in cc_pin_list]"
+      ]
+    },
+    "__seqeunce__" : [
+      "__pin_is_valid__", 
+      "__clock_pin_is_valid__", 
+      "__pin_is_differential__"
+    ],
+    "__pin_is_valid__" : {
+      "__module__" : ["__all__"],
+      "__equation__" : [
+        "pin_result = '__location0__' in all_pins"
+      ]
+    },
+    "__clock_pin_is_valid__" : {
+      "__module__" : ["CLK_BUF"],
+      "__equation__" : [
+        "pin_result = '__location0__' in all_clock_pins"
+      ]
+    },
+    "__pin_is_differential__" : {
+      "__module__" : ["I_BUF_DS", "O_BUF_DS"],
+      "__equation__" : [
+        "import re",
+        "pin_result = '__location0__' in all_pins",
+        "pin_result = pin_result and '__location1__' in all_pins",
+        "m0 = re.search(r'H(P|R?)_(\\d?)(|_CC?)_(\\d+?)_(\\d\\d?)(P|N?)', '__location0__')",
+        "m1 = re.search(r'H(P|R?)_(\\d?)(|_CC?)_(\\d+?)_(\\d\\d?)(P|N?)', '__location1__')",
+        "pin_result = pin_result and m0 != None",
+        "pin_result = pin_result and m1 != None",
+        "pin_result = pin_result and len(m0.groups()) == 6",
+        "pin_result = pin_result and len(m1.groups()) == 6",
+        "pin_result = pin_result and m0.group(1) == m1.group(1)",
+        "pin_result = pin_result and m0.group(2) == m1.group(2)",
+        "pin_result = pin_result and m0.group(3) == m1.group(3)",
+        "pin_result = pin_result and m0.group(4) != m1.group(4)",
+        "pin_result = pin_result and m0.group(5) == m1.group(5)",
+        "pin_result = pin_result and m0.group(6) != m1.group(6)"
+      ]
+    }
+  },
   "__define__" : {
     "parse_location" : {
-      "__clkable__" : ["__clkable__='1' if ('__location__'.find('_CC_') != -1) else '0'"],
-      "__type__" : ["__type__='HP' if ('__location__'.find('HP_') == 0) else 'HV'"],
-      "__stype__" : ["__stype__='hp' if ('__location__'.find('HP_') == 0) else 'hv'"],
-      "__side__" : ["__side__='L' if ('__location__'.find('HR_1_') == 0 or '__location__'.find('HR_2_') == 0) else 'R'"],
-      "__pll_refmux_index__" : ["__pll_refmux_index__='0' if ('__location__'.find('HR_1_') == 0 or '__location__'.find('HR_2_') == 0) else '1'"],
-      "__bank__" : ["__bank__='0' if ('__location__'.find('HP_1_') == 0 or '__location__'.find('HR_1_') == 0 or '__location__'.find('HR_4_') == 0) else '1'"],
-      "__signal__" : ["__signal__='0' if ('__location__'.find('_10_5P') == (len('__location__') - 6)) else '1'"]
+      "__args__" : ["__clkable__", "__type__", "__stype__", "__side__", "__pll_refmux_index__", "__bank__"],
+      "__equation__" : [
+        "import re",
+        "assert '__location__' in all_pins",
+        "m = re.search(r'H(P|R?)_(\\d?)(|_CC?)_(\\d+?)_(\\d\\d?)(P|N?)', '__location__')",
+        "__clkable__ = '1' if m.group(3) == '_CC' else '0'",
+        "__type__ = 'HP' if m.group(1) == 'P' else 'HV'",
+        "__stype__ = __type__.lower()",
+        "__side__ = 'B' if m.group(1) == 'P' else ('L' if m.group(2) in ['1', '2'] else 'R')",
+        "__pll_refmux_index__ = '0' if __side__ == 'L' else '1'",
+        "__bank__ = '0' if m.group(1) in ['0', '4'] else '1'"
+      ]
     }
   }
 }

--- a/tests/unittest/ModelConfig/golden/model_config.ppdb.json
+++ b/tests/unittest/ModelConfig/golden/model_config.ppdb.json
@@ -1,288 +1,345 @@
 {
-  "instances": [
+  "instances" : [
     {
-      "connectivity": {
-        "I": "clk0",
-        "O": "$iopadmap$clk0"
-      },
-      "linked_object": "clk0",
-      "linked_objects": {
-        "clk0": {
-          "config_attributes": [
+      "module" : "I_BUF",
+      "name" : "$iopadmap$top.clk0",
+      "linked_object" : "clk0",
+      "linked_objects" : {
+        "clk0" : {
+          "location" : "HP_2_CC_10_5P",
+          "properties" : {
+            "IOSTANDARD" : "LVCMOS_18_HP",
+            "PACKAGE_PIN" : "HP_2_CC_10_5P"
+          },
+          "config_attributes" : [
             {
-              "I_BUF": "WEAK_KEEPER==NONE"
+              "I_BUF" : "WEAK_KEEPER==NONE"
             },
             {
-              "I_BUF": "IOSTANDARD==LVCMOS_18_HP"
+              "I_BUF" : "IOSTANDARD==LVCMOS_18_HP"
             }
-          ],
-          "location": "HP_2_CC_10_5P",
-          "properties": {
-            "IOSTANDARD": "LVCMOS_18_HP",
-            "PACKAGE_PIN": "HP_2_CC_10_5P"
-          }
+          ]
         }
       },
-      "module": "I_BUF",
-      "name": "$iopadmap$top.clk0",
-      "parameters": {
-        "WEAK_KEEPER": "NONE"
+      "connectivity" : {
+        "I" : "clk0",
+        "O" : "$iopadmap$clk0"
+      },
+      "parameters" : {
+        "WEAK_KEEPER" : "NONE"
       }
     },
     {
-      "connectivity": {
-        "I": "$iopadmap$clk0",
-        "O": "$auto$clkbufmap.cc:262:execute$433"
-      },
-      "linked_object": "clk0",
-      "linked_objects": {
-        "clk0": {
-          "config_attributes": [],
-          "location": "HP_2_CC_10_5P",
-          "properties": {
-            "PACKAGE_PIN": "HP_2_CC_10_5P"
-          }
+      "module" : "WIRE",
+      "name" : "AUTO_CLK_BUF_clk0_#0",
+      "linked_object" : "clk0",
+      "linked_objects" : {
+        "clk0" : {
+          "location" : "HP_2_CC_10_5P",
+          "properties" : {
+            "PACKAGE_PIN" : "HP_2_CC_10_5P"
+          },
+          "config_attributes" : [
+          ]
         }
       },
-      "module": "WIRE",
-      "name": "AUTO_CLK_BUF_clk0_#0",
-      "parameters": {}
-    },
-    {
-      "connectivity": {
-        "I": "$auto$clkbufmap.cc:262:execute$433",
-        "O": "$auto$clkbufmap.cc:294:execute$434"
+      "connectivity" : {
+        "I" : "$iopadmap$clk0",
+        "O" : "$auto$clkbufmap.cc:262:execute$433"
       },
-      "linked_object": "clk0",
-      "linked_objects": {
-        "clk0": {
-          "config_attributes": [
-            {
-              "CLK_BUF": "FCLK_MUX_SRC==HP_2_CC_10_5P",
-              "__mapped_name__": "__parent__.u_gbox_fclk_mux_hp_all",
-              "__name__": "__parent__.__name__"
-            },
-            {
-              "CLK_BUF": "GBOX_TOP_SRC==DEFAULT"
-            },
-            {
-              "CLK_BUF": "PLL_REFMUX_SRC==HP_2_CC_10_5P",
-              "__mapped_name__": "u_GBOX_HP_40X2.u_gbox_pll_refmux_1",
-              "__name__": "__parent__.__name__"
-            },
-            {
-              "CLK_BUF": "ROOT_BANK_CLKMUX_SRC==HP_2_CC_10_5P",
-              "__mapped_name__": "__parent__.u_gbox_root_bank_clkmux_hp_1",
-              "__name__": "__parent__.__name__"
-            },
-            {
-              "CLK_BUF": "ROOT_MUX_SRC==HP_2_CC_10_5P",
-              "__mapped_name__": "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_0",
-              "__name__": "__parent__.__name__"
-            }
-          ],
-          "location": "HP_2_CC_10_5P",
-          "properties": {
-            "PACKAGE_PIN": "HP_2_CC_10_5P"
-          }
-        }
-      },
-      "module": "CLK_BUF",
-      "name": "$auto$clkbufmap.cc:261:execute$432",
-      "parameters": {}
-    },
-    {
-      "connectivity": {
-        "I": "clk1",
-        "O": "$iopadmap$clk1"
-      },
-      "linked_object": "clk1",
-      "linked_objects": {
-        "clk1": {
-          "config_attributes": [
-            {
-              "I_BUF": "WEAK_KEEPER==NONE"
-            },
-            {
-              "I_BUF": "IOSTANDARD==DEFAULT"
-            }
-          ],
-          "location": "HR_5_CC_28_14P",
-          "properties": {
-            "PACKAGE_PIN": "HR_5_CC_28_14P",
-            "ROUTE_TO_FABRIC_CLK": "1"
-          }
-        }
-      },
-      "module": "I_BUF",
-      "name": "$iopadmap$top.clk1",
-      "parameters": {
-        "WEAK_KEEPER": "NONE"
+      "parameters" : {
       }
     },
     {
-      "connectivity": {
-        "I": "$iopadmap$clk1",
-        "O": "$auto$clkbufmap.cc:262:execute$436"
-      },
-      "linked_object": "clk1",
-      "linked_objects": {
-        "clk1": {
-          "config_attributes": [],
-          "location": "HR_5_CC_28_14P",
-          "properties": {
-            "PACKAGE_PIN": "HR_5_CC_28_14P",
-            "ROUTE_TO_FABRIC_CLK": "1"
-          }
-        }
-      },
-      "module": "WIRE",
-      "name": "AUTO_CLK_BUF_clk1_#0",
-      "parameters": {}
-    },
-    {
-      "connectivity": {
-        "I": "$auto$clkbufmap.cc:262:execute$436",
-        "O": "$auto$clkbufmap.cc:294:execute$437"
-      },
-      "linked_object": "clk1",
-      "linked_objects": {
-        "clk1": {
-          "config_attributes": [
+      "module" : "CLK_BUF",
+      "name" : "$auto$clkbufmap.cc:261:execute$432",
+      "linked_object" : "clk0",
+      "linked_objects" : {
+        "clk0" : {
+          "location" : "HP_2_CC_10_5P",
+          "properties" : {
+            "PACKAGE_PIN" : "HP_2_CC_10_5P"
+          },
+          "config_attributes" : [
             {
-              "CLK_BUF": "FCLK_MUX_SRC==HR_5_CC_28_14P",
-              "__mapped_name__": "__parent__.u_gbox_fclk_mux_hv_all",
-              "__name__": "__parent__.__name__"
+              "CLK_BUF" : "FCLK_MUX_SRC==HP_2_CC_10_5P",
+              "__mapped_name__" : "__parent__.u_gbox_fclk_mux_hp_all",
+              "__name__" : "__parent__.__name__"
             },
             {
-              "CLK_BUF": "GBOX_TOP_SRC==DEFAULT"
+              "CLK_BUF" : "GBOX_TOP_SRC==DEFAULT"
             },
             {
-              "CLK_BUF": "PLL_REFMUX_SRC==HR_5_CC_28_14P",
-              "__mapped_name__": "u_GBOX_HP_40X2.u_gbox_pll_refmux_1",
-              "__name__": "__parent__.__name__"
+              "CLK_BUF" : "PLL_REFMUX_SRC==HP_2_CC_10_5P",
+              "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_pll_refmux_1",
+              "__name__" : "__parent__.__name__"
             },
             {
-              "CLK_BUF": "ROOT_BANK_CLKMUX_SRC==HR_5_CC_28_14P",
-              "__mapped_name__": "__parent__.u_gbox_root_bank_clkmux_hv_1",
-              "__name__": "__parent__.__name__"
+              "CLK_BUF" : "ROOT_BANK_CLKMUX_SRC==HP_2_CC_10_5P",
+              "__mapped_name__" : "__parent__.u_gbox_root_bank_clkmux_hp_1",
+              "__name__" : "__parent__.__name__"
             },
             {
-              "CLK_BUF": "ROOT_MUX_SRC==HR_5_CC_28_14P",
-              "__mapped_name__": "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_1",
-              "__name__": "__parent__.__name__"
+              "CLK_BUF" : "ROOT_MUX_SRC==HP_2_CC_10_5P",
+              "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_0",
+              "__name__" : "__parent__.__name__"
             }
-          ],
-          "location": "HR_5_CC_28_14P",
-          "properties": {
-            "PACKAGE_PIN": "HR_5_CC_28_14P",
-            "ROUTE_TO_FABRIC_CLK": "1"
-          }
+          ]
         }
       },
-      "module": "CLK_BUF",
-      "name": "$auto$clkbufmap.cc:261:execute$435",
-      "parameters": {}
-    },
-    {
-      "connectivity": {
-        "I": "din[0]",
-        "O": "$iopadmap$din[0]"
+      "connectivity" : {
+        "I" : "$auto$clkbufmap.cc:262:execute$433",
+        "O" : "$auto$clkbufmap.cc:294:execute$434"
       },
-      "linked_object": "din[0]",
-      "linked_objects": {
-        "din[0]": {
-          "config_attributes": [
-            {
-              "I_BUF": "WEAK_KEEPER==NONE"
-            },
-            {
-              "I_BUF": "IOSTANDARD==LVCMOS_18_HR"
-            }
-          ],
-          "location": "HR_2_6_3P",
-          "properties": {
-            "IOSTANDARD": "LVCMOS_18_HR",
-            "PACKAGE_PIN": "HR_2_6_3P"
-          }
-        }
-      },
-      "module": "I_BUF",
-      "name": "$iopadmap$top.din",
-      "parameters": {
-        "WEAK_KEEPER": "NONE"
+      "parameters" : {
       }
     },
     {
-      "connectivity": {
-        "I": "din[1]",
-        "O": "$iopadmap$din[1]"
-      },
-      "linked_object": "din[1]",
-      "linked_objects": {
-        "din[1]": {
-          "config_attributes": [
+      "module" : "I_BUF",
+      "name" : "$iopadmap$top.clk1",
+      "linked_object" : "clk1",
+      "linked_objects" : {
+        "clk1" : {
+          "location" : "HR_5_CC_28_14P",
+          "properties" : {
+            "PACKAGE_PIN" : "HR_5_CC_28_14P",
+            "ROUTE_TO_FABRIC_CLK" : "1"
+          },
+          "config_attributes" : [
             {
-              "I_BUF": "WEAK_KEEPER==NONE"
+              "I_BUF" : "WEAK_KEEPER==NONE"
             },
             {
-              "I_BUF": "IOSTANDARD==DEFAULT"
+              "I_BUF" : "IOSTANDARD==DEFAULT"
             }
-          ],
-          "location": "",
-          "properties": {}
+          ]
         }
       },
-      "module": "I_BUF",
-      "name": "$iopadmap$top.din_1",
-      "parameters": {
-        "WEAK_KEEPER": "NONE"
+      "connectivity" : {
+        "I" : "clk1",
+        "O" : "$iopadmap$clk1"
+      },
+      "parameters" : {
+        "WEAK_KEEPER" : "NONE"
       }
     },
     {
-      "connectivity": {
-        "I": "$iopadmap$dout[0]",
-        "O": "dout[0]"
-      },
-      "linked_object": "dout[0]",
-      "linked_objects": {
-        "dout[0]": {
-          "config_attributes": [
-            {
-              "O_BUF": "IOSTANDARD==LVCMOS_18_HR"
-            }
-          ],
-          "location": "HR_5_12_6P",
-          "properties": {
-            "IOSTANDARD": "LVCMOS_18_HR",
-            "PACKAGE_PIN": "HR_5_12_6P"
-          }
+      "module" : "WIRE",
+      "name" : "AUTO_CLK_BUF_clk1_#0",
+      "linked_object" : "clk1",
+      "linked_objects" : {
+        "clk1" : {
+          "location" : "HR_5_CC_28_14P",
+          "properties" : {
+            "PACKAGE_PIN" : "HR_5_CC_28_14P",
+            "ROUTE_TO_FABRIC_CLK" : "1"
+          },
+          "config_attributes" : [
+          ]
         }
       },
-      "module": "O_BUF",
-      "name": "$iopadmap$top.dout",
-      "parameters": {}
+      "connectivity" : {
+        "I" : "$iopadmap$clk1",
+        "O" : "$auto$clkbufmap.cc:262:execute$436"
+      },
+      "parameters" : {
+      }
     },
     {
-      "connectivity": {
-        "I": "$iopadmap$dout[1]",
-        "O": "dout[1]"
-      },
-      "linked_object": "dout[1]",
-      "linked_objects": {
-        "dout[1]": {
-          "config_attributes": [
+      "module" : "CLK_BUF",
+      "name" : "$auto$clkbufmap.cc:261:execute$435",
+      "linked_object" : "clk1",
+      "linked_objects" : {
+        "clk1" : {
+          "location" : "HR_5_CC_28_14P",
+          "properties" : {
+            "PACKAGE_PIN" : "HR_5_CC_28_14P",
+            "ROUTE_TO_FABRIC_CLK" : "1"
+          },
+          "config_attributes" : [
             {
-              "O_BUF": "IOSTANDARD==DEFAULT"
+              "CLK_BUF" : "FCLK_MUX_SRC==HR_5_CC_28_14P",
+              "__mapped_name__" : "__parent__.u_gbox_fclk_mux_hv_all",
+              "__name__" : "__parent__.__name__"
+            },
+            {
+              "CLK_BUF" : "GBOX_TOP_SRC==DEFAULT"
+            },
+            {
+              "CLK_BUF" : "PLL_REFMUX_SRC==HR_5_CC_28_14P",
+              "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_pll_refmux_1",
+              "__name__" : "__parent__.__name__"
+            },
+            {
+              "CLK_BUF" : "ROOT_BANK_CLKMUX_SRC==HR_5_CC_28_14P",
+              "__mapped_name__" : "__parent__.u_gbox_root_bank_clkmux_hv_1",
+              "__name__" : "__parent__.__name__"
+            },
+            {
+              "CLK_BUF" : "ROOT_MUX_SRC==HR_5_CC_28_14P",
+              "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_1",
+              "__name__" : "__parent__.__name__"
             }
-          ],
-          "location": "",
-          "properties": {}
+          ]
         }
       },
-      "module": "O_BUF",
-      "name": "$iopadmap$top.dout_1",
-      "parameters": {}
+      "connectivity" : {
+        "I" : "$auto$clkbufmap.cc:262:execute$436",
+        "O" : "$auto$clkbufmap.cc:294:execute$437"
+      },
+      "parameters" : {
+      }
+    },
+    {
+      "module" : "I_BUF",
+      "name" : "$iopadmap$top.din",
+      "linked_object" : "din[0]",
+      "linked_objects" : {
+        "din[0]" : {
+          "location" : "HR_2_6_3P",
+          "properties" : {
+            "IOSTANDARD" : "LVCMOS_18_HR",
+            "PACKAGE_PIN" : "HR_2_6_3P"
+          },
+          "config_attributes" : [
+            {
+              "I_BUF" : "WEAK_KEEPER==NONE"
+            },
+            {
+              "I_BUF" : "IOSTANDARD==LVCMOS_18_HR"
+            }
+          ]
+        }
+      },
+      "connectivity" : {
+        "I" : "din[0]",
+        "O" : "$iopadmap$din[0]"
+      },
+      "parameters" : {
+        "WEAK_KEEPER" : "NONE"
+      }
+    },
+    {
+      "module" : "I_BUF",
+      "name" : "$iopadmap$top.din_1",
+      "linked_object" : "din[1]",
+      "linked_objects" : {
+        "din[1]" : {
+          "location" : "",
+          "properties" : {
+          },
+          "config_attributes" : [
+          ]
+        }
+      },
+      "connectivity" : {
+        "I" : "din[1]",
+        "O" : "$iopadmap$din[1]"
+      },
+      "parameters" : {
+        "WEAK_KEEPER" : "NONE"
+      }
+    },
+    {
+      "module" : "O_BUF",
+      "name" : "$iopadmap$top.dout",
+      "linked_object" : "dout[0]",
+      "linked_objects" : {
+        "dout[0]" : {
+          "location" : "HR_5_12_6P",
+          "properties" : {
+            "IOSTANDARD" : "LVCMOS_18_HR",
+            "PACKAGE_PIN" : "HR_5_12_6P"
+          },
+          "config_attributes" : [
+            {
+              "O_BUF" : "IOSTANDARD==LVCMOS_18_HR"
+            }
+          ]
+        }
+      },
+      "connectivity" : {
+        "I" : "$iopadmap$dout[0]",
+        "O" : "dout[0]"
+      },
+      "parameters" : {
+      }
+    },
+    {
+      "module" : "O_BUF",
+      "name" : "$iopadmap$top.dout_1",
+      "linked_object" : "dout[1]",
+      "linked_objects" : {
+        "dout[1]" : {
+          "location" : "",
+          "properties" : {
+          },
+          "config_attributes" : [
+          ]
+        }
+      },
+      "connectivity" : {
+        "I" : "$iopadmap$dout[1]",
+        "O" : "dout[1]"
+      },
+      "parameters" : {
+      }
+    },
+    {
+      "module" : "I_BUF_DS",
+      "name" : "$iopadmap$top.i_buf_ds0",
+      "linked_object" : "inP0+inN0",
+      "linked_objects" : {
+        "inP0" : {
+          "location" : "HP_1_0_0P",
+          "properties" : {
+          },
+          "config_attributes" : [
+          ]
+        },
+        "inN0" : {
+          "location" : "HP_1_39_19N",
+          "properties" : {
+          },
+          "config_attributes" : [
+          ]
+        }
+      },
+      "connectivity" : {
+        "I_N" : "$iopadmap$inN0",
+        "I_P" : "$iopadmap$inP0",
+        "O" : "__internal__"
+      },
+      "parameters" : {
+      }
+    },
+    {
+      "module" : "I_BUF_DS",
+      "name" : "$iopadmap$top.i_buf_ds1",
+      "linked_object" : "inP1+inN1",
+      "linked_objects" : {
+        "inP1" : {
+          "location" : "HP_1_2_1P",
+          "properties" : {
+          },
+          "config_attributes" : [
+          ]
+        },
+        "inN1" : {
+          "location" : "HP_1_3_1N",
+          "properties" : {
+          },
+          "config_attributes" : [
+          ]
+        }
+      },
+      "connectivity" : {
+        "I_N" : "$iopadmap$inN1",
+        "I_P" : "$iopadmap$inP1",
+        "O" : "__internal__"
+      },
+      "parameters" : {
+      }
     }
   ]
 }

--- a/tests/unittest/ModelConfig/model_config_netlist.ppdb.json
+++ b/tests/unittest/ModelConfig/model_config_netlist.ppdb.json
@@ -221,6 +221,54 @@
       },
       "parameters" : {
       }
+    },
+    {
+      "module" : "I_BUF_DS",
+      "name" : "$iopadmap$top.i_buf_ds0",
+      "linked_object" : "inP0+inN0",
+      "linked_objects" : {
+        "inP0" : {
+          "location" : "HP_1_0_0P",
+          "properties" : {
+          }
+        },
+        "inN0" : {
+          "location" : "HP_1_39_19N",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "I_P" : "$iopadmap$inP0",
+        "I_N" : "$iopadmap$inN0",
+        "O" : "__internal__"
+      },
+      "parameters" : {
+      }
+    },
+    {
+      "module" : "I_BUF_DS",
+      "name" : "$iopadmap$top.i_buf_ds1",
+      "linked_object" : "inP1+inN1",
+      "linked_objects" : {
+        "inP1" : {
+          "location" : "HP_1_2_1P",
+          "properties" : {
+          }
+        },
+        "inN1" : {
+          "location" : "HP_1_3_1N",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "I_P" : "$iopadmap$inP1",
+        "I_N" : "$iopadmap$inN1",
+        "O" : "__internal__"
+      },
+      "parameters" : {
+      }
     }
   ]
 }


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
Add infrastructure to validate pin location.
   - For example in I_BUF_DS and O_BUF_DS case, the respective pad pin must be assigned as a pair
   - The unit test netlist PPDB is hand-crafted, but generated by yosys. 
   - This is because of issue https://rapidsilicon.atlassian.net/browse/EDA-2652. Once it is fixed, will retest

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [x] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [x] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
