### PR TITLE
Improvement and add O_SERDES_CLK test case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
 
-set(VERSION_PATCH 370)
+set(VERSION_PATCH 371)
 
 option(
   WITH_LIBCXX

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -3436,6 +3436,9 @@ bool CompilerOpenFPGA::GenerateBitstream() {
     }
     command = CFG_print("%s\nwrite_property model_config.property.json",
                         command.c_str());
+    command = CFG_print(
+        "%s\nwrite_simplified_property model_config.simplified.property.json",
+        command.c_str());
     command = CFG_print("%s\nundefine_device PERIPHERY", command.c_str());
     command = CFG_print("%s\nsource %s", command.c_str(), ric_model.c_str());
     command = CFG_print("%s\nmodel_config set_model -feature IO PERIPHERY",
@@ -3458,6 +3461,17 @@ bool CompilerOpenFPGA::GenerateBitstream() {
     command = CFG_print(
         "%s\nmodel_config set_design -feature IO model_config.ppdb.json",
         command.c_str());
+    nlohmann::json properties = m_constraints->get_simplified_property_json();
+    if (properties.contains("INI")) {
+      if (properties["INI"].contains("IO_MODEL_CONFIG_OVERWRITE")) {
+        std::string io_model_config_file =
+            properties["INI"]["IO_MODEL_CONFIG_OVERWRITE"];
+        if (std::filesystem::exists(io_model_config_file)) {
+          command = CFG_print("%s\nsource %s", command.c_str(),
+                              io_model_config_file.c_str());
+        }
+      }
+    }
     command = CFG_print(
         "%s\nmodel_config write -feature IO -format BIT io_bitstream.bit",
         command.c_str());

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -3430,7 +3430,17 @@ bool CompilerOpenFPGA::GenerateBitstream() {
     // update constraints
     const auto& constrFiles = ProjManager()->getConstrFiles();
     m_constraints->reset();
+    for (const auto& file : constrFiles) {
+      int res{TCL_OK};
+      auto status = m_interp->evalCmd(
+          std::string("read_sdc {" + file + "}").c_str(), &res);
+      if (res != TCL_OK) {
+        ErrorMessage(status);
+        return false;
+      }
+    }
     command = CFG_print("cd %s", workingDir.c_str());
+    command = CFG_print("%s\nclear_property", command.c_str());
     for (const auto& file : constrFiles) {
       command = CFG_print("%s\nread_sdc {%s}", command.c_str(), file.c_str());
     }

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -3482,6 +3482,7 @@ bool CompilerOpenFPGA::GenerateBitstream() {
         }
       }
     }
+    m_constraints->reset();
     command = CFG_print(
         "%s\nmodel_config write -feature IO -format BIT io_bitstream.bit",
         command.c_str());

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -3463,9 +3463,9 @@ bool CompilerOpenFPGA::GenerateBitstream() {
         command.c_str());
     nlohmann::json properties = m_constraints->get_simplified_property_json();
     if (properties.contains("INI")) {
-      if (properties["INI"].contains("IO_MODEL_CONFIG_OVERWRITE")) {
+      if (properties["INI"].contains("SOURCE_IO_MODEL_CONFIG_FILE")) {
         std::string io_model_config_file =
-            properties["INI"]["IO_MODEL_CONFIG_OVERWRITE"];
+            properties["INI"]["SOURCE_IO_MODEL_CONFIG_FILE"];
         if (std::filesystem::exists(io_model_config_file)) {
           command = CFG_print("%s\nsource %s", command.c_str(),
                               io_model_config_file.c_str());

--- a/src/Compiler/Constraints.cpp
+++ b/src/Compiler/Constraints.cpp
@@ -844,6 +844,23 @@ void Constraints::registerCommands(TclInterpreter* interp) {
   };
   interp->registerCmd("write_property", write_property, this, 0);
 
+  auto write_simplified_property = [](void* clientData, Tcl_Interp* interp,
+                                      int argc, const char* argv[]) -> int {
+    if (argc < 2) {
+      Tcl_AppendResult(
+          interp,
+          "ERROR: Invalid write_simplified_property format. Expect "
+          "\"write_simplified_property <filepath>\"",
+          (char*)NULL);
+      return TCL_ERROR;
+    }
+    Constraints* constraints = (Constraints*)clientData;
+    constraints->write_simplified_property(argv[1]);
+    return TCL_OK;
+  };
+  interp->registerCmd("write_simplified_property", write_simplified_property,
+                      this, 0);
+
   auto set_clock_pin = [](void* clientData, Tcl_Interp* interp, int argc,
                           const char* argv[]) -> int {
     Constraints* constraints = (Constraints*)clientData;

--- a/src/Compiler/Constraints.cpp
+++ b/src/Compiler/Constraints.cpp
@@ -1061,11 +1061,33 @@ nlohmann::json Constraints::get_property_by_json() {
   return instances;
 }
 
+nlohmann::json Constraints::get_simplified_property_json() {
+  nlohmann::json properties = nlohmann::json::object();
+  for (auto& obj_p : m_object_properties) {
+    for (auto obj : obj_p.objects) {
+      if (!properties.contains(obj)) {
+        properties[obj] = nlohmann::json::object();
+      }
+      for (auto property : obj_p.properties) {
+        properties[obj][property.name] = property.value;
+      }
+    }
+  }
+  return properties;
+}
+
 void Constraints::write_property(const std::string& filepath) {
   nlohmann::json instances = get_property_by_json();
   nlohmann::json json = nlohmann::json::object();
   json["instances"] = instances;
   std::ofstream file(filepath);
   file << json.dump(2);
+  file.close();
+}
+
+void Constraints::write_simplified_property(const std::string& filepath) {
+  nlohmann::json properties = get_simplified_property_json();
+  std::ofstream file(filepath);
+  file << properties.dump(2);
   file.close();
 }

--- a/src/Compiler/Constraints.h
+++ b/src/Compiler/Constraints.h
@@ -87,7 +87,9 @@ class Constraints {
   void clear_property();
   const std::vector<OBJECT_PROPERTY> get_property();
   nlohmann::json get_property_by_json();
+  nlohmann::json get_simplified_property_json();
   void write_property(const std::string& filepath);
+  void write_simplified_property(const std::string& filepath);
   bool verify_mode_property(int argc, const char* argv[], std::string& oldMode);
   const std::string SafeParens(const std::string& name);
   const std::string ExpandGetters(const std::string& fcall);

--- a/src/Configuration/ModelConfig/ModelConfig.cpp
+++ b/src/Configuration/ModelConfig/ModelConfig.cpp
@@ -252,7 +252,7 @@ class ModelConfig_DEVICE {
     std::string name = options.at("name");
     std::string value = options.at("value");
     if (reason.empty()) {
-      reason = CFG_print("%s [%s:%s]", instance.c_str(), name.c_str(),
+      reason = CFG_print("set_attr %s [%s:%s]", instance.c_str(), name.c_str(),
                          value.c_str());
     }
     if (m_api.find(name) != m_api.end()) {

--- a/src/Configuration/ModelConfig/ModelConfig_IO.h
+++ b/src/Configuration/ModelConfig/ModelConfig_IO.h
@@ -96,8 +96,9 @@ class ModelConfig_IO {
   void validations(bool init, const std::string& key, CFG_Python_MGR& python);
   void validation(nlohmann::json& instance, MODEL_RESOURCES& resources,
                   CFG_Python_MGR& python, const std::string& key);
+  void internal_error_validations();
   void invalidate_childs();
-  void invalidate_child(const std::string& linked_object);
+  void invalidate_chain(const std::string& linked_object);
   void assign_boot_clock_location();
   void assign_boot_clock_child_location(const std::string& linked_object);
   void allocate_fclk_routing();
@@ -157,7 +158,7 @@ class ModelConfig_IO {
   void set_validation_msg(bool status, std::string& msg,
                           const std::string& module, const std::string& name,
                           const std::string& location,
-                          const std::string& seq_name);
+                          const std::string& seq_name, bool skip = false);
   std::vector<std::string> get_json_string_list(
       const nlohmann::json& strings, std::map<std::string, std::string>& args);
   void retrieve_instance_args(nlohmann::json& instance,

--- a/tests/unittest/ModelConfig/ModelConfig_IO_test.cpp
+++ b/tests/unittest/ModelConfig/ModelConfig_IO_test.cpp
@@ -119,6 +119,9 @@ TEST_F(ModelConfig_IO, set_property) {
       "clk0");
   compiler_tcl_common_run(
       "write_property utst/ModelConfig/model_config.property.json");
+  compiler_tcl_common_run(
+      "write_simplified_property "
+      "utst/ModelConfig/model_config.simplified.property.json");
 }
 
 TEST_F(ModelConfig_IO, gen_ppdb) {
@@ -175,6 +178,10 @@ TEST_F(ModelConfig_IO, gen_bitstream_write_negative) {
 
 TEST_F(ModelConfig_IO, compare_result) {
   std::string golden_dir = COMPILER_TCL_COMMON_GET_CURRENT_GOLDEN_DIR();
+  compare_unittest_file(false, "model_config.property.json", "ModelConfig",
+                        golden_dir);
+  compare_unittest_file(false, "model_config.simplified.property.json",
+                        "ModelConfig", golden_dir);
   compare_unittest_file(false, "model_config.ppdb.json", "ModelConfig",
                         golden_dir);
   compare_unittest_file(false, "model_config_io_bitstream.detail.bit",

--- a/tests/unittest/ModelConfig/apis/config_attributes.mapping.json
+++ b/tests/unittest/ModelConfig/apis/config_attributes.mapping.json
@@ -62,7 +62,6 @@
       "not_pre_primitive" : "O_BUF",
       "not_post_primitive" : "I_BUF",
       "rules" : {
-        "__location__" : "__arg0__"
       },
       "results" : {
         "I_DDR" : "MODE==DDR"
@@ -70,10 +69,16 @@
     },
     "O_DDR" : {
       "rules" : {
-        "__location__" : "__arg0__"
       },
       "results" : {
         "O_DDR" : "MODE==DDR"
+      }
+    },
+    "I_SERDES.BYPASS" : {
+      "rules" : {
+      },
+      "results" : {
+        "RX_BYPASS" : "RX_gear_on"
       }
     },
     "I_SERDES.DDR_MODE" : {
@@ -98,6 +103,13 @@
         "I_SERDES" : "DPA_MODE==NONE"
       }
     },
+    "O_SERDES.BYPASS" : {
+      "rules" : {
+      },
+      "results" : {
+        "TX_BYPASS" : "TX_gear_on"
+      }
+    },
     "O_SERDES.DDR_MODE" : {
       "rules" : {
         "DATA_RATE" : "__arg0__"
@@ -107,6 +119,30 @@
       },
       "neg_results" : {
         "O_SERDES" : "DDR_MODE==SDR"
+      }
+    },
+    "O_SERDES_CLK.CLK_PHASE" : {
+      "rules" : {
+        "CLOCK_PHASE" : "__argCLOCK_PHASE__"
+      },
+      "results" : {
+        "__other__" : [
+          {
+            "__define__" : "parse_o_serdes_clk_phase_parameter",
+            "TX_CLK_PHASE" : "__clock_phase__"
+          }
+        ]
+      }
+    },
+    "O_SERDES_CLK.DDR_MODE" : {
+      "rules" : {
+        "DATA_RATE" : "__arg0__"
+      },
+      "results" : {
+        "O_SERDES_CLK" : "DDR_MODE==__arg0__"
+      },
+      "neg_results" : {
+        "O_SERDES_CLK" : "DDR_MODE==SDR"
       }
     },
     "BOOT_CLOCK" : {
@@ -124,7 +160,6 @@
     },
     "PLL.PLLREF_MUX" : {
       "rules" : {
-        "__location__" : "__arg0__"
       },
       "results" : {
         "__other__" : [
@@ -296,7 +331,6 @@
     },
     "CLK_BUF.GBOX_TOP" : {
       "rules" : {
-        "__location__" : "__arg0__"
       },
       "results" : {
         "CLK_BUF" : "GBOX_TOP_SRC==DEFAULT"
@@ -304,8 +338,7 @@
     },
     "CLK_BUF.ROOT_BANK_CLKMUX" : {
       "rules" : {
-        "__location__" : "__arg0__",
-        "ROUTE_TO_FABRIC_CLK" : "__arg1__"
+        "ROUTE_TO_FABRIC_CLK" : "__arg0__"
       },
       "results" : {
         "__other__" : [
@@ -322,13 +355,12 @@
     },
     "CLK_BUF.ROOT_MUX" : {
       "rules" : {
-        "__location__" : "__arg0__",
-        "ROUTE_TO_FABRIC_CLK" : "__arg1__"
+        "ROUTE_TO_FABRIC_CLK" : "__arg0__"
       },
       "results" : {
         "__other__" : [
           {
-            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg0__",
             "ROOT_MUX_SEL" : "__ROOT_MUX_SEL__"
           }
         ]
@@ -442,6 +474,9 @@
   "__secondary_validation__" : {
     "__seqeunce__" : [
       "__check_fabric_clock_resource__",
+      "__check_data_rate_parameter__",
+      "__check_dpa_mode_parameter__",
+      "__check_clock_phase_parameter__",
       "__check_pll_parameter__",
       "__check_pll_clock_pin_resource__",
       "__update_fabric_clock_resource__"
@@ -451,6 +486,27 @@
       "__connectivity__" : ["O", "CLK_OUT", "CLK_OUT_DIV2", "CLK_OUT_DIV3", "CLK_OUT_DIV4"],
       "__equation__" : [
         "pin_result = (__connectivity_count__ + g_fabric_clock_resources) <= MAX_FABRIC_CLOCK_RESOURCE"
+      ]
+    },
+    "__check_data_rate_parameter__" : {
+      "__module__" : ["I_SERDES", "O_SERDES", "O_SERDES_CLK"],
+      "__parameter__" : ["DATA_RATE"],
+      "__equation__" : [
+        "pin_result = 'DATA_RATE' in ['SDR', 'DDR']"
+      ]
+    },
+    "__check_dpa_mode_parameter__" : {
+      "__module__" : ["I_SERDES"],
+      "__parameter__" : ["DPA_MODE"],
+      "__equation__" : [
+        "pin_result = 'DPA_MODE' in ['NONE', 'DPA', 'CDR']"
+      ]
+    },
+    "__check_clock_phase_parameter__" : {
+      "__module__" : ["O_SERDES_CLK"],
+      "__parameter__" : ["CLOCK_PHASE"],
+      "__equation__" : [
+        "pin_result = 'CLOCK_PHASE' in ['0', '90', '180', '270']"
       ]
     },
     "__check_pll_parameter__" : {
@@ -496,6 +552,12 @@
         "m = re.search(r'H(P|R?)_(\\d?)(|_CC?)_(\\d+?)_(\\d\\d?)(P|N?)', '__location__')",
         "__type__ = 'HP' if m.group(1) == 'P' else 'HV'",
         "__bank__ = '0' if m.group(2) in ['1', '3'] else '1'"
+      ]
+    },
+    "parse_o_serdes_clk_phase_parameter" : {
+      "__args__" : ["__clock_phase__"],
+      "__equation__" : [
+        "__clock_phase__ = 'TX_phase_%d' % __argCLOCK_PHASE__"
       ]
     },
     "parse_pll_parameter" : {

--- a/tests/unittest/ModelConfig/golden/model_config.negative.ppdb.json
+++ b/tests/unittest/ModelConfig/golden/model_config.negative.ppdb.json
@@ -5,6 +5,7 @@
     "Re-location instances",
     "Configure Mapping file initialization",
     "Validation using '__primary_validation__' rule",
+    "Internal error validations",
     "Assign Boot Clock location",
     "  Assign Boot Clock child location",
     "Allocate FCLK routing resource",
@@ -23,9 +24,9 @@
     "      Warning: Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module i_ddr11 clock (module:I_DDR) (location:HR_5_2_1P). Reason: They are not in same physical bank",
     "    Route to gearbox module i_ddr12 (location:HR_1_22_11P)",
     "      Warning: Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module i_ddr12 clock (module:I_DDR) (location:HR_1_22_11P). Reason: Attemp to use FCLK: hvl_fclk_0_B, but it had been used by PLL:HP_1_CC_18_9P",
-    "  CLKBUF $auto$clkbufmap.cc:265:execute$707 (location:HP_1_CC_38_19P)",
-    "    Route clock-capable pin $auto$clkbufmap.cc:265:execute$707 (location:HP_1_CC_38_19P) to fabric",
-    "      Warning: Not able to route clock-capable pin $auto$clkbufmap.cc:265:execute$707 (location:HP_1_CC_38_19P) to fabric. Reason: Attemp to use FCLK: hp_fclk_0_B, but it had been used by HP_1_CC_18_9P",
+    "  CLKBUF $auto$clkbufmap.cc:265:execute$706 (location:HP_1_CC_38_19P)",
+    "    Route clock-capable pin $auto$clkbufmap.cc:265:execute$706 (location:HP_1_CC_38_19P) to fabric",
+    "      Warning: Not able to route clock-capable pin $auto$clkbufmap.cc:265:execute$706 (location:HP_1_CC_38_19P) to fabric. Reason: Attemp to use FCLK: hp_fclk_0_B, but it had been used by HP_1_CC_18_9P",
     "  PLL pllosc0 Port CLK_OUT (location:BOOT_CLOCK#0)",
     "    Route to gearbox module i_ddr_osc0 (location:HR_2_20_10P)",
     "      Use FCLK: hvl_fclk_1_B",
@@ -48,6 +49,9 @@
     "  PLL pll31 Port CLK_OUT (location:HR_3_CC_38_19P)",
     "    Route to gearbox module i_ddr31 (location:HR_2_3_1N)",
     "      Warning: Not able to route PLL pll31 Port CLK_OUT (location:HR_3_CC_38_19P) to gearbox module i_ddr31 clock (module:I_DDR) (location:HR_2_3_1N). Reason: PLL #1 (needed by HVR) cannot route to HVL",
+    "  CLKBUF clk_buf40 (location:HR_2_CC_38_19P)",
+    "    Route to gearbox module o_serdes_clk (location:HR_2_8_4P)",
+    "      Warning: Not able to route clock-capable pin clk_buf40 (location:HR_2_CC_38_19P) to gearbox module o_serdes_clk clock (module:O_SERDES_CLK) (location:HR_2_8_4P). Reason: Attemp to use FCLK: hvl_fclk_1_A, but it had been used by PLL:HR_1_CC_38_19P",
     "Set CLKBUF configuration attributes",
     "  Set FCLK configuration attributes",
     "    CLKBUF clk_buf00 (location:HP_1_CC_18_9P) use hp_fclk_0_A",
@@ -120,6 +124,21 @@
     "      Property",
     "        Rule I_BUF.IOSTANDARD",
     "          Mismatch",
+    "  Module: O_BUF ($iopadmap$top.clk_out)",
+    "    Object: clk_out",
+    "      Parameter",
+    "      Property",
+    "        Rule O_BUF.IOSTANDARD",
+    "          Mismatch",
+    "  Module: O_SERDES_CLK (o_serdes_clk)",
+    "    Object: clk_out",
+    "      Parameter",
+    "        Rule O_SERDES_CLK.CLK_PHASE",
+    "          Match",
+    "            Defined function: parse_o_serdes_clk_phase_parameter",
+    "        Rule O_SERDES_CLK.DDR_MODE",
+    "          Match",
+    "      Property",
     "  Module: I_BUF ($iopadmap$top.din00)",
     "    Object: din00",
     "      Parameter",
@@ -328,6 +347,14 @@
     "          Mismatch",
     "        Rule CLK_BUF.ROOT_MUX",
     "          Mismatch",
+    "  Module: I_BUF (i_buf40)",
+    "    Object: clk40",
+    "      Parameter",
+    "        Rule I_BUF.WEAK_KEEPER",
+    "          Mismatch",
+    "      Property",
+    "        Rule I_BUF.IOSTANDARD",
+    "          Mismatch",
     "  Module: I_BUF_DS (i_buf_ds30)",
     "    Object: din30_n",
     "      Parameter",
@@ -417,6 +444,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -506,6 +535,8 @@
           "Use FCLK: hp_fclk_0_B"
         ]
       },
+      "errors" : [
+      ],
       "__CDR_CLK_ROOT_SEL_A__" : "__DONT__",
       "__CDR_CLK_ROOT_SEL_B__" : "__DONT__",
       "__CORE_CLK_ROOT_SEL_A__" : "18",
@@ -642,6 +673,8 @@
           "Use FCLK: hvl_fclk_0_B"
         ]
       },
+      "errors" : [
+      ],
       "__cfg_pllref_hp_bank_rx_io_sel__" : "0",
       "__cfg_pllref_hp_rx_io_sel__" : "0",
       "__cfg_pllref_hv_bank_rx_io_sel__" : "__DONT__",
@@ -687,6 +720,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -728,6 +763,8 @@
           "Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module i_ddr12 clock (module:I_DDR) (location:HR_1_22_11P). Reason: Attemp to use FCLK: hvl_fclk_0_B, but it had been used by PLL:HP_1_CC_18_9P"
         ]
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail to route the clock"
     },
@@ -765,12 +802,14 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
     {
       "module" : "CLK_BUF",
-      "name" : "$auto$clkbufmap.cc:265:execute$707",
+      "name" : "$auto$clkbufmap.cc:265:execute$706",
       "linked_object" : "clk20",
       "linked_objects" : {
         "clk20" : {
@@ -784,7 +823,7 @@
       },
       "connectivity" : {
         "I" : "$iopadmap$clk20",
-        "O" : "$auto$clkbufmap.cc:298:execute$709"
+        "O" : "$auto$clkbufmap.cc:298:execute$708"
       },
       "parameters" : {
         "ROUTE_TO_FABRIC_CLK" : "6"
@@ -796,8 +835,150 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
-      "__validation_msg__" : "Not able to route clock-capable pin $auto$clkbufmap.cc:265:execute$707 (location:HP_1_CC_38_19P) to fabric. Reason: Attemp to use FCLK: hp_fclk_0_B, but it had been used by HP_1_CC_18_9P"
+      "__validation_msg__" : "Not able to route clock-capable pin $auto$clkbufmap.cc:265:execute$706 (location:HP_1_CC_38_19P) to fabric. Reason: Attemp to use FCLK: hp_fclk_0_B, but it had been used by HP_1_CC_18_9P"
+    },
+    {
+      "module" : "O_BUF",
+      "name" : "$iopadmap$top.clk_out",
+      "linked_object" : "clk_out",
+      "linked_objects" : {
+        "clk_out" : {
+          "location" : "HR_2_8_4P",
+          "properties" : {
+          },
+          "config_attributes" : [
+            {
+              "O_BUF" : "IOSTANDARD==DEFAULT"
+            }
+          ]
+        }
+      },
+      "connectivity" : {
+        "I" : "$iopadmap$clk_out",
+        "O" : "clk_out"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+        "O_SERDES_CLK"
+      ],
+      "route_clock_to" : {
+      },
+      "route_clock_result" : {
+      },
+      "errors" : [
+      ],
+      "__validation__" : "TRUE",
+      "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
+    },
+    {
+      "module" : "O_SERDES_CLK",
+      "name" : "o_serdes_clk",
+      "linked_object" : "clk_out",
+      "linked_objects" : {
+        "clk_out" : {
+          "location" : "HR_2_8_4P",
+          "properties" : {
+          },
+          "config_attributes" : [
+            {
+              "TX_CLK_PHASE" : "TX_phase_270"
+            },
+            {
+              "O_SERDES_CLK" : "DDR_MODE==SDR"
+            }
+          ]
+        }
+      },
+      "connectivity" : {
+        "OUTPUT_CLK" : "$iopadmap$clk_out",
+        "PLL_CLK" : "clkbuf40"
+      },
+      "parameters" : {
+        "CLOCK_PHASE" : "270",
+        "DATA_RATE" : "SDR"
+      },
+      "pre_primitive" : "O_BUF",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+      },
+      "route_clock_result" : {
+      },
+      "errors" : [
+      ],
+      "__validation__" : "TRUE",
+      "__validation_msg__" : "Pass:__check_data_rate_parameter__,__check_clock_phase_parameter__"
+    },
+    {
+      "module" : "O_BUF",
+      "name" : "$iopadmap$top.clk_out_osc",
+      "linked_object" : "clk_out_osc",
+      "linked_objects" : {
+        "clk_out_osc" : {
+          "location" : "HR_2_9_4N",
+          "properties" : {
+          },
+          "config_attributes" : [
+          ]
+        }
+      },
+      "connectivity" : {
+        "I" : "$iopadmap$clk_out_osc",
+        "O" : "clk_out_osc"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+        "O_SERDES_CLK"
+      ],
+      "route_clock_to" : {
+      },
+      "route_clock_result" : {
+      },
+      "errors" : [
+      ],
+      "__validation__" : "FALSE",
+      "__validation_msg__" : "Invalidated because other instance in the chain is invalid"
+    },
+    {
+      "module" : "O_SERDES_CLK",
+      "name" : "o_serdes_clk_osc",
+      "linked_object" : "clk_out_osc",
+      "linked_objects" : {
+        "clk_out_osc" : {
+          "location" : "HR_2_9_4N",
+          "properties" : {
+          },
+          "config_attributes" : [
+          ]
+        }
+      },
+      "connectivity" : {
+        "OUTPUT_CLK" : "$iopadmap$clk_out_osc",
+        "PLL_CLK" : "osc"
+      },
+      "parameters" : {
+        "CLOCK_PHASE" : "180",
+        "DATA_RATE" : "DDR"
+      },
+      "pre_primitive" : "O_BUF",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+      },
+      "route_clock_result" : {
+      },
+      "errors" : [
+        "Not able to route signal \\osc to port \\PLL_CLK"
+      ],
+      "__validation__" : "FALSE",
+      "__validation_msg__" : "Fail:internal_error"
     },
     {
       "module" : "I_BUF",
@@ -833,6 +1014,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -865,6 +1048,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -902,6 +1087,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -934,6 +1121,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -965,6 +1154,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail:__pin_is_valid__"
     },
@@ -994,8 +1185,10 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
-      "__validation_msg__" : "Invalidated because parent is invalid"
+      "__validation_msg__" : "Invalidated because other instance in the chain is invalid"
     },
     {
       "module" : "I_BUF",
@@ -1031,6 +1224,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1063,6 +1258,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1100,6 +1297,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1132,6 +1331,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1162,6 +1363,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail:__pin_is_valid__"
     },
@@ -1199,6 +1402,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1231,6 +1436,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1268,6 +1475,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1300,6 +1509,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1331,6 +1542,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail:__pin_is_valid__"
     },
@@ -1360,8 +1573,10 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
-      "__validation_msg__" : "Invalidated because parent is invalid"
+      "__validation_msg__" : "Invalidated because other instance in the chain is invalid"
     },
     {
       "module" : "I_BUF",
@@ -1397,6 +1612,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1429,6 +1646,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1466,6 +1685,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1498,6 +1719,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1530,6 +1753,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1563,6 +1788,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1595,6 +1822,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1628,6 +1857,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1660,6 +1891,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1690,6 +1923,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail:__pin_is_valid__"
     },
@@ -1719,8 +1954,10 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
-      "__validation_msg__" : "Invalidated because parent is invalid"
+      "__validation_msg__" : "Invalidated because other instance in the chain is invalid"
     },
     {
       "module" : "O_BUF",
@@ -1752,6 +1989,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1784,6 +2023,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1817,6 +2058,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1849,6 +2092,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1878,6 +2123,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail:__pin_is_valid__"
     },
@@ -1915,6 +2162,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__check_boot_clock_resource__"
     },
@@ -1958,6 +2207,8 @@
           "Not able to route PLL pllosc0 Port CLK_OUT (location:BOOT_CLOCK#0) to gearbox module i_ddr_osc2 clock. Reason: Module usage is invalid in the first place"
         ]
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail to route the clock"
     },
@@ -1997,6 +2248,8 @@
           "Not able to route PLL pllosc1 Port CLK_OUT_DIV2 (location:BOOT_CLOCK#0) to gearbox module i_ddr_osc3 clock. Reason: Only PLL output port 'CLK_OUT' can use FCLK resource"
         ]
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail to route the clock"
     },
@@ -2036,6 +2289,8 @@
           "Not able to route clock-capable pin pllosc2 (location:BOOT_CLOCK#0) to gearbox module i_ddr_osc4 clock (module:I_DDR) (location:HR_1_30_15P). Reason: Attemp to use FCLK: hvl_fclk_0_B, but it had been used by PLL:HP_1_CC_18_9P"
         ]
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail to route the clock"
     },
@@ -2073,6 +2328,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -2106,6 +2363,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__clock_pin_is_valid__,__check_fabric_clock_resource__,__update_fabric_clock_resource__"
     },
@@ -2145,6 +2404,8 @@
           "Use FCLK: hvl_fclk_1_A"
         ]
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Cannot fit in any Pin/FCLK/PLL resource"
     },
@@ -2182,6 +2443,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -2215,6 +2478,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__clock_pin_is_valid__,__check_fabric_clock_resource__,__update_fabric_clock_resource__"
     },
@@ -2256,6 +2521,83 @@
           "Not able to route PLL pll31 Port CLK_OUT (location:HR_3_CC_38_19P) to gearbox module i_ddr31 clock (module:I_DDR) (location:HR_2_3_1N). Reason: PLL #1 (needed by HVR) cannot route to HVL"
         ]
       },
+      "errors" : [
+      ],
+      "__validation__" : "FALSE",
+      "__validation_msg__" : "Fail to route the clock"
+    },
+    {
+      "module" : "I_BUF",
+      "name" : "i_buf40",
+      "linked_object" : "clk40",
+      "linked_objects" : {
+        "clk40" : {
+          "location" : "HR_2_CC_38_19P",
+          "properties" : {
+          },
+          "config_attributes" : [
+            {
+              "I_BUF" : "WEAK_KEEPER==DEFAULT"
+            },
+            {
+              "I_BUF" : "IOSTANDARD==DEFAULT"
+            }
+          ]
+        }
+      },
+      "connectivity" : {
+        "I" : "clk40",
+        "O" : "ibuf40"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+        "CLK_BUF"
+      ],
+      "route_clock_to" : {
+      },
+      "route_clock_result" : {
+      },
+      "errors" : [
+      ],
+      "__validation__" : "TRUE",
+      "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
+    },
+    {
+      "module" : "CLK_BUF",
+      "name" : "clk_buf40",
+      "linked_object" : "clk40",
+      "linked_objects" : {
+        "clk40" : {
+          "location" : "HR_2_CC_38_19P",
+          "properties" : {
+          },
+          "config_attributes" : [
+          ]
+        }
+      },
+      "connectivity" : {
+        "I" : "ibuf40",
+        "O" : "clkbuf40"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "I_BUF",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+        "O" : [
+          "o_serdes_clk"
+        ]
+      },
+      "route_clock_result" : {
+        "O" : [
+          "Not able to route clock-capable pin clk_buf40 (location:HR_2_CC_38_19P) to gearbox module o_serdes_clk clock (module:O_SERDES_CLK) (location:HR_2_8_4P). Reason: Attemp to use FCLK: hvl_fclk_1_A, but it had been used by PLL:HR_1_CC_38_19P"
+        ]
+      },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail to route the clock"
     },
