### PR TITLE
Fixed issue when user can't add same IP with different versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
 
-set(VERSION_PATCH 378)
+set(VERSION_PATCH 379)
 
 option(
   WITH_LIBCXX

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -269,7 +269,8 @@ bool IPGenerator::AddIPInstance(IPInstance* instance) {
 
   // Remove old IP Instance if an instance with the same ModuleName is passed
   auto isMatch = [instance](IPInstance* targetInstance) {
-    return targetInstance->ModuleName() == instance->ModuleName();
+    return (targetInstance->ModuleName() == instance->ModuleName()) &&
+           (targetInstance->Version() == instance->Version());
   };
   auto it = std::find_if(m_instances.begin(), m_instances.end(), isMatch);
   if (it != m_instances.end()) {


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

 ### Describe the technical details
Fixed issue with IP configurator, when user wasn't able to generate same IP but with different version.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: ipgenerate
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
