### PR TITLE
merge pin_c with stars (1st step) pin_c -> stars in FOEDAG

### DIFF
--- a/src/Compiler/CompilerOpenFPGA.h
+++ b/src/Compiler/CompilerOpenFPGA.h
@@ -208,7 +208,7 @@ class CompilerOpenFPGA : public Compiler {
   std::filesystem::path m_vprExecutablePath = "vpr";
   std::filesystem::path m_ReConstructVExecPath = "finalize";
   std::filesystem::path m_staExecutablePath = "sta";
-  std::filesystem::path m_pinConvExecutablePath = "pin_c";
+  std::filesystem::path m_pinConvExecutablePath = "stars";
   /*!
    * \brief m_architectureFile
    * We required from user explicitly specify architecture file.

--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -67,7 +67,7 @@ int main(int argc, char** argv) {
     std::filesystem::path yosysPath = binpath / "yosys";
     std::filesystem::path vprPath = binpath / "vpr";
     std::filesystem::path openFpgaPath = binpath / "openfpga";
-    std::filesystem::path pinConvPath = binpath / "pin_c";
+    std::filesystem::path pinConvPath = binpath / "stars";
     std::filesystem::path bitstreamSettingPath =
         datapath / "Arch" / "bitstream_annotation.xml";
     std::filesystem::path simSettingPath =


### PR DESCRIPTION
Change exec name 'pin_c' to 'stars' in FOEDAG.
Currently 'stars' have all the source code of pin_c, plus more.
'stars' can function as pin_c for a couple of month now, I tested it many times.

'stars' detects "pin_c mode" is one of 3 ways:
1. if the absolute exec path (argv[0]) ends in "pin_c"
2. if the "--function pin_c" command line option is specified
3. if there is a typical set of pin_c options, i.e. "--csv" and "--assign_unconstrained_pins"

With this FOEDAG  checkin, the 3rd way will be used, temporarily.

This is the 1st step of multi-stage process of combining 'pin_c' and 'stars' functionality in component named 'planner'.
The executable name will be 'pln', because there is already an app with exec called 'planner' (GNOME planner).

Further stages will be:
- change exec name 'pin_c' to 'stars' in Raptor and FOEDAG_rs
- stop building pin_c
- change makefiles to copy 'stars' binary as 'pln'
- rename 'stars' -> 'pln' in FOEDAG, FOEDAG_rs, Raptor, and start passing "--function" argument
- change makefiles to produce only 'pln', without 'stars'