@@ -2309,6 +2651,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__ds_pin_is_valid__,__pin_is_differential__,__check_ds_pin_resource__"
     },
@@ -2351,6 +2695,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -2404,6 +2750,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__ds_pin_is_valid__,__pin_is_differential__,__check_ds_pin_resource__"
     },
@@ -2446,6 +2794,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -2484,8 +2834,10 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
-      "__validation_msg__" : ";Fail:Pass:__ds_pin_is_valid__"
+      "__validation_msg__" : "Pass:__ds_pin_is_valid__;Fail:__pin_is_differential__"
     },
     {
       "module" : "O_DDR",
@@ -2520,8 +2872,10 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
-      "__validation_msg__" : "Invalidated because parent is invalid"
+      "__validation_msg__" : "Invalidated because other instance in the chain is invalid"
     }
   ]
 }

--- a/tests/unittest/ModelConfig/golden/model_config.ppdb.json
+++ b/tests/unittest/ModelConfig/golden/model_config.ppdb.json
@@ -4,8 +4,8 @@
     "Merge properties into instances",
     "  Assign Property:IOSTANDARD value:LVCMOS_18_HP to \"$iopadmap$top.clk0\"",
     "  Assign Property:PACKAGE_PIN value:HR_1_CC_38_19P to \"$iopadmap$top.clk0\"",
-    "  Assign Property:IOSTANDARD value:LVCMOS_18_HP to \"$auto$clkbufmap.cc:265:execute$433\"",
-    "  Assign Property:PACKAGE_PIN value:HR_1_CC_38_19P to \"$auto$clkbufmap.cc:265:execute$433\"",
+    "  Assign Property:IOSTANDARD value:LVCMOS_18_HP to \"$auto$clkbufmap.cc:265:execute$432\"",
+    "  Assign Property:PACKAGE_PIN value:HR_1_CC_38_19P to \"$auto$clkbufmap.cc:265:execute$432\"",
     "  Assign Property:IOSTANDARD value:LVCMOS_18_HR to \"$iopadmap$top.din\"",
     "  Assign Property:PACKAGE_PIN value:HR_1_4_2P to \"$iopadmap$top.din\"",
     "  Assign Property:IOSTANDARD value:LVCMOS_18_HR to \"i_delay\"",
@@ -16,20 +16,21 @@
     "  Assign Property:PACKAGE_PIN value:HR_1_6_3P to \"o_delay\"",
     "Re-location instances",
     "  Overwrite location value:$iopadmap$top.clk0 to \"HR_1_CC_38_19P\" (value existing: HR_1_CC_18_9P)",
-    "  Overwrite location value:$auto$clkbufmap.cc:265:execute$433 to \"HR_1_CC_38_19P\" (value existing: HR_1_CC_18_9P)",
+    "  Overwrite location value:$auto$clkbufmap.cc:265:execute$432 to \"HR_1_CC_38_19P\" (value existing: HR_1_CC_18_9P)",
     "  Overwrite location value:$iopadmap$top.din to \"HR_1_4_2P\" (value existing: HP_1_2_1P)",
     "  Overwrite location value:i_delay to \"HR_1_4_2P\" (value existing: HP_1_2_1P)",
     "  Overwrite location value:$iopadmap$top.dout to \"HR_1_6_3P\" (value existing: HP_1_6_3P)",
     "  Overwrite location value:o_delay to \"HR_1_6_3P\" (value existing: HP_1_6_3P)",
     "Configure Mapping file initialization",
     "Validation using '__primary_validation__' rule",
+    "Internal error validations",
     "Assign Boot Clock location",
     "  Assign Boot Clock child location",
     "Allocate FCLK routing resource",
-    "  CLKBUF $auto$clkbufmap.cc:265:execute$433 (location:HR_1_CC_38_19P)",
+    "  CLKBUF $auto$clkbufmap.cc:265:execute$432 (location:HR_1_CC_38_19P)",
     "    Route to gearbox module i_delay (location:HR_1_4_2P)",
     "      Use FCLK: hvl_fclk_0_A",
-    "    Route clock-capable pin $auto$clkbufmap.cc:265:execute$433 (location:HR_1_CC_38_19P) to fabric",
+    "    Route clock-capable pin $auto$clkbufmap.cc:265:execute$432 (location:HR_1_CC_38_19P) to fabric",
     "      Use FCLK: hvl_fclk_0_B",
     "  CLKBUF clk_buf (location:HP_1_CC_18_9P)",
     "    Route to gearbox module o_delay (location:HR_1_6_3P)",
@@ -41,15 +42,17 @@
     "      Use FCLK: hp_fclk_0_A",
     "    Route to gearbox module o_serdes (location:HR_2_1_0N)",
     "      Use FCLK: hvl_fclk_1_A",
-    "  CLKBUF $auto$clkbufmap.cc:265:execute$436 (location:HR_5_CC_38_19P)",
-    "    Route clock-capable pin $auto$clkbufmap.cc:265:execute$436 (location:HR_5_CC_38_19P) to fabric",
+    "    Route to gearbox module o_serdes_clk (location:HR_2_2_1P)",
+    "      Use FCLK: hvl_fclk_1_A",
+    "  CLKBUF $auto$clkbufmap.cc:265:execute$435 (location:HR_5_CC_38_19P)",
+    "    Route clock-capable pin $auto$clkbufmap.cc:265:execute$435 (location:HR_5_CC_38_19P) to fabric",
     "      Use FCLK: hvr_fclk_1_B",
     "Set CLKBUF configuration attributes",
     "  Set FCLK configuration attributes",
-    "    CLKBUF $auto$clkbufmap.cc:265:execute$433 (location:HR_1_CC_38_19P) use hvl_fclk_0_A",
-    "    CLKBUF $auto$clkbufmap.cc:265:execute$433 (location:HR_1_CC_38_19P) use hvl_fclk_0_B",
+    "    CLKBUF $auto$clkbufmap.cc:265:execute$432 (location:HR_1_CC_38_19P) use hvl_fclk_0_A",
+    "    CLKBUF $auto$clkbufmap.cc:265:execute$432 (location:HR_1_CC_38_19P) use hvl_fclk_0_B",
     "  Set FCLK configuration attributes",
-    "    CLKBUF $auto$clkbufmap.cc:265:execute$436 (location:HR_5_CC_38_19P) use hvr_fclk_1_B",
+    "    CLKBUF $auto$clkbufmap.cc:265:execute$435 (location:HR_5_CC_38_19P) use hvr_fclk_1_B",
     "Allocate PLL resource (and set PLLREF configuration attributes)",
     "  PLL pll (location:HP_1_CC_18_9P) uses FCLK 'hp_fclk_0_A, hvl_fclk_1_A'",
     "    Pin resource: 3, PLL FCLK requested resource: 1, PLL availability: 3",
@@ -76,7 +79,7 @@
     "      Property",
     "        Rule I_BUF.IOSTANDARD",
     "          Match",
-    "  Module: CLK_BUF ($auto$clkbufmap.cc:265:execute$433)",
+    "  Module: CLK_BUF ($auto$clkbufmap.cc:265:execute$432)",
     "    Object: clk0",
     "      Parameter",
     "      Property",
@@ -120,7 +123,7 @@
     "      Property",
     "        Rule I_BUF.IOSTANDARD",
     "          Mismatch",
-    "  Module: CLK_BUF ($auto$clkbufmap.cc:265:execute$436)",
+    "  Module: CLK_BUF ($auto$clkbufmap.cc:265:execute$435)",
     "    Object: clk2",
     "      Parameter",
     "      Property",
@@ -130,6 +133,21 @@
     "          Match",
     "        Rule CLK_BUF.ROOT_MUX",
     "          Match",
+    "  Module: O_BUF ($iopadmap$top.clk_out)",
+    "    Object: clk_out",
+    "      Parameter",
+    "      Property",
+    "        Rule O_BUF.IOSTANDARD",
+    "          Mismatch",
+    "  Module: O_SERDES_CLK (o_serdes_clk)",
+    "    Object: clk_out",
+    "      Parameter",
+    "        Rule O_SERDES_CLK.CLK_PHASE",
+    "          Match",
+    "            Defined function: parse_o_serdes_clk_phase_parameter",
+    "        Rule O_SERDES_CLK.DDR_MODE",
+    "          Match",
+    "      Property",
     "  Module: I_BUF ($iopadmap$top.din)",
     "    Object: din",
     "      Parameter",
@@ -162,6 +180,8 @@
     "  Module: I_SERDES (i_serdes)",
     "    Object: din_serdes",
     "      Parameter",
+    "        Rule I_SERDES.BYPASS",
+    "          Match",
     "        Rule I_SERDES.DDR_MODE",
     "          Match",
     "        Rule I_SERDES.DPA_MODE",
@@ -194,6 +214,8 @@
     "  Module: O_SERDES (o_serdes)",
     "    Object: dout_serdes",
     "      Parameter",
+    "        Rule O_SERDES.BYPASS",
+    "          Match",
     "        Rule O_SERDES.DDR_MODE",
     "          Match",
     "      Property",
@@ -338,12 +360,14 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
     {
       "module" : "CLK_BUF",
-      "name" : "$auto$clkbufmap.cc:265:execute$433",
+      "name" : "$auto$clkbufmap.cc:265:execute$432",
       "linked_object" : "clk0",
       "linked_objects" : {
         "clk0" : {
@@ -410,7 +434,7 @@
       },
       "connectivity" : {
         "I" : "$iopadmap$clk0",
-        "O" : "$auto$clkbufmap.cc:298:execute$435"
+        "O" : "$auto$clkbufmap.cc:298:execute$434"
       },
       "parameters" : {
         "ROUTE_TO_FABRIC_CLK" : "0"
@@ -428,6 +452,8 @@
           "Use FCLK: hvl_fclk_0_A"
         ]
       },
+      "errors" : [
+      ],
       "__CDR_CLK_ROOT_SEL_A__" : "__DONT__",
       "__CDR_CLK_ROOT_SEL_B__" : "__DONT__",
       "__CORE_CLK_ROOT_SEL_A__" : "__DONT__",
@@ -471,6 +497,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -507,6 +535,8 @@
           "Not able to route clock-capable pin clk_buf (location:HP_1_CC_18_9P) to gearbox module o_delay clock (module:O_DELAY) (location:HR_1_6_3P). Reason: They are not in same physical bank"
         ]
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail to route the clock"
     },
@@ -622,16 +652,20 @@
         "CLK_OUT" : [
           "i_serdes",
           "i_ddr",
-          "o_serdes"
+          "o_serdes",
+          "o_serdes_clk"
         ]
       },
       "route_clock_result" : {
         "CLK_OUT" : [
           "Use FCLK: hvl_fclk_1_A",
           "Use FCLK: hp_fclk_0_A",
+          "Use FCLK: hvl_fclk_1_A",
           "Use FCLK: hvl_fclk_1_A"
         ]
       },
+      "errors" : [
+      ],
       "__cfg_pllref_hp_bank_rx_io_sel__" : "0",
       "__cfg_pllref_hp_rx_io_sel__" : "0",
       "__cfg_pllref_hv_bank_rx_io_sel__" : "__DONT__",
