### PR TITLE
Add error message when simulation files are missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
 
-set(VERSION_PATCH 365)
+set(VERSION_PATCH 366)
 
 option(
   WITH_LIBCXX

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -2924,6 +2924,15 @@ int Compiler::add_files(Compiler* compiler, Tcl_Interp* interp, int argc,
     }
   }
 
+  if (fileList.empty()) {
+    compiler->ErrorMessage(QString{"Incorrect syntax for %1: file(s) missing."}
+                               .arg((filesType == AddFilesType::Design)
+                                        ? "add_design_file"
+                                        : "add_simulation_file")
+                               .toStdString());
+    return TCL_ERROR;
+  }
+
   compiler->Message("Adding " + actualType + " " +
                     StringUtils::join(fileList, " "));
   std::ostringstream out;

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -346,6 +346,10 @@ Simulator::SimulatorType Simulator::UserSimulationType(
 
 bool Simulator::Simulate(SimulationType action, SimulatorType type,
                          const std::string& wave_file) {
+  if (ProjManager()->SimulationFiles().empty()) {
+    m_compiler->ErrorMessage("Simulation file(s) missing.");
+    return false;
+  }
   m_simType = action;
   if (SimulationOption() == SimulationOpt::Clean) return Clean(action);
   WaveFile(action, wave_file);


### PR DESCRIPTION
### Motivate of the pull request
- [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
- [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Change list:
* Add an error message for TCL commands `add_design_file` and `add_simulation_file` when the file name is missing
* Add an error message for all types of simulations when simulation file(s) are missing from the project.

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/0159a19d-caf7-45b6-9bc6-ec55a8815366)

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/20764179-6e1e-40fe-8c6e-68116ed088a4)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
