### PR TITLE
Install bzip2-devel libffi-devel on centos 7 for Python

### DIFF
--- a/.github/workflows/build_centos_image.yml.yml
+++ b/.github/workflows/build_centos_image.yml.yml
@@ -43,4 +43,5 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:centos7latest
           labels: ${{ steps.meta.outputs.labels }}
 
-          
+
+    

--- a/.github/workflows/install_centos_dependencies_build.sh
+++ b/.github/workflows/install_centos_dependencies_build.sh
@@ -31,7 +31,7 @@ yum install -y libusbx-devel libusb-devel
 yum install -y pkgconfig
 yum install -y perl-IPC-Cmd
 yum install -y alsa-lib mesa-dri-drivers openssl openssl-devel sudo
-yum install -y python3-devel
+yum install -y python3-devel bzip2-devel libffi-devel
 ln -s $PWD/cmake-3.24.4-linux-x86_64/bin/ctest /usr/bin/ctest
 
 # downloads the Qt6 artifact from a specific URL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 347)
+set(VERSION_PATCH 348)
 
 option(
   WITH_LIBCXX


### PR DESCRIPTION
To build FOEDAG with CPython, install bzip2-devel libffi-devel on CentOS 