@@ -677,12 +711,14 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
     {
       "module" : "CLK_BUF",
-      "name" : "$auto$clkbufmap.cc:265:execute$436",
+      "name" : "$auto$clkbufmap.cc:265:execute$435",
       "linked_object" : "clk2",
       "linked_objects" : {
         "clk2" : {
@@ -735,7 +771,7 @@
       },
       "connectivity" : {
         "I" : "$iopadmap$clk2",
-        "O" : "$auto$clkbufmap.cc:298:execute$438"
+        "O" : "$auto$clkbufmap.cc:298:execute$437"
       },
       "parameters" : {
         "ROUTE_TO_FABRIC_CLK" : "2"
@@ -747,6 +783,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__CDR_CLK_ROOT_SEL_A__" : "__DONT__",
       "__CDR_CLK_ROOT_SEL_B__" : "__DONT__",
       "__CORE_CLK_ROOT_SEL_A__" : "__DONT__",
@@ -755,6 +793,80 @@
       "__bank__" : "1",
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__clock_pin_is_valid__,__check_fabric_clock_resource__,__update_fabric_clock_resource__"
+    },
+    {
+      "module" : "O_BUF",
+      "name" : "$iopadmap$top.clk_out",
+      "linked_object" : "clk_out",
+      "linked_objects" : {
+        "clk_out" : {
+          "location" : "HR_2_2_1P",
+          "properties" : {
+          },
+          "config_attributes" : [
+            {
+              "O_BUF" : "IOSTANDARD==DEFAULT"
+            }
+          ]
+        }
+      },
+      "connectivity" : {
+        "I" : "$iopadmap$clk_out",
+        "O" : "clk_out"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+        "O_SERDES_CLK"
+      ],
+      "route_clock_to" : {
+      },
+      "route_clock_result" : {
+      },
+      "errors" : [
+      ],
+      "__validation__" : "TRUE",
+      "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
+    },
+    {
+      "module" : "O_SERDES_CLK",
+      "name" : "o_serdes_clk",
+      "linked_object" : "clk_out",
+      "linked_objects" : {
+        "clk_out" : {
+          "location" : "HR_2_2_1P",
+          "properties" : {
+          },
+          "config_attributes" : [
+            {
+              "TX_CLK_PHASE" : "TX_phase_270"
+            },
+            {
+              "O_SERDES_CLK" : "DDR_MODE==SDR"
+            }
+          ]
+        }
+      },
+      "connectivity" : {
+        "OUTPUT_CLK" : "$iopadmap$clk_out",
+        "PLL_CLK" : "pll_clk"
+      },
+      "parameters" : {
+        "CLOCK_PHASE" : "270",
+        "DATA_RATE" : "SDR"
+      },
+      "pre_primitive" : "O_BUF",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+      },
+      "route_clock_result" : {
+      },
+      "errors" : [
+      ],
+      "__validation__" : "TRUE",
+      "__validation_msg__" : "Pass:__check_data_rate_parameter__,__check_clock_phase_parameter__"
     },
     {
       "module" : "I_BUF",
@@ -792,6 +904,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -814,7 +928,7 @@
         }
       },
       "connectivity" : {
-        "CLK_IN" : "$auto$clkbufmap.cc:298:execute$435",
+        "CLK_IN" : "$auto$clkbufmap.cc:298:execute$434",
         "I" : "$iopadmap$din",
         "O" : "din_delay"
       },
@@ -828,6 +942,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -864,6 +980,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -898,6 +1016,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -911,6 +1031,9 @@
           "properties" : {
           },
           "config_attributes" : [
+            {
+              "RX_BYPASS" : "RX_gear_on"
+            },
             {
               "I_SERDES" : "DDR_MODE==SDR"
             },
@@ -937,8 +1060,10 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
-      "__validation_msg__" : ""
+      "__validation_msg__" : "Pass:__check_data_rate_parameter__,__check_dpa_mode_parameter__"
     },
     {
       "module" : "O_BUF",
@@ -972,6 +1097,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1008,6 +1135,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1040,6 +1169,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1073,6 +1204,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1086,6 +1219,9 @@
           "properties" : {
           },
           "config_attributes" : [
+            {
+              "TX_BYPASS" : "TX_gear_on"
+            },
             {
               "O_SERDES" : "DDR_MODE==DDR"
             }
@@ -1108,8 +1244,10 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
-      "__validation_msg__" : ""
+      "__validation_msg__" : "Pass:__check_data_rate_parameter__"
     },
     {
       "module" : "I_BUF",
@@ -1138,6 +1276,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "FALSE",
       "__validation_msg__" : "Fail:__pin_is_valid__"
     },
@@ -1174,6 +1314,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
@@ -1209,6 +1351,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__check_boot_clock_resource__"
     },
@@ -1300,6 +1444,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__cfg_pllref_hp_bank_rx_io_sel__" : "__DONT__",
       "__cfg_pllref_hp_rx_io_sel__" : "__DONT__",
       "__cfg_pllref_hv_bank_rx_io_sel__" : "__DONT__",
@@ -1358,6 +1504,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__ds_pin_is_valid__,__pin_is_differential__,__check_ds_pin_resource__"
     },
@@ -1400,6 +1548,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1444,6 +1594,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__ds_pin_is_valid__,__pin_is_differential__,__check_ds_pin_resource__"
     },
@@ -1486,6 +1638,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     },
@@ -1530,6 +1684,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__ds_pin_is_valid__,__pin_is_differential__,__check_ds_pin_resource__"
     },
@@ -1572,6 +1728,8 @@
       },
       "route_clock_result" : {
       },
+      "errors" : [
+      ],
       "__validation__" : "TRUE",
       "__validation_msg__" : ""
     }

--- a/tests/unittest/ModelConfig/golden/model_config.simplified.property.json
+++ b/tests/unittest/ModelConfig/golden/model_config.simplified.property.json
@@ -1,0 +1,14 @@
+{
+  "clk0": {
+    "IOSTANDARD": "LVCMOS_18_HP",
+    "PACKAGE_PIN": "HR_1_CC_38_19P"
+  },
+  "din": {
+    "IOSTANDARD": "LVCMOS_18_HR",
+    "PACKAGE_PIN": "HR_1_4_2P"
+  },
+  "dout": {
+    "IOSTANDARD": "LVCMOS_18_HR",
+    "PACKAGE_PIN": "HR_1_6_3P"
+  }
+}

--- a/tests/unittest/ModelConfig/golden/model_config_detail.txt
+++ b/tests/unittest/ModelConfig/golden/model_config_detail.txt
@@ -5,19 +5,19 @@
 // Format: DETAIL
 Block SUB1_A []
   Attributes:
-    ATTR1 - Addr: 0x00000000, Size:  2, Value: (0x00000001) 1 { SUB1_A [mode:MODE1] }
-    ATTR2 - Addr: 0x00000002, Size:  6, Value: (0x0000001A) 26 { SUB1_A [mode:MODE1] }
-    ATTR3 - Addr: 0x00000008, Size:  2, Value: (0x00000003) 3 { SUB1_A [mode:MODE1] }
+    ATTR1 - Addr: 0x00000000, Size:  2, Value: (0x00000001) 1 { set_attr SUB1_A [mode:MODE1] }
+    ATTR2 - Addr: 0x00000002, Size:  6, Value: (0x0000001A) 26 { set_attr SUB1_A [mode:MODE1] }
+    ATTR3 - Addr: 0x00000008, Size:  2, Value: (0x00000003) 3 { set_attr SUB1_A [mode:MODE1] }
 Block SUB1_B []
   Attributes:
-    ATTR1 - Addr: 0x0000000A, Size:  2, Value: (0x00000002) 2 { SUB1_B [ATTR1:ENUM3] }
-    ATTR2 - Addr: 0x0000000C, Size:  6, Value: (0x00000011) 17 { SUB1_B [ATTR2:17] }
+    ATTR1 - Addr: 0x0000000A, Size:  2, Value: (0x00000002) 2 { set_attr SUB1_B [ATTR1:ENUM3] }
+    ATTR2 - Addr: 0x0000000C, Size:  6, Value: (0x00000011) 17 { set_attr SUB1_B [ATTR2:17] }
     ATTR3 - Addr: 0x00000012, Size:  2, Value: (0x00000002) 2
 Block SUB2_A []
   Attributes:
-    ATTR1 - Addr: 0x00000014, Size:  1, Value: (0x00000001) 1 { SUB2_A [ATTR1:ENUM2] }
-    ATTR2 - Addr: 0x00000015, Size:  2, Value: (0x00000003) 3 { SUB2_A [ATTR2:ENUM2] }
-    ATTR3 - Addr: 0x00000017, Size:  9, Value: (0x00000155) 341 { SUB2_A [ATTR3:0x155] }
+    ATTR1 - Addr: 0x00000014, Size:  1, Value: (0x00000001) 1 { set_attr SUB2_A [ATTR1:ENUM2] }
+    ATTR2 - Addr: 0x00000015, Size:  2, Value: (0x00000003) 3 { set_attr SUB2_A [ATTR2:ENUM2] }
+    ATTR3 - Addr: 0x00000017, Size:  9, Value: (0x00000155) 341 { set_attr SUB2_A [ATTR3:0x155] }
 Block SUB2_B []
   Attributes:
     ATTR1 - Addr: 0x00000020, Size:  1, Value: (0x00000001) 1

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
@@ -994,11 +994,11 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_19 [HR_5_CC_38_19P]
                       PEER_IS_ON - Addr: 0x000006BF, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x000006C0, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x000006C1, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x000006C3, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], $auto$clkbufmap.cc:265:execute$436 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
+                       TX_BYPASS - Addr: 0x000006C3, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], $auto$clkbufmap.cc:265:execute$435 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x000006C4, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x000006C6, Size:  6, Value: (0x00000000) 0 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x000006CC, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x000006CE, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], $auto$clkbufmap.cc:265:execute$436 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
+                       RX_BYPASS - Addr: 0x000006CE, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], $auto$clkbufmap.cc:265:execute$435 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                           RX_DLY - Addr: 0x000006CF, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x000006D5, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000006D7, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -1930,15 +1930,15 @@ Block u_GBOX_HV_40X2_VR.u_HV_PGEN_dummy []
 Block u_GBOX_HV_40X2_VR.u_gbox_fclk_mux_all []
   Attributes:
          cfg_rxclk_phase_sel_B_0 - Addr: 0x00000D22, Size:  1, Value: (0x00000000) 0
-         cfg_rxclk_phase_sel_B_1 - Addr: 0x00000D23, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$436 [CLK_BUF] [cfg_rxclk_phase_sel_B_1:1] [from HR_5_CC_38_19P] }
+         cfg_rxclk_phase_sel_B_1 - Addr: 0x00000D23, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$435 [CLK_BUF] [cfg_rxclk_phase_sel_B_1:1] [from HR_5_CC_38_19P] }
          cfg_rxclk_phase_sel_A_0 - Addr: 0x00000D24, Size:  1, Value: (0x00000000) 0
          cfg_rxclk_phase_sel_A_1 - Addr: 0x00000D25, Size:  1, Value: (0x00000000) 0
            cfg_rx_fclkio_sel_B_0 - Addr: 0x00000D26, Size:  1, Value: (0x00000000) 0
-           cfg_rx_fclkio_sel_B_1 - Addr: 0x00000D27, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$436 [CLK_BUF] [cfg_rx_fclkio_sel_B_1:1] [from HR_5_CC_38_19P] }
+           cfg_rx_fclkio_sel_B_1 - Addr: 0x00000D27, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$435 [CLK_BUF] [cfg_rx_fclkio_sel_B_1:1] [from HR_5_CC_38_19P] }
            cfg_rx_fclkio_sel_A_0 - Addr: 0x00000D28, Size:  1, Value: (0x00000000) 0
            cfg_rx_fclkio_sel_A_1 - Addr: 0x00000D29, Size:  1, Value: (0x00000000) 0
              cfg_vco_clk_sel_B_0 - Addr: 0x00000D2A, Size:  1, Value: (0x00000000) 0
-             cfg_vco_clk_sel_B_1 - Addr: 0x00000D2B, Size:  1, Value: (0x00000000) 0 { $auto$clkbufmap.cc:265:execute$436 [CLK_BUF] [cfg_vco_clk_sel_B_1:0] [from HR_5_CC_38_19P] }
+             cfg_vco_clk_sel_B_1 - Addr: 0x00000D2B, Size:  1, Value: (0x00000000) 0 { $auto$clkbufmap.cc:265:execute$435 [CLK_BUF] [cfg_vco_clk_sel_B_1:0] [from HR_5_CC_38_19P] }
              cfg_vco_clk_sel_A_0 - Addr: 0x00000D2C, Size:  1, Value: (0x00000000) 0
              cfg_vco_clk_sel_A_1 - Addr: 0x00000D2D, Size:  1, Value: (0x00000000) 0
 Block u_GBOX_HV_40X2_VR.u_gbox_root_bank_clkmux_0 []
@@ -1951,7 +1951,7 @@ Block u_GBOX_HV_40X2_VR.u_gbox_root_bank_clkmux_1 []
   Attributes:
               CDR_CLK_ROOT_SEL_B - Addr: 0x00000D42, Size:  5, Value: (0x00000000) 0
               CDR_CLK_ROOT_SEL_A - Addr: 0x00000D47, Size:  5, Value: (0x00000000) 0
-             CORE_CLK_ROOT_SEL_B - Addr: 0x00000D4C, Size:  5, Value: (0x00000012) 18 { $auto$clkbufmap.cc:265:execute$436 [CLK_BUF] [CORE_CLK_ROOT_SEL_B:18] [from HR_5_CC_38_19P] }
+             CORE_CLK_ROOT_SEL_B - Addr: 0x00000D4C, Size:  5, Value: (0x00000012) 18 { $auto$clkbufmap.cc:265:execute$435 [CLK_BUF] [CORE_CLK_ROOT_SEL_B:18] [from HR_5_CC_38_19P] }
              CORE_CLK_ROOT_SEL_A - Addr: 0x00000D51, Size:  5, Value: (0x00000000) 0
 Block u_GBOX_HP_40X2.u_HP_GBOX_BK1_B_19 [HP_2_CC_39_19N]
   Attributes:
