### PR TITLE
For the custom device window, show device resources when user change any of fields

### DIFF
--- a/src/NewProject/CustomLayout.h
+++ b/src/NewProject/CustomLayout.h
@@ -46,6 +46,9 @@ class CustomLayout : public QDialog {
  signals:
   void sendCustomLayoutData(FOEDAG::CustomLayoutData);
 
+ private slots:
+  void updateRunTimeResources();
+
  private:
   Ui::CustomLayout *ui;
   QRegularExpressionValidator *m_validator{nullptr};

--- a/src/NewProject/CustomLayout.ui
+++ b/src/NewProject/CustomLayout.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>430</width>
-    <height>275</height>
+    <height>343</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -138,6 +138,128 @@
      <property name="alignment">
       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="tableWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+     <property name="cornerButtonEnabled">
+      <bool>false</bool>
+     </property>
+     <attribute name="horizontalHeaderCascadingSectionResizes">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="horizontalHeaderHighlightSections">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <row>
+      <property name="text">
+       <string/>
+      </property>
+     </row>
+     <column>
+      <property name="text">
+       <string>LUT</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>FF</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>BRAM</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>DSP</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Carry Length</string>
+      </property>
+     </column>
+     <item row="0" column="0">
+      <property name="text">
+       <string>0</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
+     <item row="0" column="1">
+      <property name="text">
+       <string>0</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
+     <item row="0" column="2">
+      <property name="text">
+       <string>0</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
+     <item row="0" column="3">
+      <property name="text">
+       <string>0</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+      <property name="flags">
+       <set>ItemIsEnabled</set>
+      </property>
+     </item>
+     <item row="0" column="4">
+      <property name="text">
+       <string>0</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </item>
     </widget>
    </item>
    <item>

--- a/src/NewProject/CustomLayoutBuilder.cpp
+++ b/src/NewProject/CustomLayoutBuilder.cpp
@@ -420,7 +420,7 @@ int CustomDeviceResources::carryLengthCount() const {
 }
 
 bool CustomDeviceResources::isValid() const {
-  return isHeightValid() && (lutsCount() >= 0) && (ffsCount() >= 0) &&
+  return isHeightValid() && (lutsCount() > 0) && (ffsCount() > 0) &&
          (dspCount() >= 0) && (bramCount() >= 0) && (carryLengthCount() >= 0);
 }
 

--- a/tests/TestGui/gui_new_project.tcl
+++ b/tests/TestGui/gui_new_project.tcl
@@ -34,7 +34,7 @@ puts "NEXT" ; flush stdout ; next
 puts "Create device" ; flush stdout ; createdevice
 
 sendData lineEditName $customDevice
-sendData spinBoxWidth 6
+sendData spinBoxWidth 7
 sendData spinBoxHeight 5
 sendData lineEditDsp 1,2
 sendData lineEditBram 2,3
@@ -50,7 +50,7 @@ EXPECT_EQ $customDevice $modifyDeviceName
 
 set spinBoxWidth [qt_getWidget spinBoxWidth]
 set width [qt_getWidgetData $spinBoxWidth]
-EXPECT_EQ $width 6
+EXPECT_EQ $width 7
 
 set spinBoxHeight [qt_getWidget spinBoxHeight]
 set height [qt_getWidgetData $spinBoxHeight]


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Updates:
* Add custom device resources shown during creation/modification
* Indicate error in case some of the parameters is not valid.

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/1ecea796-03c0-45d8-aee1-c688ea58ce20)

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/005f5771-3bcc-41e3-99d7-f4beedad9b8d)

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/14f6f04e-87f1-40d2-8de0-a9b8064e9cf4)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: newproject
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts