### PR TITLE
Skip block if property has no_configuration set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
 
-set(VERSION_PATCH 369)
+set(VERSION_PATCH 370)
 
 option(
   WITH_LIBCXX

--- a/src/Configuration/ModelConfig/ModelConfig.cpp
+++ b/src/Configuration/ModelConfig/ModelConfig.cpp
@@ -30,6 +30,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace FOEDAG {
 
+bool is_none_config_block(const device_block* block) {
+  std::string is_none_config = block->getProperty("is_none_config");
+  return CFG_find_string_in_vector({"1", "true", "on"}, is_none_config) >= 0;
+}
+
 struct ModelConfig_BITFIELD {
  public:
   ModelConfig_BITFIELD(const std::string& block_name,
@@ -741,10 +746,6 @@ static class ModelConfig_MRG {
         m_feature_devices.find(m_current_feature) != m_feature_devices.end(),
         "Device model for feature '%s' is not set", m_current_feature.c_str());
     m_current_device = m_feature_devices.at(m_current_feature);
-  }
-  bool is_none_config_block(const device_block* block) {
-    std::string is_none_config = block->getProperty("is_none_config");
-    return CFG_find_string_in_vector({"1", "true", "on"}, is_none_config) >= 0;
   }
   void dump_ric(std::ofstream& file, const device* device,
                 const device_block* block, const std::string& space,

--- a/src/Configuration/ModelConfig/ModelConfig.cpp
+++ b/src/Configuration/ModelConfig/ModelConfig.cpp
@@ -31,7 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace FOEDAG {
 
 bool is_none_config_block(const device_block* block) {
-  std::string is_none_config = block->getProperty("is_none_config");
+  std::string is_none_config = block->getProperty("no_configuration");
   return CFG_find_string_in_vector({"1", "true", "on"}, is_none_config) >= 0;
 }
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
Referring to https://rapidsilicon.atlassian.net/browse/EDA-2854, which Manadher propose to use "property" feature to identify config or none-config block

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