@@ -3909,13 +3909,13 @@ Block u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_1 []
              CORE_CLK_ROOT_SEL_A - Addr: 0x00001AAB, Size:  5, Value: (0x00000000) 0
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_0 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AB0, Size:  6, Value: (0x00000009) 9 { $auto$clkbufmap.cc:265:execute$433 [CLK_BUF] [ROOT_MUX_SEL:9] [from HR_1_CC_38_19P] }
+                    ROOT_MUX_SEL - Addr: 0x00001AB0, Size:  6, Value: (0x00000009) 9 { $auto$clkbufmap.cc:265:execute$432 [CLK_BUF] [ROOT_MUX_SEL:9] [from HR_1_CC_38_19P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_1 []
   Attributes:
                     ROOT_MUX_SEL - Addr: 0x00001AB6, Size:  6, Value: (0x00000020) 32 { pll [PLL] [ROOT_MUX_SEL:32] [from HP_1_CC_18_9P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_2 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001ABC, Size:  6, Value: (0x00000013) 19 { $auto$clkbufmap.cc:265:execute$436 [CLK_BUF] [ROOT_MUX_SEL:19] [from HR_5_CC_38_19P] }
+                    ROOT_MUX_SEL - Addr: 0x00001ABC, Size:  6, Value: (0x00000013) 19 { $auto$clkbufmap.cc:265:execute$435 [CLK_BUF] [ROOT_MUX_SEL:19] [from HR_5_CC_38_19P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_3 []
   Attributes:
                     ROOT_MUX_SEL - Addr: 0x00001AC2, Size:  6, Value: (0x00000030) 48 { boot_clock [BOOT_CLOCK] [ROOT_MUX_SEL:48] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
@@ -4041,11 +4041,11 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_19 [HR_1_CC_38_19P]
                       PEER_IS_ON - Addr: 0x00001BEA, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
                      TX_CLOCK_IO - Addr: 0x00001BEB, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
                      TX_DDR_MODE - Addr: 0x00001BEC, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
-                       TX_BYPASS - Addr: 0x00001BEE, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP], $auto$clkbufmap.cc:265:execute$433 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00001BEE, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP], $auto$clkbufmap.cc:265:execute$432 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001BEF, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
                           TX_DLY - Addr: 0x00001BF1, Size:  6, Value: (0x00000000) 0 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
                      RX_DDR_MODE - Addr: 0x00001BF7, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
-                       RX_BYPASS - Addr: 0x00001BF9, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP], $auto$clkbufmap.cc:265:execute$433 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00001BF9, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP], $auto$clkbufmap.cc:265:execute$432 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                           RX_DLY - Addr: 0x00001BFA, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001C00, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
                     RX_MIPI_MODE - Addr: 0x00001C02, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
@@ -5860,28 +5860,28 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_1 [HR_2_3_1N]
                               MC - Addr: 0x00002859, Size:  4, Value: (0x00000000) 0
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_1 [HR_2_2_1P]
   Attributes:
-                            RATE - Addr: 0x0000285D, Size:  4, Value: (0x00000000) 0
-                    MASTER_SLAVE - Addr: 0x00002861, Size:  1, Value: (0x00000000) 0
-                      PEER_IS_ON - Addr: 0x00002862, Size:  1, Value: (0x00000000) 0
-                     TX_CLOCK_IO - Addr: 0x00002863, Size:  1, Value: (0x00000000) 0
-                     TX_DDR_MODE - Addr: 0x00002864, Size:  2, Value: (0x00000000) 0
-                       TX_BYPASS - Addr: 0x00002866, Size:  1, Value: (0x00000000) 0
-                    TX_CLK_PHASE - Addr: 0x00002867, Size:  2, Value: (0x00000000) 0
+                            RATE - Addr: 0x0000285D, Size:  4, Value: (0x00000003) 3 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                    MASTER_SLAVE - Addr: 0x00002861, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                      PEER_IS_ON - Addr: 0x00002862, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                     TX_CLOCK_IO - Addr: 0x00002863, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                     TX_DDR_MODE - Addr: 0x00002864, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00002866, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                    TX_CLK_PHASE - Addr: 0x00002867, Size:  2, Value: (0x00000003) 3 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT], o_serdes_clk [O_SERDES_CLK] [TX_CLK_PHASE:TX_phase_270] }
                           TX_DLY - Addr: 0x00002869, Size:  6, Value: (0x00000000) 0
-                     RX_DDR_MODE - Addr: 0x0000286F, Size:  2, Value: (0x00000000) 0
-                       RX_BYPASS - Addr: 0x00002871, Size:  1, Value: (0x00000000) 0
-                          RX_DLY - Addr: 0x00002872, Size:  6, Value: (0x00000000) 0
-                     RX_DPA_MODE - Addr: 0x00002878, Size:  2, Value: (0x00000000) 0
-                    RX_MIPI_MODE - Addr: 0x0000287A, Size:  1, Value: (0x00000000) 0
-                         TX_MODE - Addr: 0x0000287B, Size:  1, Value: (0x00000000) 0
-                         RX_MODE - Addr: 0x0000287C, Size:  1, Value: (0x00000000) 0
-                     RX_CLOCK_IO - Addr: 0x0000287D, Size:  1, Value: (0x00000000) 0
-                            DFEN - Addr: 0x0000287E, Size:  1, Value: (0x00000000) 0
-                              SR - Addr: 0x0000287F, Size:  1, Value: (0x00000000) 0
-                              PE - Addr: 0x00002880, Size:  1, Value: (0x00000000) 0
-                             PUD - Addr: 0x00002881, Size:  1, Value: (0x00000000) 0
-                         DFODTEN - Addr: 0x00002882, Size:  1, Value: (0x00000000) 0
-                              MC - Addr: 0x00002883, Size:  4, Value: (0x00000000) 0
+                     RX_DDR_MODE - Addr: 0x0000286F, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00002871, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x00002872, Size:  6, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                     RX_DPA_MODE - Addr: 0x00002878, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                    RX_MIPI_MODE - Addr: 0x0000287A, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x0000287B, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x0000287C, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                     RX_CLOCK_IO - Addr: 0x0000287D, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                            DFEN - Addr: 0x0000287E, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                              SR - Addr: 0x0000287F, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00002880, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                             PUD - Addr: 0x00002881, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                         DFODTEN - Addr: 0x00002882, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                              MC - Addr: 0x00002883, Size:  4, Value: (0x00000001) 1 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_0 [HR_2_1_0N]
   Attributes:
                             RATE - Addr: 0x00002887, Size:  4, Value: (0x00000003) 3 { $iopadmap$top.dout_serdes [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
@@ -5889,7 +5889,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_0 [HR_2_1_0N]
                       PEER_IS_ON - Addr: 0x0000288C, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.dout_serdes [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x0000288D, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.dout_serdes [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x0000288E, Size:  2, Value: (0x00000001) 1 { $iopadmap$top.dout_serdes [O_BUF] [O_BUF:IOSTANDARD==DEFAULT], o_serdes [O_SERDES] [O_SERDES:DDR_MODE==DDR] }
-                       TX_BYPASS - Addr: 0x00002890, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.dout_serdes [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00002890, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.dout_serdes [O_BUF] [O_BUF:IOSTANDARD==DEFAULT], o_serdes [O_SERDES] [TX_BYPASS:TX_gear_on] }
                     TX_CLK_PHASE - Addr: 0x00002891, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.dout_serdes [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002893, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00002899, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.dout_serdes [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
@@ -5917,7 +5917,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_0 [HR_2_0_0P]
                     TX_CLK_PHASE - Addr: 0x000028BB, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x000028BD, Size:  6, Value: (0x00000000) 0 { $iopadmap$top.din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x000028C3, Size:  2, Value: (0x00000002) 2 { $iopadmap$top.din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_serdes [I_SERDES] [I_SERDES:DDR_MODE==SDR] }
-                       RX_BYPASS - Addr: 0x000028C5, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x000028C5, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_serdes [I_SERDES] [RX_BYPASS:RX_gear_on] }
                           RX_DLY - Addr: 0x000028C6, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x000028CC, Size:  2, Value: (0x00000002) 2 { $iopadmap$top.din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_serdes [I_SERDES] [I_SERDES:DPA_MODE==DPA] }
                     RX_MIPI_MODE - Addr: 0x000028CE, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -5936,23 +5936,23 @@ Block u_GBOX_HV_40X2_VL.u_HV_PGEN_dummy []
                    hv_cfg_EN_BK1 - Addr: 0x000028DC, Size:  1, Value: (0x00000000) 0
 Block u_GBOX_HV_40X2_VL.u_gbox_fclk_mux_all []
   Attributes:
-         cfg_rxclk_phase_sel_B_0 - Addr: 0x000028DD, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$433 [CLK_BUF] [cfg_rxclk_phase_sel_B_0:1] [from HR_1_CC_38_19P] }
+         cfg_rxclk_phase_sel_B_0 - Addr: 0x000028DD, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$432 [CLK_BUF] [cfg_rxclk_phase_sel_B_0:1] [from HR_1_CC_38_19P] }
          cfg_rxclk_phase_sel_B_1 - Addr: 0x000028DE, Size:  1, Value: (0x00000000) 0
-         cfg_rxclk_phase_sel_A_0 - Addr: 0x000028DF, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$433 [CLK_BUF] [cfg_rxclk_phase_sel_A_0:1] [from HR_1_CC_38_19P] }
+         cfg_rxclk_phase_sel_A_0 - Addr: 0x000028DF, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$432 [CLK_BUF] [cfg_rxclk_phase_sel_A_0:1] [from HR_1_CC_38_19P] }
          cfg_rxclk_phase_sel_A_1 - Addr: 0x000028E0, Size:  1, Value: (0x00000000) 0 { pll [PLL] [cfg_rxclk_phase_sel_A_1:0] [from HP_1_CC_18_9P] }
-           cfg_rx_fclkio_sel_B_0 - Addr: 0x000028E1, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$433 [CLK_BUF] [cfg_rx_fclkio_sel_B_0:1] [from HR_1_CC_38_19P] }
+           cfg_rx_fclkio_sel_B_0 - Addr: 0x000028E1, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$432 [CLK_BUF] [cfg_rx_fclkio_sel_B_0:1] [from HR_1_CC_38_19P] }
            cfg_rx_fclkio_sel_B_1 - Addr: 0x000028E2, Size:  1, Value: (0x00000000) 0
-           cfg_rx_fclkio_sel_A_0 - Addr: 0x000028E3, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$433 [CLK_BUF] [cfg_rx_fclkio_sel_A_0:1] [from HR_1_CC_38_19P] }
+           cfg_rx_fclkio_sel_A_0 - Addr: 0x000028E3, Size:  1, Value: (0x00000001) 1 { $auto$clkbufmap.cc:265:execute$432 [CLK_BUF] [cfg_rx_fclkio_sel_A_0:1] [from HR_1_CC_38_19P] }
            cfg_rx_fclkio_sel_A_1 - Addr: 0x000028E4, Size:  1, Value: (0x00000000) 0 { pll [PLL] [cfg_rx_fclkio_sel_A_1:0] [from HP_1_CC_18_9P] }
-             cfg_vco_clk_sel_B_0 - Addr: 0x000028E5, Size:  1, Value: (0x00000000) 0 { $auto$clkbufmap.cc:265:execute$433 [CLK_BUF] [cfg_vco_clk_sel_B_0:0] [from HR_1_CC_38_19P] }
+             cfg_vco_clk_sel_B_0 - Addr: 0x000028E5, Size:  1, Value: (0x00000000) 0 { $auto$clkbufmap.cc:265:execute$432 [CLK_BUF] [cfg_vco_clk_sel_B_0:0] [from HR_1_CC_38_19P] }
              cfg_vco_clk_sel_B_1 - Addr: 0x000028E6, Size:  1, Value: (0x00000000) 0
-             cfg_vco_clk_sel_A_0 - Addr: 0x000028E7, Size:  1, Value: (0x00000000) 0 { $auto$clkbufmap.cc:265:execute$433 [CLK_BUF] [cfg_vco_clk_sel_A_0:0] [from HR_1_CC_38_19P] }
+             cfg_vco_clk_sel_A_0 - Addr: 0x000028E7, Size:  1, Value: (0x00000000) 0 { $auto$clkbufmap.cc:265:execute$432 [CLK_BUF] [cfg_vco_clk_sel_A_0:0] [from HR_1_CC_38_19P] }
              cfg_vco_clk_sel_A_1 - Addr: 0x000028E8, Size:  1, Value: (0x00000001) 1 { pll [PLL] [cfg_vco_clk_sel_A_1:1] [from HP_1_CC_18_9P] }
 Block u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_0 []
   Attributes:
               CDR_CLK_ROOT_SEL_B - Addr: 0x000028E9, Size:  5, Value: (0x00000000) 0
               CDR_CLK_ROOT_SEL_A - Addr: 0x000028EE, Size:  5, Value: (0x00000000) 0
-             CORE_CLK_ROOT_SEL_B - Addr: 0x000028F3, Size:  5, Value: (0x00000012) 18 { $auto$clkbufmap.cc:265:execute$433 [CLK_BUF] [CORE_CLK_ROOT_SEL_B:18] [from HR_1_CC_38_19P] }
+             CORE_CLK_ROOT_SEL_B - Addr: 0x000028F3, Size:  5, Value: (0x00000012) 18 { $auto$clkbufmap.cc:265:execute$432 [CLK_BUF] [CORE_CLK_ROOT_SEL_B:18] [from HR_1_CC_38_19P] }
              CORE_CLK_ROOT_SEL_A - Addr: 0x000028F8, Size:  5, Value: (0x00000000) 0
 Block u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_1 []
   Attributes:

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
@@ -5864,7 +5864,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_1 [HR_2_2_1P]
                     MASTER_SLAVE - Addr: 0x00002861, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
                       PEER_IS_ON - Addr: 0x00002862, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00002863, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
-                     TX_DDR_MODE - Addr: 0x00002864, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                     TX_DDR_MODE - Addr: 0x00002864, Size:  2, Value: (0x00000002) 2 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT], o_serdes_clk [O_SERDES_CLK] [O_SERDES_CLK:DDR_MODE==SDR] }
                        TX_BYPASS - Addr: 0x00002866, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00002867, Size:  2, Value: (0x00000003) 3 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT], o_serdes_clk [O_SERDES_CLK] [TX_CLK_PHASE:TX_phase_270] }
                           TX_DLY - Addr: 0x00002869, Size:  6, Value: (0x00000000) 0

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.negative.detail.bit
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.negative.detail.bit
@@ -5720,7 +5720,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_4 [HR_2_8_4P]
                     MASTER_SLAVE - Addr: 0x00002765, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
                       PEER_IS_ON - Addr: 0x00002766, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00002767, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
