### PR TITLE
sdc fix for VPR parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
 
-set(VERSION_PATCH 357)
+set(VERSION_PATCH 358)
 
 option(
   WITH_LIBCXX

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -2237,6 +2237,12 @@ void CompilerOpenFPGA::WriteTimingConstraints() {
     for (uint32_t i = 0; i < tokens.size(); i++) {
       const std::string& tok = tokens[i];
       tokens[i] = getNetlistEditData()->PIO2InnerNet(tok);
+      std::size_t pos = tokens[i].find("[");
+      if (pos != std::string::npos && pos != 0) {
+        // If a [ character is part of the string and is not the first
+        // character, then it is a complex signal name.
+        tokens[i] = "{" + tokens[i] + "}";
+      }
     }
 
     // VPR does not understand: create_clock -period 2 clk -name <logical_name>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

VPR SDC parser requires we surround complex name like FOO[0].bar with {} 
Result: {FOO[0].bar}
