### PR TITLE
set_clock_pin based on existing m_constraints

### DIFF
--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -2448,6 +2448,22 @@ bool CompilerOpenFPGA::Placement() {
       return false;
     }
     sdc_text.close();
+    // Temporarily use the old method to set_clock_pin from m_constraints
+    // By right user should not care the Fabric Clock assignment
+    // It should be auto-taken-care
+    // This piece of code is copied from below, but only take "set_clock_pin"
+    // part
+    for (auto constraint : m_constraints->getConstraints()) {
+      constraint = ReplaceAll(constraint, "@", "[");
+      constraint = ReplaceAll(constraint, "%", "]");
+      // pin location constraints have to be translated to .place:
+      if (constraint.find("set_clock_pin") != std::string::npos) {
+        set_clks.push_back(constraint);
+        repackConstraint = true;
+        constraints.push_back("# " +
+                              constraint);  // so there is a diff if changed
+      }
+    }
   } else {
 #else
   {


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
This is to fix the case https://rapidsilicon.atlassian.net/browse/EDA-2661
   - Temporarily set_clock_pin using existing m_constraints
   - Should switch to 'set_clock_pin' from extractor version of SDC

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