-                     TX_DDR_MODE - Addr: 0x00002768, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                     TX_DDR_MODE - Addr: 0x00002768, Size:  2, Value: (0x00000002) 2 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT], o_serdes_clk [O_SERDES_CLK] [O_SERDES_CLK:DDR_MODE==SDR] }
                        TX_BYPASS - Addr: 0x0000276A, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x0000276B, Size:  2, Value: (0x00000003) 3 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT], o_serdes_clk [O_SERDES_CLK] [TX_CLK_PHASE:TX_phase_270] }
                           TX_DLY - Addr: 0x0000276D, Size:  6, Value: (0x00000000) 0

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.negative.detail.bit
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.negative.detail.bit
@@ -4996,28 +4996,28 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_19 [HR_2_CC_39_19N]
                               MC - Addr: 0x00002271, Size:  4, Value: (0x00000000) 0
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_19 [HR_2_CC_38_19P]
   Attributes:
-                            RATE - Addr: 0x00002275, Size:  4, Value: (0x00000000) 0
-                    MASTER_SLAVE - Addr: 0x00002279, Size:  1, Value: (0x00000000) 0
-                      PEER_IS_ON - Addr: 0x0000227A, Size:  1, Value: (0x00000000) 0
-                     TX_CLOCK_IO - Addr: 0x0000227B, Size:  1, Value: (0x00000000) 0
-                     TX_DDR_MODE - Addr: 0x0000227C, Size:  2, Value: (0x00000000) 0
-                       TX_BYPASS - Addr: 0x0000227E, Size:  1, Value: (0x00000000) 0
-                    TX_CLK_PHASE - Addr: 0x0000227F, Size:  2, Value: (0x00000000) 0
-                          TX_DLY - Addr: 0x00002281, Size:  6, Value: (0x00000000) 0
-                     RX_DDR_MODE - Addr: 0x00002287, Size:  2, Value: (0x00000000) 0
-                       RX_BYPASS - Addr: 0x00002289, Size:  1, Value: (0x00000000) 0
+                            RATE - Addr: 0x00002275, Size:  4, Value: (0x00000003) 3 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                    MASTER_SLAVE - Addr: 0x00002279, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                      PEER_IS_ON - Addr: 0x0000227A, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                     TX_CLOCK_IO - Addr: 0x0000227B, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                     TX_DDR_MODE - Addr: 0x0000227C, Size:  2, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x0000227E, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                    TX_CLK_PHASE - Addr: 0x0000227F, Size:  2, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00002281, Size:  6, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                     RX_DDR_MODE - Addr: 0x00002287, Size:  2, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00002289, Size:  1, Value: (0x00000001) 1 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x0000228A, Size:  6, Value: (0x00000000) 0
-                     RX_DPA_MODE - Addr: 0x00002290, Size:  2, Value: (0x00000000) 0
-                    RX_MIPI_MODE - Addr: 0x00002292, Size:  1, Value: (0x00000000) 0
-                         TX_MODE - Addr: 0x00002293, Size:  1, Value: (0x00000000) 0
-                         RX_MODE - Addr: 0x00002294, Size:  1, Value: (0x00000000) 0
-                     RX_CLOCK_IO - Addr: 0x00002295, Size:  1, Value: (0x00000000) 0
-                            DFEN - Addr: 0x00002296, Size:  1, Value: (0x00000000) 0
-                              SR - Addr: 0x00002297, Size:  1, Value: (0x00000000) 0
-                              PE - Addr: 0x00002298, Size:  1, Value: (0x00000000) 0
-                             PUD - Addr: 0x00002299, Size:  1, Value: (0x00000000) 0
-                         DFODTEN - Addr: 0x0000229A, Size:  1, Value: (0x00000000) 0
-                              MC - Addr: 0x0000229B, Size:  4, Value: (0x00000000) 0
+                     RX_DPA_MODE - Addr: 0x00002290, Size:  2, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                    RX_MIPI_MODE - Addr: 0x00002292, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00002293, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00002294, Size:  1, Value: (0x00000001) 1 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                     RX_CLOCK_IO - Addr: 0x00002295, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                            DFEN - Addr: 0x00002296, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                              SR - Addr: 0x00002297, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00002298, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:WEAK_KEEPER==DEFAULT] }
+                             PUD - Addr: 0x00002299, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:WEAK_KEEPER==DEFAULT] }
+                         DFODTEN - Addr: 0x0000229A, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                              MC - Addr: 0x0000229B, Size:  4, Value: (0x00000001) 1 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_18 [HR_2_37_18N]
   Attributes:
                             RATE - Addr: 0x0000229F, Size:  4, Value: (0x00000000) 0
@@ -5716,28 +5716,28 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_4 [HR_2_9_4N]
                               MC - Addr: 0x0000275D, Size:  4, Value: (0x00000000) 0
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_4 [HR_2_8_4P]
   Attributes:
-                            RATE - Addr: 0x00002761, Size:  4, Value: (0x00000000) 0
-                    MASTER_SLAVE - Addr: 0x00002765, Size:  1, Value: (0x00000000) 0
-                      PEER_IS_ON - Addr: 0x00002766, Size:  1, Value: (0x00000000) 0
-                     TX_CLOCK_IO - Addr: 0x00002767, Size:  1, Value: (0x00000000) 0
-                     TX_DDR_MODE - Addr: 0x00002768, Size:  2, Value: (0x00000000) 0
-                       TX_BYPASS - Addr: 0x0000276A, Size:  1, Value: (0x00000000) 0
-                    TX_CLK_PHASE - Addr: 0x0000276B, Size:  2, Value: (0x00000000) 0
+                            RATE - Addr: 0x00002761, Size:  4, Value: (0x00000003) 3 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                    MASTER_SLAVE - Addr: 0x00002765, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                      PEER_IS_ON - Addr: 0x00002766, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                     TX_CLOCK_IO - Addr: 0x00002767, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                     TX_DDR_MODE - Addr: 0x00002768, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x0000276A, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                    TX_CLK_PHASE - Addr: 0x0000276B, Size:  2, Value: (0x00000003) 3 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT], o_serdes_clk [O_SERDES_CLK] [TX_CLK_PHASE:TX_phase_270] }
                           TX_DLY - Addr: 0x0000276D, Size:  6, Value: (0x00000000) 0
