### PR TITLE
Workaround for PLL architectural flaw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
 
-set(VERSION_PATCH 377)
+set(VERSION_PATCH 378)
 
 option(
   WITH_LIBCXX

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -3465,21 +3465,21 @@ bool CompilerOpenFPGA::GenerateBitstream() {
   if (std::filesystem::exists(ric_model) &&
       std::filesystem::exists(config_mapping) &&
       std::filesystem::exists(netlist_ppdb)) {
-    // update constraints
-    const auto& constrFiles = ProjManager()->getConstrFiles();
-    m_constraints->reset();
-    for (const auto& file : constrFiles) {
-      int res{TCL_OK};
-      auto status = m_interp->evalCmd(
-          std::string("read_sdc {" + file + "}").c_str(), &res);
-      if (res != TCL_OK) {
-        ErrorMessage(status);
-        return false;
+    // Read the INI before the m_constraints is reset
+    nlohmann::json properties = m_constraints->get_simplified_property_json();
+    std::string io_model_config_file = "";
+    if (properties.contains("INI")) {
+      if (properties["INI"].contains("SOURCE_IO_MODEL_CONFIG_FILE")) {
+        io_model_config_file = properties["INI"]["SOURCE_IO_MODEL_CONFIG_FILE"];
+        if (!std::filesystem::exists(io_model_config_file)) {
+          io_model_config_file = "";
+        }
       }
     }
+    // update constraints
     command = CFG_print("cd %s", workingDir.c_str());
     command = CFG_print("%s\nclear_property", command.c_str());
-    for (const auto& file : constrFiles) {
+    for (const auto& file : ProjManager()->getConstrFiles()) {
       command = CFG_print("%s\nread_sdc {%s}", command.c_str(), file.c_str());
     }
     command = CFG_print("%s\nwrite_property model_config.property.json",
@@ -3502,32 +3502,49 @@ bool CompilerOpenFPGA::GenerateBitstream() {
     }
     command = CFG_print("%s\nmodel_config dump_ric PERIPHERY io_ric.txt",
                         command.c_str());
-    command = CFG_print(
-        "%s\nmodel_config gen_ppdb -netlist_ppdb %s -config_mapping %s "
-        "model_config.ppdb.json -property_json model_config.property.json",
-        command.c_str(), netlist_ppdb.c_str(), config_mapping.c_str());
-    command = CFG_print(
-        "%s\nmodel_config set_design -feature IO model_config.ppdb.json",
-        command.c_str());
-    nlohmann::json properties = m_constraints->get_simplified_property_json();
-    if (properties.contains("INI")) {
-      if (properties["INI"].contains("SOURCE_IO_MODEL_CONFIG_FILE")) {
-        std::string io_model_config_file =
-            properties["INI"]["SOURCE_IO_MODEL_CONFIG_FILE"];
-        if (std::filesystem::exists(io_model_config_file)) {
-          command = CFG_print("%s\nsource %s", command.c_str(),
-                              io_model_config_file.c_str());
-        }
+    uint32_t gen_bitstream_count = 1;
+    if (CFG_find_string_in_vector({"Gemini", "Virgo"}, device_data.series) >=
+        0) {
+      command = CFG_print(
+          "%s\nmodel_config gen_ppdb -netlist_ppdb %s -config_mapping %s "
+          "-property_json model_config.property.json -pll_workaround 0 "
+          "model_config.ppdb.json",
+          command.c_str(), netlist_ppdb.c_str(), config_mapping.c_str());
+      command = CFG_print(
+          "%s\nmodel_config gen_ppdb -netlist_ppdb %s -config_mapping %s "
+          "-property_json model_config.property.json -pll_workaround 1 "
+          "model_config.post.ppdb.json",
+          command.c_str(), netlist_ppdb.c_str(), config_mapping.c_str());
+      gen_bitstream_count = 2;
+    } else {
+      command = CFG_print(
+          "%s\nmodel_config gen_ppdb -netlist_ppdb %s -config_mapping %s "
+          "-property_json model_config.property.json model_config.ppdb.json",
+          command.c_str(), netlist_ppdb.c_str(), config_mapping.c_str());
+    }
+    std::string design = "model_config.ppdb.json";
+    std::string bit_file = "io_bitstream.bit";
+    std::string detail_file = "io_bitstream.detail.bit";
+    for (uint32_t i = 0; i < gen_bitstream_count; i++) {
+      command = CFG_print("%s\nmodel_config set_design -feature IO %s",
+                          command.c_str(), design.c_str());
+      if (io_model_config_file.size()) {
+        command = CFG_print("%s\nsource %s", command.c_str(),
+                            io_model_config_file.c_str());
+      }
+      command = CFG_print("%s\nmodel_config write -feature IO -format BIT %s",
+                          command.c_str(), bit_file.c_str());
+      command =
+          CFG_print("%s\nmodel_config write -feature IO -format DETAIL %s",
+                    command.c_str(), detail_file.c_str());
+      if (i == 0 && gen_bitstream_count == 2) {
+        command =
+            CFG_print("%s\nmodel_config reset -feature IO", command.c_str());
+        design = "model_config.post.ppdb.json";
+        bit_file = "io_bitstream.post.bit";
+        detail_file = "io_bitstream.post.detail.bit";
       }
     }
-    m_constraints->reset();
-    command = CFG_print(
-        "%s\nmodel_config write -feature IO -format BIT io_bitstream.bit",
-        command.c_str());
-    command = CFG_print(
-        "%s\nmodel_config write -feature IO -format DETAIL "
-        "io_bitstream.detail.txt",
-        command.c_str());
     file = ProjManager()->projectName() + "_io_bitstream_cmd.tcl";
     FileUtils::WriteToFile(file, command);
     command = CFG_print("source %s", file.c_str());

--- a/src/Compiler/Constraints.cpp
+++ b/src/Compiler/Constraints.cpp
@@ -68,7 +68,7 @@ void Constraints::reset() {
   m_constraints.erase(m_constraints.begin(), m_constraints.end());
   m_keeps.erase(m_keeps.begin(), m_keeps.end());
   m_virtualClocks.clear();
-  clear_property();
+  m_object_properties.clear();
 }
 
 std::string Constraints::getConstraint(uint64_t argc, const char* argv[]) {
@@ -1041,7 +1041,7 @@ void Constraints::set_property(std::vector<std::string> objects,
   m_object_properties.push_back(OBJECT_PROPERTY(objects, properties));
 }
 
-void Constraints::clear_property() { m_object_properties.clear(); }
+void Constraints::clear_property() { reset(); }
 
 const std::vector<OBJECT_PROPERTY> Constraints::get_property() {
   return m_object_properties;

--- a/src/Configuration/ModelConfig/ModelConfig_IO.cpp
+++ b/src/Configuration/ModelConfig/ModelConfig_IO.cpp
@@ -70,6 +70,9 @@ ModelConfig_IO::ModelConfig_IO(
                                   : "";
   bool is_unittest = std::find(flag_options.begin(), flag_options.end(),
                                "is_unittest") != flag_options.end();
+  if (options.find("pll_workaround") != options.end()) {
+    m_pll_around = options.at("pll_workaround");
+  }
   if (!is_unittest) {
     POST_INFO_MSG(0, "Netlist PPDB: %s", netlist_ppdb.c_str());
     POST_INFO_MSG(0, "Config Mapping: %s", config_mapping.c_str());
@@ -1200,6 +1203,7 @@ void ModelConfig_IO::allocate_pll(bool force) {
         POST_WARN_MSG(3, msg.c_str());
       } else if (one_count == 1) {
         instance["__pll_resource__"] = std::to_string(pll_index);
+        instance["__pll_enable__"] = m_pll_around.size() ? m_pll_around : "1";
         std::string pll_resource_name = CFG_print("pll_%d", pll_index);
         CFG_ASSERT(m_resource->use_pll(src_location, pll_resource_name));
         POST_DEBUG_MSG(3, m_resource->m_msg.c_str());

--- a/src/Configuration/ModelConfig/ModelConfig_IO.h
+++ b/src/Configuration/ModelConfig/ModelConfig_IO.h
@@ -217,6 +217,7 @@ class ModelConfig_IO {
       std::vector<MODEL_RESOURCE_INSTANCE*>& instances, bool print_msg);
 
  protected:
+  std::string m_pll_around = "";
   nlohmann::json m_instances;
   nlohmann::json m_config_mapping;
   std::map<std::string, std::string> m_global_args;

--- a/tests/unittest/ModelConfig/ModelConfig_IO_test.cpp
+++ b/tests/unittest/ModelConfig/ModelConfig_IO_test.cpp
@@ -130,7 +130,7 @@ TEST_F(ModelConfig_IO, gen_ppdb) {
       "model_config gen_ppdb -netlist_ppdb %s/model_config_netlist.ppdb.json "
       "-config_mapping %s/apis/config_attributes.mapping.json "
       "-property_json utst/ModelConfig/model_config.property.json "
-      "-is_unittest "
+      "-is_unittest -pll_workaround 0 "
       "utst/ModelConfig/model_config.ppdb.json",
       current_dir.c_str(), current_dir.c_str());
   compiler_tcl_common_run(cmd);

--- a/tests/unittest/ModelConfig/ModelConfig_test.cpp
+++ b/tests/unittest/ModelConfig/ModelConfig_test.cpp
@@ -70,6 +70,7 @@ TEST_F(ModelConfig, device_model) {
 TEST_F(ModelConfig, model_config) {
   std::string current_dir = COMPILER_TCL_COMMON_GET_CURRENT_DIR();
   compiler_tcl_common_run("model_config set_model -feature IO TOP");
+  compiler_tcl_common_run("model_config reset -feature IO");
   std::string tcl_cmd = CFG_print("model_config set_api %s/model_config.json",
                                   current_dir.c_str());
   compiler_tcl_common_run(tcl_cmd);

--- a/tests/unittest/ModelConfig/apis/config_attributes.mapping.json
+++ b/tests/unittest/ModelConfig/apis/config_attributes.mapping.json
@@ -192,7 +192,7 @@
             "pll_FBDIV" : "__fbdiv__",
             "pll_POSTDIV1" : "__postdiv1__",
             "pll_POSTDIV2" : "__postdiv2__",
-            "pll_PLLEN" : "PLLEN_0"
+            "pll_PLLEN" : "__pll_enable__"
           }
         ]
       }

--- a/tests/unittest/ModelConfig/golden/model_config.negative.ppdb.json
+++ b/tests/unittest/ModelConfig/golden/model_config.negative.ppdb.json
@@ -575,7 +575,7 @@
             },
             {
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_0",
-              "pll_PLLEN" : "PLLEN_0"
+              "pll_PLLEN" : "1"
             },
             {
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_0",
@@ -675,6 +675,7 @@
       "__cfg_pllref_use_div__" : "0",
       "__cfg_pllref_use_hv__" : "0",
       "__cfg_pllref_use_rosc__" : "0",
+      "__pll_enable__" : "1",
       "__pll_resource__" : "0",
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pll_clock_pin_is_valid__,__check_fabric_clock_resource__,__check_pll_parameter__,__check_pll_clock_pin_resource__,__update_fabric_clock_resource__"

--- a/tests/unittest/ModelConfig/golden/model_config.ppdb.json
+++ b/tests/unittest/ModelConfig/golden/model_config.ppdb.json
@@ -568,7 +568,7 @@
             },
             {
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_0",
-              "pll_PLLEN" : "PLLEN_0"
+              "pll_PLLEN" : "1"
             },
             {
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_0",
@@ -656,6 +656,7 @@
       "__cfg_pllref_use_div__" : "0",
       "__cfg_pllref_use_hv__" : "0",
       "__cfg_pllref_use_rosc__" : "0",
+      "__pll_enable__" : "1",
       "__pll_resource__" : "0",
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pll_clock_pin_is_valid__,__check_fabric_clock_resource__,__check_pll_parameter__,__check_pll_clock_pin_resource__,__update_fabric_clock_resource__"
@@ -1342,7 +1343,7 @@
             },
             {
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_1",
-              "pll_PLLEN" : "PLLEN_0"
+              "pll_PLLEN" : "1"
             },
             {
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_1",
@@ -1418,6 +1419,7 @@
       "__cfg_pllref_use_div__" : "1",
       "__cfg_pllref_use_hv__" : "__DONT__",
       "__cfg_pllref_use_rosc__" : "1",
+      "__pll_enable__" : "1",
       "__pll_resource__" : "1",
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__check_fabric_clock_resource__,__check_pll_parameter__,__check_pll_clock_pin_resource__,__update_fabric_clock_resource__"

--- a/tests/unittest/ModelConfig/golden/model_config.ppdb.json
+++ b/tests/unittest/ModelConfig/golden/model_config.ppdb.json
@@ -568,7 +568,7 @@
             },
             {
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_0",
-              "pll_PLLEN" : "1"
+              "pll_PLLEN" : "0"
             },
             {
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_0",
@@ -656,7 +656,7 @@
       "__cfg_pllref_use_div__" : "0",
       "__cfg_pllref_use_hv__" : "0",
       "__cfg_pllref_use_rosc__" : "0",
-      "__pll_enable__" : "1",
+      "__pll_enable__" : "0",
       "__pll_resource__" : "0",
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__pll_clock_pin_is_valid__,__check_fabric_clock_resource__,__check_pll_parameter__,__check_pll_clock_pin_resource__,__update_fabric_clock_resource__"
@@ -1343,7 +1343,7 @@
             },
             {
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_1",
-              "pll_PLLEN" : "1"
+              "pll_PLLEN" : "0"
             },
             {
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_1",
@@ -1419,7 +1419,7 @@
       "__cfg_pllref_use_div__" : "1",
       "__cfg_pllref_use_hv__" : "__DONT__",
       "__cfg_pllref_use_rosc__" : "1",
-      "__pll_enable__" : "1",
+      "__pll_enable__" : "0",
       "__pll_resource__" : "1",
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__check_fabric_clock_resource__,__check_pll_parameter__,__check_pll_clock_pin_resource__,__update_fabric_clock_resource__"

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
@@ -3972,7 +3972,7 @@ Block u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_0 []
                         pll_FRAC - Addr: 0x00001B31, Size: 24, Value: (0x00000000) 0 { pll [PLL] [PLL:PLL_SRC==DEFAULT] [from HP_1_CC_18_9P] }
                        pll_FBDIV - Addr: 0x00001B49, Size: 12, Value: (0x00000010) 16 { pll [PLL] [pll_FBDIV:16] [from HP_1_CC_18_9P] }
                       pll_REFDIV - Addr: 0x00001B55, Size:  6, Value: (0x00000001) 1 { pll [PLL] [pll_REFDIV:1] [from HP_1_CC_18_9P] }
-                       pll_PLLEN - Addr: 0x00001B5B, Size:  1, Value: (0x00000001) 1 { pll [PLL] [pll_PLLEN:1] [from HP_1_CC_18_9P] }
+                       pll_PLLEN - Addr: 0x00001B5B, Size:  1, Value: (0x00000000) 0 { pll [PLL] [pll_PLLEN:0] [from HP_1_CC_18_9P] }
                     pll_POSTDIV1 - Addr: 0x00001B5C, Size:  3, Value: (0x00000002) 2 { pll [PLL] [pll_POSTDIV1:2] [from HP_1_CC_18_9P] }
                     pll_POSTDIV2 - Addr: 0x00001B5F, Size:  3, Value: (0x00000002) 2 { pll [PLL] [pll_POSTDIV2:2] [from HP_1_CC_18_9P] }
                        pll_DSMEN - Addr: 0x00001B62, Size:  1, Value: (0x00000000) 0 { pll [PLL] [PLL:PLL_SRC==DEFAULT] [from HP_1_CC_18_9P] }
@@ -3996,7 +3996,7 @@ Block u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_1 []
                         pll_FRAC - Addr: 0x00001B7F, Size: 24, Value: (0x00000000) 0 { pll_osc [PLL] [PLL:PLL_SRC==DEFAULT] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
                        pll_FBDIV - Addr: 0x00001B97, Size: 12, Value: (0x00000010) 16 { pll_osc [PLL] [pll_FBDIV:16] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
                       pll_REFDIV - Addr: 0x00001BA3, Size:  6, Value: (0x00000001) 1 { pll_osc [PLL] [pll_REFDIV:1] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
-                       pll_PLLEN - Addr: 0x00001BA9, Size:  1, Value: (0x00000001) 1 { pll_osc [PLL] [pll_PLLEN:1] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
+                       pll_PLLEN - Addr: 0x00001BA9, Size:  1, Value: (0x00000000) 0 { pll_osc [PLL] [pll_PLLEN:0] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
                     pll_POSTDIV1 - Addr: 0x00001BAA, Size:  3, Value: (0x00000002) 2 { pll_osc [PLL] [pll_POSTDIV1:2] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
                     pll_POSTDIV2 - Addr: 0x00001BAD, Size:  3, Value: (0x00000002) 2 { pll_osc [PLL] [pll_POSTDIV2:2] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
                        pll_DSMEN - Addr: 0x00001BB0, Size:  1, Value: (0x00000000) 0 { pll_osc [PLL] [PLL:PLL_SRC==DEFAULT] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
@@ -3972,7 +3972,7 @@ Block u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_0 []
                         pll_FRAC - Addr: 0x00001B31, Size: 24, Value: (0x00000000) 0 { pll [PLL] [PLL:PLL_SRC==DEFAULT] [from HP_1_CC_18_9P] }
                        pll_FBDIV - Addr: 0x00001B49, Size: 12, Value: (0x00000010) 16 { pll [PLL] [pll_FBDIV:16] [from HP_1_CC_18_9P] }
                       pll_REFDIV - Addr: 0x00001B55, Size:  6, Value: (0x00000001) 1 { pll [PLL] [pll_REFDIV:1] [from HP_1_CC_18_9P] }
-                       pll_PLLEN - Addr: 0x00001B5B, Size:  1, Value: (0x00000000) 0 { pll [PLL] [pll_PLLEN:PLLEN_0] [from HP_1_CC_18_9P] }
+                       pll_PLLEN - Addr: 0x00001B5B, Size:  1, Value: (0x00000001) 1 { pll [PLL] [pll_PLLEN:1] [from HP_1_CC_18_9P] }
                     pll_POSTDIV1 - Addr: 0x00001B5C, Size:  3, Value: (0x00000002) 2 { pll [PLL] [pll_POSTDIV1:2] [from HP_1_CC_18_9P] }
                     pll_POSTDIV2 - Addr: 0x00001B5F, Size:  3, Value: (0x00000002) 2 { pll [PLL] [pll_POSTDIV2:2] [from HP_1_CC_18_9P] }
                        pll_DSMEN - Addr: 0x00001B62, Size:  1, Value: (0x00000000) 0 { pll [PLL] [PLL:PLL_SRC==DEFAULT] [from HP_1_CC_18_9P] }
@@ -3996,7 +3996,7 @@ Block u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_1 []
                         pll_FRAC - Addr: 0x00001B7F, Size: 24, Value: (0x00000000) 0 { pll_osc [PLL] [PLL:PLL_SRC==DEFAULT] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
                        pll_FBDIV - Addr: 0x00001B97, Size: 12, Value: (0x00000010) 16 { pll_osc [PLL] [pll_FBDIV:16] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
                       pll_REFDIV - Addr: 0x00001BA3, Size:  6, Value: (0x00000001) 1 { pll_osc [PLL] [pll_REFDIV:1] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
-                       pll_PLLEN - Addr: 0x00001BA9, Size:  1, Value: (0x00000000) 0 { pll_osc [PLL] [pll_PLLEN:PLLEN_0] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
+                       pll_PLLEN - Addr: 0x00001BA9, Size:  1, Value: (0x00000001) 1 { pll_osc [PLL] [pll_PLLEN:1] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
                     pll_POSTDIV1 - Addr: 0x00001BAA, Size:  3, Value: (0x00000002) 2 { pll_osc [PLL] [pll_POSTDIV1:2] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
                     pll_POSTDIV2 - Addr: 0x00001BAD, Size:  3, Value: (0x00000002) 2 { pll_osc [PLL] [pll_POSTDIV2:2] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
                        pll_DSMEN - Addr: 0x00001BB0, Size:  1, Value: (0x00000000) 0 { pll_osc [PLL] [PLL:PLL_SRC==DEFAULT] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.negative.detail.bit
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.negative.detail.bit
@@ -3972,7 +3972,7 @@ Block u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_0 []
                         pll_FRAC - Addr: 0x00001B31, Size: 24, Value: (0x00000000) 0 { pll00 [PLL] [PLL:PLL_SRC==DEFAULT] [from HP_1_CC_18_9P] }
                        pll_FBDIV - Addr: 0x00001B49, Size: 12, Value: (0x00000010) 16 { pll00 [PLL] [pll_FBDIV:16] [from HP_1_CC_18_9P] }
                       pll_REFDIV - Addr: 0x00001B55, Size:  6, Value: (0x00000001) 1 { pll00 [PLL] [pll_REFDIV:1] [from HP_1_CC_18_9P] }
-                       pll_PLLEN - Addr: 0x00001B5B, Size:  1, Value: (0x00000000) 0 { pll00 [PLL] [pll_PLLEN:PLLEN_0] [from HP_1_CC_18_9P] }
+                       pll_PLLEN - Addr: 0x00001B5B, Size:  1, Value: (0x00000001) 1 { pll00 [PLL] [pll_PLLEN:1] [from HP_1_CC_18_9P] }
                     pll_POSTDIV1 - Addr: 0x00001B5C, Size:  3, Value: (0x00000002) 2 { pll00 [PLL] [pll_POSTDIV1:2] [from HP_1_CC_18_9P] }
                     pll_POSTDIV2 - Addr: 0x00001B5F, Size:  3, Value: (0x00000002) 2 { pll00 [PLL] [pll_POSTDIV2:2] [from HP_1_CC_18_9P] }
                        pll_DSMEN - Addr: 0x00001B62, Size:  1, Value: (0x00000000) 0 { pll00 [PLL] [PLL:PLL_SRC==DEFAULT] [from HP_1_CC_18_9P] }


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue - https://rapidsilicon.atlassian.net/browse/CASTORIP-156
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
There is existing PLL architectural flaw, which we need to configure the ICB data twice:
   - first time with pll_PLLEN set to 0
   - second time with pll_PLLEN set to 1 (if the PLL is used)

This PR generates two ICB data:
   - io_bitstream.bit (first time)
   - io_bitstream.post.bit (second time)
   - this only happen if the device series is Gemini or Virgo

Testing done:
   - Port this PR to latest NS Raptor
   - Run test/batch, test/batch_gen2. test/batch_gen3
 
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
