### PR TITLE
Update main.yml to stick to macos 12 to support py3.8

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -17,3 +17,4 @@ ENV PRODUCTION_DEVICES=""
 RUN useradd -m -d /home/runner -u 1001 -s /bin/bash -p $(openssl passwd -1 "$pass") runner
 USER runner
 ENTRYPOINT ["/bin/bash"]
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -387,7 +387,7 @@ jobs:
 
 
   macos-gcc:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
     - uses: actions/setup-python@v5.0.0
@@ -449,7 +449,7 @@ jobs:
 
 
   macos-clang:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
     - uses: actions/setup-python@v5.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 352)
+set(VERSION_PATCH 353)
 
 option(
   WITH_LIBCXX


### PR DESCRIPTION
The latest GitHub runners are using MacOS 14 now and this MacOS version does not support Python 3.8 while we still want to support Python 3.8 due to CentOS 7 so making sure CI runs on MacOS 12