-                     RX_DDR_MODE - Addr: 0x00002773, Size:  2, Value: (0x00000000) 0
-                       RX_BYPASS - Addr: 0x00002775, Size:  1, Value: (0x00000000) 0
-                          RX_DLY - Addr: 0x00002776, Size:  6, Value: (0x00000000) 0
-                     RX_DPA_MODE - Addr: 0x0000277C, Size:  2, Value: (0x00000000) 0
-                    RX_MIPI_MODE - Addr: 0x0000277E, Size:  1, Value: (0x00000000) 0
-                         TX_MODE - Addr: 0x0000277F, Size:  1, Value: (0x00000000) 0
-                         RX_MODE - Addr: 0x00002780, Size:  1, Value: (0x00000000) 0
-                     RX_CLOCK_IO - Addr: 0x00002781, Size:  1, Value: (0x00000000) 0
-                            DFEN - Addr: 0x00002782, Size:  1, Value: (0x00000000) 0
-                              SR - Addr: 0x00002783, Size:  1, Value: (0x00000000) 0
-                              PE - Addr: 0x00002784, Size:  1, Value: (0x00000000) 0
-                             PUD - Addr: 0x00002785, Size:  1, Value: (0x00000000) 0
-                         DFODTEN - Addr: 0x00002786, Size:  1, Value: (0x00000000) 0
-                              MC - Addr: 0x00002787, Size:  4, Value: (0x00000000) 0
+                     RX_DDR_MODE - Addr: 0x00002773, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00002775, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x00002776, Size:  6, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                     RX_DPA_MODE - Addr: 0x0000277C, Size:  2, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                    RX_MIPI_MODE - Addr: 0x0000277E, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x0000277F, Size:  1, Value: (0x00000001) 1 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00002780, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                     RX_CLOCK_IO - Addr: 0x00002781, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                            DFEN - Addr: 0x00002782, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                              SR - Addr: 0x00002783, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00002784, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                             PUD - Addr: 0x00002785, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                         DFODTEN - Addr: 0x00002786, Size:  1, Value: (0x00000000) 0 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
+                              MC - Addr: 0x00002787, Size:  4, Value: (0x00000001) 1 { $iopadmap$top.clk_out [O_BUF] [O_BUF:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_3 [HR_2_7_3N]
   Attributes:
                             RATE - Addr: 0x0000278B, Size:  4, Value: (0x00000000) 0

--- a/tests/unittest/ModelConfig/model_config_netlist.negative.ppdb.json
+++ b/tests/unittest/ModelConfig/model_config_netlist.negative.ppdb.json
@@ -7,6 +7,9 @@
     "    Detect input port \\clk20 (index=0, width=1, offset=0)",
     "    Detect input port \\clk30 (index=0, width=1, offset=0)",
     "    Detect input port \\clk31 (index=0, width=1, offset=0)",
+    "    Detect input port \\clk40 (index=0, width=1, offset=0)",
+    "    Detect output port \\clk_out (index=0, width=1, offset=0)",
+    "    Detect output port \\clk_out_osc (index=0, width=1, offset=0)",
     "    Detect input port \\din00 (index=0, width=1, offset=0)",
     "    Detect input port \\din01 (index=0, width=1, offset=0)",
     "    Detect input port \\din10 (index=0, width=1, offset=0)",
@@ -41,6 +44,10 @@
     "    Get important connection of cell \\I_BUF $iopadmap$top.clk20",
     "      Cell port \\I is connected to input port \\clk20",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
+    "    Get important connection of cell \\O_BUF $iopadmap$top.clk_out",
+    "      Cell port \\O is connected to output port \\clk_out",
+    "    Get important connection of cell \\O_BUF $iopadmap$top.clk_out_osc",
+    "      Cell port \\O is connected to output port \\clk_out_osc",
     "    Get important connection of cell \\I_BUF $iopadmap$top.din00",
     "      Cell port \\I is connected to input port \\din00",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
@@ -95,6 +102,8 @@
     "    Get important connection of cell \\I_BUF \\i_buf31",
     "      Cell port \\I is connected to input port \\clk31",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
+    "    Get important connection of cell \\I_BUF \\i_buf40",
+    "      Cell port \\I is connected to input port \\clk40",
     "    Get important connection of cell \\I_BUF_DS \\i_buf_ds30",
     "      Cell port \\I_N is connected to input port \\din30_n",
     "      Cell port \\I_P is connected to input port \\din30_p",
@@ -115,12 +124,14 @@
     "      Connected \\clk_buf00",
     "    Try \\I_BUF $iopadmap$top.clk10 out connection: $iopadmap$clk10 -> \\clk_buf10",
     "      Connected \\clk_buf10",
-    "    Try \\I_BUF $iopadmap$top.clk20 out connection: $iopadmap$clk20 -> $auto$clkbufmap.cc:265:execute$707",
-    "      Connected $auto$clkbufmap.cc:265:execute$707",
+    "    Try \\I_BUF $iopadmap$top.clk20 out connection: $iopadmap$clk20 -> $auto$clkbufmap.cc:265:execute$706",
+    "      Connected $auto$clkbufmap.cc:265:execute$706",
     "    Try \\I_BUF \\i_buf30 out connection: \\ibuf30 -> \\clk_buf30",
     "      Connected \\clk_buf30",
     "    Try \\I_BUF \\i_buf31 out connection: \\ibuf31 -> \\clk_buf31",
     "      Connected \\clk_buf31",
+    "    Try \\I_BUF \\i_buf40 out connection: \\ibuf40 -> \\clk_buf40",
+    "      Connected \\clk_buf40",
     "  Trace \\CLK_BUF --> \\PLL",
     "    Try \\CLK_BUF \\clk_buf00 out connection: \\clkbuf00 -> \\pll00",
     "      Connected \\pll00",
@@ -217,6 +228,18 @@
     "  Trace \\O_BUFT_DS --> \\O_SERDES",
     "  Trace \\O_DELAY --> \\O_DDR",
     "  Trace \\O_DELAY --> \\O_SERDES",
+    "  Trace \\O_BUF --> \\O_SERDES_CLK",
+    "    Try \\O_BUF $iopadmap$top.clk_out out connection: $iopadmap$clk_out -> \\o_serdes_clk",
+    "      Connected \\o_serdes_clk",
+    "        Parameter \\CLOCK_PHASE: 270",
+    "        Parameter \\DATA_RATE: \"SDR\"",
+    "    Try \\O_BUF $iopadmap$top.clk_out_osc out connection: $iopadmap$clk_out_osc -> \\o_serdes_clk_osc",
+    "      Connected \\o_serdes_clk_osc",
+    "        Parameter \\CLOCK_PHASE: 180",
+    "        Parameter \\DATA_RATE: \"DDR\"",
+    "  Trace \\O_BUFT --> \\O_SERDES_CLK",
+    "  Trace \\O_BUF_DS --> \\O_SERDES_CLK",
+    "  Trace \\O_BUFT_DS --> \\O_SERDES_CLK",
     "  Trace gearbox clock source",
     "    \\I_DDR \\i_ddr00 port \\C: \\clkbuf00",
     "      Connected to \\CLK_BUF \\clk_buf00 port \\O",
@@ -242,12 +265,106 @@
     "      Connected to \\PLL \\pll30 port \\CLK_OUT",
     "    \\I_DDR \\i_ddr31 port \\C: \\pll31_clk",
     "      Connected to \\PLL \\pll31 port \\CLK_OUT",
+    "    \\O_SERDES_CLK \\o_serdes_clk port \\PLL_CLK: \\clkbuf40",
+    "      Connected to \\CLK_BUF \\clk_buf40 port \\O",
+    "    \\O_SERDES_CLK \\o_serdes_clk_osc port \\PLL_CLK: \\osc",
+    "      Warning: Not able to route signal \\osc to port \\PLL_CLK",
+    "  Trace Fabric Clock",
+    "    Module \\CLK_BUF \\clk_buf00: clock port \\O, net \\clkbuf00",
+    "      Connected to cell \\I_DDR \\i_ddr00",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\O_DDR \\o_ddr00",
+    "        Which is a primitive",
+    "        This is core_clk. Send to fabric",
+    "    Module \\PLL \\pll00: clock port \\CLK_OUT, net \\pll00_clk1",
+    "      Connected to cell \\I_DDR \\i_ddr01",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\O_DDR \\o_ddr01",
+    "        Which is a primitive",
+    "        This is core_clk. Send to fabric",
+    "    Module \\PLL \\pll00: clock port \\CLK_OUT_DIV2, net \\pll00_clk2",
+    "      Connected to cell \\DFFRE $abc$277$auto$blifparse.cc:377:parse_blif$278",
+    "        Which is not a IO primitive. Send to fabric",
+    "    Module \\PLL \\pll00: clock port \\CLK_OUT_DIV3, net \\pll00_clk3",
+    "      Connected to cell \\DFFRE $abc$270$auto$blifparse.cc:377:parse_blif$271",
+    "        Which is not a IO primitive. Send to fabric",
+    "    Module \\PLL \\pll00: clock port \\CLK_OUT_DIV4, net \\pll00_clk4",
+    "      Connected to cell \\DFFRE $abc$263$auto$blifparse.cc:377:parse_blif$264",
+    "        Which is not a IO primitive. Send to fabric",
+    "    Module \\CLK_BUF \\clk_buf10: clock port \\O, net \\clkbuf10",
+    "      Connected to cell \\I_DDR \\i_ddr10",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\I_DDR \\i_ddr11",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\I_DDR \\i_ddr12",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\O_DDR \\o_ddr10",
+    "        Which is a primitive",
+    "        This is core_clk. Send to fabric",
+    "    Module \\CLK_BUF $auto$clkbufmap.cc:265:execute$706: clock port \\O, net $auto$clkbufmap.cc:298:execute$708",
+    "      Connected to cell \\DFFRE $abc$284$auto$blifparse.cc:377:parse_blif$285",
+    "        Which is not a IO primitive. Send to fabric",
+    "    Module \\BOOT_CLOCK \\boot_clock: clock port \\O, net \\osc",
+    "      Connected to cell \\O_SERDES_CLK \\o_serdes_clk_osc",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\PLL \\pllosc0",
+    "        Which is a primitive",
+    "        This is core_clk. Send to fabric",
+    "    Module \\PLL \\pllosc0: clock port \\CLK_OUT, net \\pllosc0_clk0",
+    "      Connected to cell \\I_DDR \\i_ddr_osc0",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\I_DDR \\i_ddr_osc1",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\I_DDR \\i_ddr_osc2",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "    Module \\PLL \\pllosc1: clock port \\CLK_OUT_DIV2, net \\pllosc1_clk1",
+    "      Connected to cell \\I_DDR \\i_ddr_osc3",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "    Module \\PLL \\pllosc2: clock port \\CLK_OUT, net \\pllosc2_clk0",
+    "      Connected to cell \\I_DDR \\i_ddr_osc4",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "    Module \\CLK_BUF \\clk_buf30: clock port \\O, net \\clkbuf30",
+    "      Connected to cell \\PLL \\pll30",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "    Module \\PLL \\pll30: clock port \\CLK_OUT, net \\pll30_clk",
+    "      Connected to cell \\I_DDR \\i_ddr30",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "    Module \\CLK_BUF \\clk_buf31: clock port \\O, net \\clkbuf31",
+    "      Connected to cell \\PLL \\pll31",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "    Module \\PLL \\pll31: clock port \\CLK_OUT, net \\pll31_clk",
+    "      Connected to cell \\I_DDR \\i_ddr31",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\O_DDR \\o_ddr3x",
+    "        Which is a primitive",
+    "        This is core_clk. Send to fabric",
+    "    Module \\CLK_BUF \\clk_buf40: clock port \\O, net \\clkbuf40",
+    "      Connected to cell \\O_SERDES_CLK \\o_serdes_clk",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "  Summary",
     "        |-----------------------------------------------------------------------------------------------|",
     "        |                 ***********************************************************                   |",
     "    IN  |           clk00 * I_BUF |-> CLK_BUF |-> PLL                               *                   |",
     "    IN  |           clk10 * I_BUF |-> CLK_BUF                                       *                   |",
     "    IN  |           clk20 * I_BUF |-> CLK_BUF                                       *                   |",
+    "    OUT |                 *                                  O_SERDES_CLK |-> O_BUF * clk_out           |",
+    "    OUT |                 *                                  O_SERDES_CLK |-> O_BUF * clk_out_osc       |",
     "    IN  |           din00 * I_BUF |-> I_DDR                                         *                   |",
     "    IN  |           din01 * I_BUF |-> I_DDR                                         *                   |",
     "    IN  |           din10 * I_BUF |-> I_DDR                                         *                   |",
@@ -271,35 +388,40 @@
     "    IN  |                 *            |-> PLL                                      *                   |",
     "    IN  |           clk30 * I_BUF |-> CLK_BUF |-> PLL                               *                   |",
     "    IN  |           clk31 * I_BUF |-> CLK_BUF |-> PLL                               *                   |",
+    "    IN  |           clk40 * I_BUF |-> CLK_BUF                                       *                   |",
     "    IN  | din30_n+din30_p * I_BUF_DS |-> I_DDR                                      *                   |",
     "    IN  | din31_n+din31_p * I_BUF_DS |-> I_DDR                                      *                   |",
     "    OUT |                 *                                      O_DDR |-> O_BUF_DS * dout30_n+dout30_p |",
     "        |                 ***********************************************************                   |",
     "        |-----------------------------------------------------------------------------------------------|",
+    "  Final checking is good",
     "  Assign location HP_1_21_10N (and properties) to Port dout00",
     "  Assign location HR_2_3_1N (and properties) to Port din31_n",
-    "  Assign location HR_5_2_1P (and properties) to Port din11",
     "  Assign location HR_2_22_11P (and properties) to Port dinoutosc",
     "  Assign location HP_1_20_10P (and properties) to Port din00",
     "  Assign location HR_2_7_3N (and properties) to Port dout30_n",
     "  Assign location HR_5_3_1N (and properties) to Port dout11",
     "  Assign location HR_1_22_11P (and properties) to Port din12",
     "  Assign location HR_1_23_11N (and properties) to Port dout12",
+    "  Assign location HR_5_21_10N (and properties) to Port dinosc3",
+    "  Assign location HR_5_20_10P (and properties) to Port dinosc1",
+    "  Assign location HR_2_CC_38_19P (and properties) to Port clk40",
     "  Assign location HR_2_4_2P (and properties) to Port dout30_p",
+    "  Assign location HR_3_CC_38_19P (and properties) to Port clk31",
+    "  Assign location HR_2_9_4N (and properties) to Port clk_out_osc",
+    "  Assign location HP_1_CC_38_19P (and properties) to Port clk20",
     "  Assign location HR_2_1_0N (and properties) to Port din30_n",
     "  Assign location HP_1_CC_18_9P (and properties) to Port clk00",
     "  Assign location HR_2_0_0P (and properties) to Port din30_p",
     "  Assign location HR_1_21_10N (and properties) to Port dout01",
+    "  Assign location HR_5_2_1P (and properties) to Port din11",
     "  Assign location HR_2_2_1P (and properties) to Port din31_p",
     "  Assign location HR_1_CC_18_9P (and properties) to Port clk10",
     "  Assign location HR_1_30_15P (and properties) to Port dinosc4",
     "  Assign location HR_2_20_10P (and properties) to Port dinosc0",
-    "  Assign location HP_1_CC_38_19P (and properties) to Port clk20",
+    "  Assign location HR_2_8_4P (and properties) to Port clk_out",
     "  Assign location HR_1_20_10P (and properties) to Port din01",
     "  Assign location HR_1_CC_38_19P (and properties) to Port clk30",
-    "  Assign location HR_3_CC_38_19P (and properties) to Port clk31",
-    "  Assign location HR_5_20_10P (and properties) to Port dinosc1",
-    "  Assign location HR_5_21_10N (and properties) to Port dinosc3",
     "End of IO Analysis"
   ],
   "instances" : [
@@ -326,7 +448,9 @@
         "CLK_BUF"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "CLK_BUF",
@@ -355,7 +479,9 @@
         "O" : [
           "i_ddr00"
         ]
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "PLL",
@@ -396,7 +522,9 @@
         "CLK_OUT" : [
           "i_ddr01"
         ]
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -421,7 +549,9 @@
         "CLK_BUF"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "CLK_BUF",
@@ -451,7 +581,9 @@
           "i_ddr11",
           "i_ddr12"
         ]
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -476,11 +608,13 @@
         "CLK_BUF"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "CLK_BUF",
-      "name" : "$auto$clkbufmap.cc:265:execute$707",
+      "name" : "$auto$clkbufmap.cc:265:execute$706",
       "linked_object" : "clk20",
       "linked_objects" : {
         "clk20" : {
@@ -492,7 +626,7 @@
       },
       "connectivity" : {
         "I" : "$iopadmap$clk20",
-        "O" : "$auto$clkbufmap.cc:298:execute$709"
+        "O" : "$auto$clkbufmap.cc:298:execute$708"
       },
       "parameters" : {
         "ROUTE_TO_FABRIC_CLK" : "6"
@@ -501,7 +635,116 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
+    },
+    {
+      "module" : "O_BUF",
+      "name" : "$iopadmap$top.clk_out",
+      "linked_object" : "clk_out",
+      "linked_objects" : {
+        "clk_out" : {
+          "location" : "HR_2_8_4P",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "I" : "$iopadmap$clk_out",
+        "O" : "clk_out"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+        "O_SERDES_CLK"
+      ],
+      "route_clock_to" : {
+      },
+      "errors" : [
+      ]
+    },
+    {
+      "module" : "O_SERDES_CLK",
+      "name" : "o_serdes_clk",
+      "linked_object" : "clk_out",
+      "linked_objects" : {
+        "clk_out" : {
+          "location" : "HR_2_8_4P",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "OUTPUT_CLK" : "$iopadmap$clk_out",
+        "PLL_CLK" : "clkbuf40"
+      },
+      "parameters" : {
+        "CLOCK_PHASE" : "270",
+        "DATA_RATE" : "SDR"
+      },
+      "pre_primitive" : "O_BUF",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+      },
+      "errors" : [
+      ]
+    },
+    {
+      "module" : "O_BUF",
+      "name" : "$iopadmap$top.clk_out_osc",
+      "linked_object" : "clk_out_osc",
+      "linked_objects" : {
+        "clk_out_osc" : {
+          "location" : "HR_2_9_4N",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "I" : "$iopadmap$clk_out_osc",
+        "O" : "clk_out_osc"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+        "O_SERDES_CLK"
+      ],
+      "route_clock_to" : {
+      },
+      "errors" : [
+      ]
+    },
+    {
+      "module" : "O_SERDES_CLK",
+      "name" : "o_serdes_clk_osc",
+      "linked_object" : "clk_out_osc",
+      "linked_objects" : {
+        "clk_out_osc" : {
+          "location" : "HR_2_9_4N",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "OUTPUT_CLK" : "$iopadmap$clk_out_osc",
+        "PLL_CLK" : "osc"
+      },
+      "parameters" : {
+        "CLOCK_PHASE" : "180",
+        "DATA_RATE" : "DDR"
+      },
+      "pre_primitive" : "O_BUF",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+      },
+      "errors" : [
+        "Not able to route signal \\osc to port \\PLL_CLK"
+      ]
     },
     {
       "module" : "I_BUF",
@@ -526,7 +769,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -549,7 +794,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -574,7 +821,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -597,7 +846,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -622,7 +873,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -645,7 +898,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -670,7 +925,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -693,7 +950,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -718,7 +977,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -741,7 +1002,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -765,7 +1028,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -790,7 +1055,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -813,7 +1080,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -838,7 +1107,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -861,7 +1132,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -886,7 +1159,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -909,7 +1184,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -934,7 +1211,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -957,7 +1236,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -982,7 +1263,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -1005,7 +1288,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF",
@@ -1028,7 +1313,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF",
@@ -1052,7 +1339,9 @@
         "O_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_DDR",
@@ -1075,7 +1364,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF",
@@ -1099,7 +1390,9 @@
         "O_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_DDR",
@@ -1122,7 +1415,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF",
@@ -1146,7 +1441,9 @@
         "O_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_DDR",
@@ -1169,7 +1466,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF",
@@ -1193,7 +1492,9 @@
         "O_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_DDR",
@@ -1216,7 +1517,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF",
@@ -1240,7 +1543,9 @@
         "O_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_DDR",
@@ -1263,7 +1568,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF",
@@ -1286,7 +1593,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "BOOT_CLOCK",
@@ -1313,7 +1622,9 @@
         "PLL"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "PLL",
@@ -1345,7 +1656,9 @@
           "i_ddr_osc1",
           "i_ddr_osc2"
         ]
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "PLL",
@@ -1375,7 +1688,9 @@
         "CLK_OUT_DIV2" : [
           "i_ddr_osc3"
         ]
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "PLL",
@@ -1405,7 +1720,9 @@
         "CLK_OUT" : [
           "i_ddr_osc4"
         ]
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -1430,7 +1747,9 @@
         "CLK_BUF"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "CLK_BUF",
@@ -1454,7 +1773,9 @@
         "PLL"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "PLL",
@@ -1484,7 +1805,9 @@
         "CLK_OUT" : [
           "i_ddr30"
         ]
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -1509,7 +1832,9 @@
         "CLK_BUF"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "CLK_BUF",
@@ -1533,7 +1858,9 @@
         "PLL"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "PLL",
@@ -1565,7 +1892,63 @@
         "CLK_OUT" : [
           "i_ddr31"
         ]
-      }
+      },
+      "errors" : [
+      ]
+    },
+    {
+      "module" : "I_BUF",
+      "name" : "i_buf40",
+      "linked_object" : "clk40",
+      "linked_objects" : {
+        "clk40" : {
+          "location" : "HR_2_CC_38_19P",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "I" : "clk40",
+        "O" : "ibuf40"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+        "CLK_BUF"
+      ],
+      "route_clock_to" : {
+      },
+      "errors" : [
+      ]
+    },
+    {
+      "module" : "CLK_BUF",
+      "name" : "clk_buf40",
+      "linked_object" : "clk40",
+      "linked_objects" : {
+        "clk40" : {
+          "location" : "HR_2_CC_38_19P",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "I" : "ibuf40",
+        "O" : "clkbuf40"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "I_BUF",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+        "O" : [
+          "o_serdes_clk"
+        ]
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF_DS",
@@ -1598,7 +1981,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -1626,7 +2011,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF_DS",
@@ -1659,7 +2046,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -1687,7 +2076,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF_DS",
@@ -1717,7 +2108,9 @@
         "O_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_DDR",
@@ -1745,7 +2138,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     }
   ]
 }

--- a/tests/unittest/ModelConfig/model_config_netlist.ppdb.json
+++ b/tests/unittest/ModelConfig/model_config_netlist.ppdb.json
@@ -5,6 +5,7 @@
     "    Detect input port \\clk0 (index=0, width=1, offset=0)",
     "    Detect input port \\clk1 (index=0, width=1, offset=0)",
     "    Detect input port \\clk2 (index=0, width=1, offset=0)",
+    "    Detect output port \\clk_out (index=0, width=1, offset=0)",
     "    Detect input port \\din (index=0, width=1, offset=0)",
     "    Detect input port \\din_clk2 (index=0, width=1, offset=0)",
     "    Detect input port \\din_n (index=0, width=1, offset=0)",
@@ -29,6 +30,8 @@
     "    Get important connection of cell \\I_BUF $iopadmap$top.clk2",
     "      Cell port \\I is connected to input port \\clk2",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
+    "    Get important connection of cell \\O_BUF $iopadmap$top.clk_out",
+    "      Cell port \\O is connected to output port \\clk_out",
     "    Get important connection of cell \\I_BUF $iopadmap$top.din",
     "      Cell port \\I is connected to input port \\din",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
@@ -61,12 +64,12 @@
     "      Cell port \\O_N is connected to output port \\dout_osc_n",
     "      Cell port \\O_P is connected to output port \\dout_osc_p",
     "  Trace \\I_BUF --> \\CLK_BUF",
-    "    Try \\I_BUF $iopadmap$top.clk0 out connection: $iopadmap$clk0 -> $auto$clkbufmap.cc:265:execute$433",
-    "      Connected $auto$clkbufmap.cc:265:execute$433",
+    "    Try \\I_BUF $iopadmap$top.clk0 out connection: $iopadmap$clk0 -> $auto$clkbufmap.cc:265:execute$432",
+    "      Connected $auto$clkbufmap.cc:265:execute$432",
     "    Try \\I_BUF $iopadmap$top.clk1 out connection: $iopadmap$clk1 -> \\clk_buf",
     "      Connected \\clk_buf",
-    "    Try \\I_BUF $iopadmap$top.clk2 out connection: $iopadmap$clk2 -> $auto$clkbufmap.cc:265:execute$436",
-    "      Connected $auto$clkbufmap.cc:265:execute$436",
+    "    Try \\I_BUF $iopadmap$top.clk2 out connection: $iopadmap$clk2 -> $auto$clkbufmap.cc:265:execute$435",
+    "      Connected $auto$clkbufmap.cc:265:execute$435",
     "  Trace \\CLK_BUF --> \\PLL",
     "    Try \\CLK_BUF \\clk_buf out connection: \\clk1_buf -> \\pll",
     "      Connected \\pll",
@@ -123,9 +126,17 @@
     "  Trace \\O_BUFT_DS --> \\O_SERDES",
     "  Trace \\O_DELAY --> \\O_DDR",
     "  Trace \\O_DELAY --> \\O_SERDES",
+    "  Trace \\O_BUF --> \\O_SERDES_CLK",
+    "    Try \\O_BUF $iopadmap$top.clk_out out connection: $iopadmap$clk_out -> \\o_serdes_clk",
+    "      Connected \\o_serdes_clk",
+    "        Parameter \\CLOCK_PHASE: 270",
+    "        Parameter \\DATA_RATE: \"SDR\"",
+    "  Trace \\O_BUFT --> \\O_SERDES_CLK",
+    "  Trace \\O_BUF_DS --> \\O_SERDES_CLK",
+    "  Trace \\O_BUFT_DS --> \\O_SERDES_CLK",
     "  Trace gearbox clock source",
-    "    \\I_DELAY \\i_delay port \\CLK_IN: $auto$clkbufmap.cc:298:execute$435",
-    "      Connected to \\CLK_BUF $auto$clkbufmap.cc:265:execute$433 port \\O",
+    "    \\I_DELAY \\i_delay port \\CLK_IN: $auto$clkbufmap.cc:298:execute$434",
+    "      Connected to \\CLK_BUF $auto$clkbufmap.cc:265:execute$432 port \\O",
     "    \\I_SERDES \\i_serdes port \\PLL_CLK: \\pll_clk",
     "      Connected to \\PLL \\pll port \\CLK_OUT",
     "    \\I_DDR \\i_ddr port \\C: \\pll_clk",
@@ -134,12 +145,48 @@
     "      Connected to \\CLK_BUF \\clk_buf port \\O",
     "    \\O_SERDES \\o_serdes port \\PLL_CLK: \\pll_clk",
     "      Connected to \\PLL \\pll port \\CLK_OUT",
+    "    \\O_SERDES_CLK \\o_serdes_clk port \\PLL_CLK: \\pll_clk",
+    "      Connected to \\PLL \\pll port \\CLK_OUT",
+    "  Trace Fabric Clock",
+    "    Module \\CLK_BUF $auto$clkbufmap.cc:265:execute$432: clock port \\O, net $auto$clkbufmap.cc:298:execute$434",
+    "      Connected to cell \\DFFRE $abc$208$auto$blifparse.cc:377:parse_blif$209",
+    "        Which is not a IO primitive. Send to fabric",
+    "    Module \\CLK_BUF \\clk_buf: clock port \\O, net \\clk1_buf",
+    "      Connected to cell \\O_DELAY \\o_delay",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\PLL \\pll",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "    Module \\PLL \\pll: clock port \\CLK_OUT, net \\pll_clk",
+    "      Connected to cell \\I_DDR \\i_ddr",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\I_SERDES \\i_serdes",
+    "        Which is a primitive",
+    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\O_DDR \\o_ddr",
+    "        Which is a primitive",
+    "        This is core_clk. Send to fabric",
+    "    Module \\PLL \\pll: clock port \\CLK_OUT_DIV4, net \\pll_clk_div4",
+    "    Module \\CLK_BUF $auto$clkbufmap.cc:265:execute$435: clock port \\O, net $auto$clkbufmap.cc:298:execute$437",
+    "      Connected to cell \\DFFRE $abc$212$auto$blifparse.cc:377:parse_blif$213",
+    "        Which is not a IO primitive. Send to fabric",
+    "    Module \\BOOT_CLOCK \\boot_clock: clock port \\O, net \\osc",
+    "      Connected to cell \\PLL \\pll_osc",
+    "        Which is a primitive",
+    "        This is core_clk. Send to fabric",
+    "    Module \\PLL \\pll_osc: clock port \\CLK_OUT, net \\osc_pll",
+    "      Connected to cell \\O_DDR \\o_ddr_osc",
+    "        Which is a primitive",
+    "        This is core_clk. Send to fabric",
     "  Summary",
     "        |------------------------------------------------------------------------------------------------|",
     "        |              ***********************************************************                       |",
     "    IN  |         clk0 * I_BUF |-> CLK_BUF                                       *                       |",
     "    IN  |         clk1 * I_BUF |-> CLK_BUF |-> PLL                               *                       |",
     "    IN  |         clk2 * I_BUF |-> CLK_BUF                                       *                       |",
+    "    OUT |              *                                  O_SERDES_CLK |-> O_BUF * clk_out               |",
     "    IN  |          din * I_BUF |-> I_DELAY                                       *                       |",
     "    IN  |     din_clk2 * I_BUF                                                   *                       |",
     "    IN  |   din_serdes * I_BUF |-> I_SERDES                                      *                       |",
@@ -154,10 +201,14 @@
     "    OUT |              *                                      O_DDR |-> O_BUF_DS * dout_osc_n+dout_osc_p |",
     "        |              ***********************************************************                       |",
     "        |------------------------------------------------------------------------------------------------|",
+    "  Final checking is good",
     "  Assign location HR_5_CC_38_19P (and properties) to Port clk2",
     "  Assign location HP_2_21_10N (and properties) to Port dout_osc_n",
     "  Assign location HP_1_0_0P (and properties) to Port reset",
+    "  Assign location HP_1_8_4P (and properties) to Port dout_p",
     "  Assign location HR_2_1_0N (and properties) to Port dout_serdes",
+    "  Assign location HR_2_2_1P (and properties) to Port clk_out",
+    "  Assign location HP_1_5_2N (and properties) to Port din_n",
     "  Assign location HR_2_0_0P (and properties) to Port din_serdes",
     "  Assign location HR_5_1_0N (and properties) to Port dout_clk2",
     "  Assign location HR_1_CC_18_9P (and properties) to Port clk0",
@@ -166,10 +217,8 @@
     "  Assign location HP_1_2_1P (and properties) to Port din",
     "  Assign location HP_1_6_3P (and properties) to Port dout",
     "  Assign location HP_2_20_10P (and properties) to Port dout_osc_p",
-    "  Assign location HP_1_5_2N (and properties) to Port din_n",
     "  Assign location HR_5_0_0P (and properties) to Port din_clk2",
     "  Assign location HP_1_9_4N (and properties) to Port dout_n",
-    "  Assign location HP_1_8_4P (and properties) to Port dout_p",
     "End of IO Analysis"
   ],
   "instances" : [
@@ -196,11 +245,13 @@
         "CLK_BUF"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "CLK_BUF",
-      "name" : "$auto$clkbufmap.cc:265:execute$433",
+      "name" : "$auto$clkbufmap.cc:265:execute$432",
       "linked_object" : "clk0",
       "linked_objects" : {
         "clk0" : {
@@ -212,7 +263,7 @@
       },
       "connectivity" : {
         "I" : "$iopadmap$clk0",
-        "O" : "$auto$clkbufmap.cc:298:execute$435"
+        "O" : "$auto$clkbufmap.cc:298:execute$434"
       },
       "parameters" : {
         "ROUTE_TO_FABRIC_CLK" : "0"
@@ -224,7 +275,9 @@
         "O" : [
           "i_delay"
         ]
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -249,7 +302,9 @@
         "CLK_BUF"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "CLK_BUF",
@@ -276,7 +331,9 @@
         "O" : [
           "o_delay"
         ]
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "PLL",
@@ -308,9 +365,12 @@
         "CLK_OUT" : [
           "i_serdes",
           "i_ddr",
-          "o_serdes"
+          "o_serdes",
+          "o_serdes_clk"
         ]
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -335,11 +395,13 @@
         "CLK_BUF"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "CLK_BUF",
-      "name" : "$auto$clkbufmap.cc:265:execute$436",
+      "name" : "$auto$clkbufmap.cc:265:execute$435",
       "linked_object" : "clk2",
       "linked_objects" : {
         "clk2" : {
@@ -351,7 +413,7 @@
       },
       "connectivity" : {
         "I" : "$iopadmap$clk2",
-        "O" : "$auto$clkbufmap.cc:298:execute$438"
+        "O" : "$auto$clkbufmap.cc:298:execute$437"
       },
       "parameters" : {
         "ROUTE_TO_FABRIC_CLK" : "2"
@@ -360,7 +422,62 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
+    },
+    {
+      "module" : "O_BUF",
+      "name" : "$iopadmap$top.clk_out",
+      "linked_object" : "clk_out",
+      "linked_objects" : {
+        "clk_out" : {
+          "location" : "HR_2_2_1P",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "I" : "$iopadmap$clk_out",
+        "O" : "clk_out"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+        "O_SERDES_CLK"
+      ],
+      "route_clock_to" : {
+      },
+      "errors" : [
+      ]
+    },
+    {
+      "module" : "O_SERDES_CLK",
+      "name" : "o_serdes_clk",
+      "linked_object" : "clk_out",
+      "linked_objects" : {
+        "clk_out" : {
+          "location" : "HR_2_2_1P",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "OUTPUT_CLK" : "$iopadmap$clk_out",
+        "PLL_CLK" : "pll_clk"
+      },
+      "parameters" : {
+        "CLOCK_PHASE" : "270",
+        "DATA_RATE" : "SDR"
+      },
+      "pre_primitive" : "O_BUF",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -385,7 +502,9 @@
         "I_DELAY"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DELAY",
@@ -399,7 +518,7 @@
         }
       },
       "connectivity" : {
-        "CLK_IN" : "$auto$clkbufmap.cc:298:execute$435",
+        "CLK_IN" : "$auto$clkbufmap.cc:298:execute$434",
         "I" : "$iopadmap$din",
         "O" : "din_delay"
       },
@@ -410,7 +529,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -434,7 +555,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -459,7 +582,9 @@
         "I_SERDES"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_SERDES",
@@ -486,7 +611,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF",
@@ -510,7 +637,9 @@
         "O_DELAY"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_DELAY",
@@ -535,7 +664,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF",
@@ -558,7 +689,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF",
@@ -582,7 +715,9 @@
         "O_SERDES"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_SERDES",
@@ -608,7 +743,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -632,7 +769,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF",
@@ -656,7 +795,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "BOOT_CLOCK",
@@ -681,7 +822,9 @@
         "PLL"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "PLL",
@@ -710,7 +853,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_BUF_DS",
@@ -740,7 +885,9 @@
         "I_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "I_DDR",
@@ -768,7 +915,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF_DS",
@@ -798,7 +947,9 @@
         "O_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_DDR",
@@ -826,7 +977,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_BUF_DS",
@@ -856,7 +1009,9 @@
         "O_DDR"
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     },
     {
       "module" : "O_DDR",
@@ -884,7 +1039,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
-      }
+      },
+      "errors" : [
+      ]
     }
   ]
 }

--- a/tests/unittest/ModelConfig/ric/O_SERDES_CLK.api.json
+++ b/tests/unittest/ModelConfig/ric/O_SERDES_CLK.api.json
@@ -1,0 +1,16 @@
+{
+  "O_SERDES_CLK": {
+    "DDR_MODE==DDR": [
+      {
+        "attr": "TX_DDR_MODE",
+        "value": "TX_ddr"
+      }
+    ],
+    "DDR_MODE==SDR": [
+      {
+        "attr": "TX_DDR_MODE",
+        "value": "TX_sdr"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
Improvement:
   - Allow overwrite any of IO bitfield via TCL using set_attr command
   - Take into consideration of error from extractor (new feature added via https://github.com/os-fpga/yosys_verific_rs/pull/652)
   - Allow parameter validation to ignore failure if parameter(s) are not defined, since we support default setting if parameter is not defined.
   - Add O_SERDES_CLK support in unit test
   - Add more parameter validation in unit test (config mapping file)

Testing:

   - ported code to latest NS Raptor manually (with https://github.com/os-fpga/yosys_verific_rs/pull/652)
   - run batch, batch_gen2 (no run on batch_gen3)

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
