### PR TITLE
Revoking the block alteration to indicate "not for config"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
 
-set(VERSION_PATCH 369)
+set(VERSION_PATCH 370)
 
 option(
   WITH_LIBCXX

--- a/src/DeviceModeling/device_block.h
+++ b/src/DeviceModeling/device_block.h
@@ -1325,8 +1325,6 @@ class device_block {
   }
   void set_was_instanciated(bool val = true) { was_instanciated_ = val; }
   bool was_instanciated() { return was_instanciated_; }
-  void set_no_configuration(bool val = true) { no_configuration_ = val; }
-  bool get_no_configuration() { return no_configuration_; }
   /**
    * @brief Sets the corresponding bits starting from the given address.
    *
@@ -1377,7 +1375,6 @@ class device_block {
   }
 
  protected:
-  bool no_configuration_ = false;
   // Bitset to store memory of set bits.
   std::bitset<16384> memory_;  // 2 KB
   // Maximum number of any bit set.

--- a/src/DeviceModeling/device_modeler.h
+++ b/src/DeviceModeling/device_modeler.h
@@ -201,7 +201,6 @@ class device_modeler {
       ss << "MUX" << in_cnt << "X1";
       std::string blockName = ss.str();
       auto block = std::make_shared<device_block>(blockName);
-      block->set_no_configuration();
       for (int k = 0; k <= in_cnt; k++) {
         block->add_port(std::make_shared<device_port>(ports[k].second,
                                                       ports[k].first == "in"));
@@ -393,10 +392,7 @@ class device_modeler {
 
     // Create a new block with the given name and ports
     auto block = std::make_shared<device_block>(blockName);
-    std::string no_conf = get_argument_value("-no_configuration", argc, argv);
-    if (std::string("on") == no_conf) {
-      block->set_no_configuration();
-    }
+
     for (auto &p : ports) {
       block->add_port(std::make_shared<device_port>(p.second, p.first == "in"));
     }


### PR DESCRIPTION
> ### Motivate of the pull request
> - Revoking redundant method to mark any module for "no_configuration"
