### PR TITLE
Reenable bitstream generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 350)
+set(VERSION_PATCH 351)
 
 option(
   WITH_LIBCXX

--- a/src/Configuration/ModelConfig/ModelConfig_IO.cpp
+++ b/src/Configuration/ModelConfig/ModelConfig_IO.cpp
@@ -34,7 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //    4. [obj] -> I_DELAY  -> I_SERDES ->         ?? not confirmed ??
 //    5.       -> O_SERDES -> O_DELAY  -> [obj]   ?? not confirmed ??
 
-bool g_is_unit_test = false;
+const bool g_enable_python = true;
 
 namespace FOEDAG {
 
@@ -47,12 +47,9 @@ void ModelConfig_IO::gen_ppdb(CFGCommon_ARG* cmdarg,
   std::string property_json = options.find("property_json") != options.end()
                                   ? options.at("property_json")
                                   : "";
-  g_is_unit_test = std::find(flag_options.begin(), flag_options.end(),
-                             "is_unittest") != flag_options.end();
   CFG_POST_MSG("Netlist PPDB: %s", netlist_ppdb.c_str());
   CFG_POST_MSG("Config Mapping: %s", config_mapping.c_str());
   CFG_POST_MSG("Property JSON: %s", property_json.c_str());
-  CFG_POST_MSG("Unit Test: %d", g_is_unit_test);
 
   std::ifstream input;
   // Read the Netlist PPDB JSON
@@ -80,7 +77,7 @@ void ModelConfig_IO::gen_ppdb(CFGCommon_ARG* cmdarg,
   locate_instances(netlist_instances);
   // Prepare for validation for location
   std::map<std::string, std::string> global_args;
-  if (g_is_unit_test) {
+  if (g_enable_python) {
     initialization(config_attributes_mapping, global_args, python);
   } else {
     CFG_POST_WARNING("Warning: Skip pin assignment legality check");
@@ -299,7 +296,7 @@ void ModelConfig_IO::validate_locations(
     CFG_ASSERT(instance.is_object());
     CFG_ASSERT(!instance.contains("__location_validation__"));
     CFG_ASSERT(!instance.contains("__location_validation_msg__"));
-    if (g_is_unit_test) {
+    if (g_enable_python) {
       validate_location(instance, mapping, global_agrs, resource_instances,
                         python);
     } else {


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
1. This is to reenable full flow IO bitstream generation. It was disabled previous via https://github.com/os-fpga/FOEDAG/pull/1531
2. In our current Python build,
   - All CI platform are using Python 3.8 or above, except CENTOS, it is using Python 3.6
   - When embeded Python into C code, CENTOS C code will be compiled based on 3.6 library (.so or .a)
   - However in Raptor, we ship precompiled python which is in version 3.8
   - This version mismatch (what we have in CI CENTOS vs what we shipped in Raptor) should be the culprit of the issue
3. With Nadeem update CI CentOS to Python version 3.8 (https://github.com/os-fpga/FOEDAG/pull/1543/files), it should be good to reenable full bitstream generation. 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
