### PR TITLE
Remove error message about Simulation files missing when clean step performs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
 
-set(VERSION_PATCH 376)
+set(VERSION_PATCH 377)
 
 option(
   WITH_LIBCXX

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -346,12 +346,12 @@ Simulator::SimulatorType Simulator::UserSimulationType(
 
 bool Simulator::Simulate(SimulationType action, SimulatorType type,
                          const std::string& wave_file) {
+  m_simType = action;
+  if (SimulationOption() == SimulationOpt::Clean) return Clean(action);
   if (ProjManager()->SimulationFiles().empty()) {
     m_compiler->ErrorMessage("Simulation file(s) missing.");
     return false;
   }
-  m_simType = action;
-  if (SimulationOption() == SimulationOpt::Clean) return Clean(action);
   WaveFile(action, wave_file);
   UserSimulationType(action, type);
   m_waveFile = wave_file;


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Change list:
* When user perform clean files for simulation (Clean all or one task clean), do not show error message that simulation files missing.

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/6fcb1e66-84b2-4cfb-a61d-fa8643b613d2)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: simulation
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
