### PR TITLE
Fix the include error for scope_guard.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk) 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
 
 set(VERSION_PATCH 359)

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -56,7 +56,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Utils/ProcessUtils.h"
 #include "Utils/QtUtils.h"
 #include "Utils/StringUtils.h"
-#include "scope_guard/scope_guard.hpp"
+#include "scope_guard.hpp"
 
 extern FOEDAG::Session* GlobalSession;
 using namespace FOEDAG;

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -43,7 +43,7 @@
 #include "Utils/QtUtils.h"
 #include "Utils/StringUtils.h"
 #include "nlohmann_json/json.hpp"
-#include "scope_guard/scope_guard.hpp"
+#include "scope_guard.hpp"
 
 using json = nlohmann::ordered_json;
 namespace fs = std::filesystem;


### PR DESCRIPTION
The scope_guard.hpp directory was not in the include directory so added it in the include directory so that compiler can find it.