### PR TITLE
Allow device level of config map if it exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 356)
+set(VERSION_PATCH 357)
 
 option(
   WITH_LIBCXX

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -3366,9 +3366,13 @@ bool CompilerOpenFPGA::GenerateBitstream() {
     ric_folder = datapath / "etc" / m_OpenFpgaRICModelDir;
   }
   std::filesystem::path ric_model = ric_folder / "periphery.tcl";
-  std::filesystem::path config_mapping = datapath / "configuration" /
-                                         device_data.series /
-                                         "config_attributes.mapping.json";
+  std::filesystem::path config_mapping =
+      datapath / "configuration" / device_data.series /
+      (device_name + "_config_attributes.mapping.json");
+  if (!std::filesystem::exists(config_mapping)) {
+    config_mapping = datapath / "configuration" / device_data.series /
+                     "config_attributes.mapping.json";
+  }
   std::filesystem::path netlist_ppdb =
       FilePath(Action::Synthesis, "config.json");
   std::vector<std::filesystem::path> api_files =


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
1. Allow device level config map if it exists.
2. If it does not exists, we will use family series config map. 
3. This allow further customization for a particular device if neccessary

Testing:
   - ported code (together with https://github.com/os-fpga/Raptor/pull/1684) to latest NS Raptor manually
   - run batch, batch_gen2 and batch_gen3 test. (Note: and2_bitstream had been failing locally)

Code coverage failed:
   - no unit test in Compiler to execute a project
   - hence it is expected to fail

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
