### PR TITLE
Fixed report generation for Timing Analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
 
-set(VERSION_PATCH 374)
+set(VERSION_PATCH 375)
 
 option(
   WITH_LIBCXX

--- a/src/Compiler/Reports/AbstractReportManager.cpp
+++ b/src/Compiler/Reports/AbstractReportManager.cpp
@@ -47,6 +47,16 @@ AbstractReportManager::AbstractReportManager(const TaskManager &taskManager)
                     ReportColumn{"Used", Qt::AlignCenter}};
 }
 
+QStringList AbstractReportManager::getAvailableReportIds() const {
+  QStringList ids;
+  for (auto reportType : {ReportIdType::Utilization, ReportIdType::Statistic,
+                          ReportIdType::Timing}) {
+    auto reportId = getReportIdByType(reportType);
+    if (!reportId.isEmpty()) ids.push_back(reportId);
+  }
+  return ids;
+}
+
 const ITaskReportManager::Messages &AbstractReportManager::getMessages() {
   if (isFileOutdated(logFile())) parseLogFile();
   return m_messages;

--- a/src/Compiler/Reports/AbstractReportManager.h
+++ b/src/Compiler/Reports/AbstractReportManager.h
@@ -43,6 +43,7 @@ class AbstractReportManager : public ITaskReportManager {
   Q_OBJECT
  public:
   AbstractReportManager(const TaskManager &taskManager);
+  QStringList getAvailableReportIds() const override;
 
  protected:
   // Launches file parsing, if needed. Returns messages.

--- a/src/Compiler/Reports/BitstreamReportManager.cpp
+++ b/src/Compiler/Reports/BitstreamReportManager.cpp
@@ -34,7 +34,10 @@ namespace FOEDAG {
 BitstreamReportManager::BitstreamReportManager(const TaskManager &taskManager)
     : AbstractReportManager(taskManager) {}
 
-QStringList BitstreamReportManager::getAvailableReportIds() const { return {}; }
+QString BitstreamReportManager::getReportIdByType(ReportIdType idType) const {
+  Q_UNUSED(idType)
+  return {};
+}
 
 std::unique_ptr<ITaskReport> BitstreamReportManager::createReport(
     const QString &reportId) {

--- a/src/Compiler/Reports/BitstreamReportManager.h
+++ b/src/Compiler/Reports/BitstreamReportManager.h
@@ -29,7 +29,7 @@ class BitstreamReportManager final : public AbstractReportManager {
   BitstreamReportManager(const TaskManager &taskManager);
 
  private:
-  QStringList getAvailableReportIds() const override;
+  QString getReportIdByType(ReportIdType idType) const override;
   std::unique_ptr<ITaskReport> createReport(const QString &reportId) override;
   QString getTimingLogFileName() const override;
   bool isStatisticalTimingLine(const QString &line) override;

--- a/src/Compiler/Reports/ITaskReportManager.h
+++ b/src/Compiler/Reports/ITaskReportManager.h
@@ -34,6 +34,12 @@ enum class MessageSeverity {
   NONE
 };
 
+enum class ReportIdType {
+  Utilization,
+  Statistic,
+  Timing,
+};
+
 struct TaskMessage {
   int m_lineNr{0};
   MessageSeverity m_severity;
@@ -115,6 +121,7 @@ class ITaskReportManager : public QObject {
   using Messages = QMap<int, TaskMessage>;
   // Returns all available reports per compilation task
   virtual QStringList getAvailableReportIds() const = 0;
+  virtual QString getReportIdByType(ReportIdType idType) const = 0;
   // Creates the report. This call will most likely result in log file parsing
   // and potentially caching, so it's not const.
   virtual std::unique_ptr<ITaskReport> createReport(

--- a/src/Compiler/Reports/PackingReportManager.cpp
+++ b/src/Compiler/Reports/PackingReportManager.cpp
@@ -44,8 +44,15 @@ PackingReportManager::PackingReportManager(const TaskManager &taskManager)
   m_dspColumns[0].m_name = "DSP";
 }
 
-QStringList PackingReportManager::getAvailableReportIds() const {
-  return {RESOURCE_REPORT_NAME, DESIGN_STAT_REPORT_NAME};
+QString PackingReportManager::getReportIdByType(ReportIdType idType) const {
+  switch (idType) {
+    case ReportIdType::Utilization:
+      return RESOURCE_REPORT_NAME;
+    case ReportIdType::Statistic:
+      return DESIGN_STAT_REPORT_NAME;
+    default:
+      return {};
+  }
 }
 
 std::unique_ptr<ITaskReport> PackingReportManager::createReport(

--- a/src/Compiler/Reports/PackingReportManager.h
+++ b/src/Compiler/Reports/PackingReportManager.h
@@ -35,7 +35,7 @@ class PackingReportManager final : public AbstractReportManager {
   PackingReportManager(const TaskManager &taskManager);
 
  private:
-  QStringList getAvailableReportIds() const override;
+  QString getReportIdByType(ReportIdType idType) const override;
   std::unique_ptr<ITaskReport> createReport(const QString &reportId) override;
   QString getTimingLogFileName() const override;
   bool isStatisticalTimingLine(const QString &line) override;

--- a/src/Compiler/Reports/PlacementReportManager.cpp
+++ b/src/Compiler/Reports/PlacementReportManager.cpp
@@ -87,8 +87,15 @@ PlacementReportManager::PlacementReportManager(const TaskManager &taskManager)
   m_dspColumns[0].m_name = "DSP";
 }
 
-QStringList PlacementReportManager::getAvailableReportIds() const {
-  return {QString(RESOURCE_REPORT_NAME), QString(DESIGN_STAT_REPORT_NAME)};
+QString PlacementReportManager::getReportIdByType(ReportIdType idType) const {
+  switch (idType) {
+    case ReportIdType::Utilization:
+      return RESOURCE_REPORT_NAME;
+    case ReportIdType::Statistic:
+      return DESIGN_STAT_REPORT_NAME;
+    default:
+      return {};
+  }
 }
 
 std::unique_ptr<ITaskReport> PlacementReportManager::createReport(

--- a/src/Compiler/Reports/PlacementReportManager.h
+++ b/src/Compiler/Reports/PlacementReportManager.h
@@ -34,7 +34,7 @@ class PlacementReportManager final : public AbstractReportManager {
   PlacementReportManager(const TaskManager &taskManager);
 
  private:
-  QStringList getAvailableReportIds() const override;
+  QString getReportIdByType(ReportIdType idType) const override;
   std::unique_ptr<ITaskReport> createReport(const QString &reportId) override;
   QString getTimingLogFileName() const override;
   bool isStatisticalTimingLine(const QString &line) override;

--- a/src/Compiler/Reports/RoutingReportManager.cpp
+++ b/src/Compiler/Reports/RoutingReportManager.cpp
@@ -65,8 +65,15 @@ RoutingReportManager::RoutingReportManager(const TaskManager &taskManager)
       QRegularExpression("Final Net Connection Criticality Histogram")};
 }
 
-QStringList RoutingReportManager::getAvailableReportIds() const {
-  return {QString(RESOURCE_REPORT_NAME), QString(DESIGN_STAT_REPORT_NAME)};
+QString RoutingReportManager::getReportIdByType(ReportIdType idType) const {
+  switch (idType) {
+    case ReportIdType::Utilization:
+      return RESOURCE_REPORT_NAME;
+    case ReportIdType::Statistic:
+      return DESIGN_STAT_REPORT_NAME;
+    default:
+      return {};
+  }
 }
 
 std::unique_ptr<ITaskReport> RoutingReportManager::createReport(

--- a/src/Compiler/Reports/RoutingReportManager.h
+++ b/src/Compiler/Reports/RoutingReportManager.h
@@ -36,7 +36,7 @@ class RoutingReportManager final : public AbstractReportManager {
   RoutingReportManager(const TaskManager &taskManager);
 
  private:
-  QStringList getAvailableReportIds() const override;
+  QString getReportIdByType(ReportIdType idType) const override;
   std::unique_ptr<ITaskReport> createReport(const QString &reportId) override;
   QString getTimingLogFileName() const override;
   bool isStatisticalTimingLine(const QString &line) override;

--- a/src/Compiler/Reports/SynthesisReportManager.cpp
+++ b/src/Compiler/Reports/SynthesisReportManager.cpp
@@ -103,8 +103,15 @@ void SynthesisReportManager::parseLogLine(const QString &line) {
   }
 }
 
-QStringList SynthesisReportManager::getAvailableReportIds() const {
-  return {QString(RESOURCE_REPORT_NAME), QString(DESIGN_STAT_REPORT_NAME)};
+QString SynthesisReportManager::getReportIdByType(ReportIdType idType) const {
+  switch (idType) {
+    case ReportIdType::Utilization:
+      return RESOURCE_REPORT_NAME;
+    case ReportIdType::Statistic:
+      return DESIGN_STAT_REPORT_NAME;
+    default:
+      return {};
+  }
 }
 
 IDataReport::TableData SynthesisReportManager::getStatistics(

--- a/src/Compiler/Reports/SynthesisReportManager.h
+++ b/src/Compiler/Reports/SynthesisReportManager.h
@@ -45,7 +45,7 @@ class SynthesisReportManager final : public AbstractReportManager {
 
  private:
   void parseLogLine(const QString &line) override;
-  QStringList getAvailableReportIds() const override;
+  QString getReportIdByType(ReportIdType idType) const override;
   std::unique_ptr<ITaskReport> createReport(const QString &reportId) override;
   QString getTimingLogFileName() const override;
   void splitTimingData(const QString &timingStr) override;

--- a/src/Compiler/Reports/TimingAnalysisReportManager.cpp
+++ b/src/Compiler/Reports/TimingAnalysisReportManager.cpp
@@ -163,7 +163,21 @@ void TimingAnalysisReportManager::parseStatisticLine(const QString &line) {
 
 QStringList TimingAnalysisReportManager::getAvailableReportIds() const {
   if (isOpensta()) return {};
-  return {RESOURCE_REPORT_NAME, DESIGN_STAT_REPORT_NAME, TIMING_REPORT};
+  return AbstractReportManager::getAvailableReportIds();
+}
+
+QString TimingAnalysisReportManager::getReportIdByType(
+    ReportIdType idType) const {
+  switch (idType) {
+    case ReportIdType::Utilization:
+      return RESOURCE_REPORT_NAME;
+    case ReportIdType::Statistic:
+      return DESIGN_STAT_REPORT_NAME;
+    case ReportIdType::Timing:
+      return TIMING_REPORT;
+    default:
+      return {};
+  }
 }
 
 std::unique_ptr<ITaskReport> TimingAnalysisReportManager::createReport(

--- a/src/Compiler/Reports/TimingAnalysisReportManager.h
+++ b/src/Compiler/Reports/TimingAnalysisReportManager.h
@@ -38,6 +38,7 @@ class TimingAnalysisReportManager final : public AbstractReportManager {
   bool isOpensta() const;
   void parseStatisticLine(const QString &line) override;
   QStringList getAvailableReportIds() const override;
+  QString getReportIdByType(ReportIdType idType) const override;
   std::unique_ptr<ITaskReport> createReport(const QString &reportId) override;
   QString getTimingLogFileName() const override;
   bool isStatisticalTimingLine(const QString &line) override;

--- a/src/Main/Tasks.cpp
+++ b/src/Main/Tasks.cpp
@@ -566,7 +566,7 @@ void FOEDAG::handleJsonReportGeneration(Task* t, TaskManager* tManager,
   auto id = tManager->taskId(t);
   auto reportManager =
       tManager->getReportManagerRegistry().getReportManager(id);
-  if (reportManager && reportManager->getAvailableReportIds().size() >= 2) {
+  if (reportManager) {
     QString taskName{};
     if (id == SYNTHESIS)
       taskName = "synth";
@@ -579,16 +579,20 @@ void FOEDAG::handleJsonReportGeneration(Task* t, TaskManager* tManager,
     else if (id == PACKING)
       taskName = "packing";
     const QSignalBlocker blocker{*reportManager};
-    auto report = reportManager->createReport(
-        reportManager->getAvailableReportIds().first());
-    auto jsonGenerator = CreateReportGenerator<JsonReportGenerator>(
-        *report, taskName + "_utilization", projectPath);
-    if (jsonGenerator) jsonGenerator->Generate();
-
-    report = reportManager->createReport(
-        reportManager->getAvailableReportIds().last());
-    jsonGenerator = CreateReportGenerator<JsonReportGenerator>(
-        *report, taskName + "_design_stat", projectPath);
-    if (jsonGenerator) jsonGenerator->Generate();
+    if (auto utilId =
+            reportManager->getReportIdByType(ReportIdType::Utilization);
+        !utilId.isEmpty()) {
+      auto report = reportManager->createReport(utilId);
+      auto jsonGenerator = CreateReportGenerator<JsonReportGenerator>(
+          *report, taskName + "_utilization", projectPath);
+      if (jsonGenerator) jsonGenerator->Generate();
+    }
+    if (auto statId = reportManager->getReportIdByType(ReportIdType::Statistic);
+        !statId.isEmpty()) {
+      auto report = reportManager->createReport(statId);
+      auto jsonGenerator = CreateReportGenerator<JsonReportGenerator>(
+          *report, taskName + "_design_stat", projectPath);
+      if (jsonGenerator) jsonGenerator->Generate();
+    }
   }
 }


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed issue with Timing Analysis report. When generate json report, wrong data were taken for Timing Analysis because of the wrong report ID. Now report id can be taken from it's integer id and converted to string if needed. 

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
