### PR TITLE
Fixed creating run_1 folder when no project specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
 
-set(VERSION_PATCH 379)
+set(VERSION_PATCH 380)
 
 option(
   WITH_LIBCXX

--- a/src/Main/Settings.cpp
+++ b/src/Main/Settings.cpp
@@ -134,6 +134,7 @@ void Settings::traverseJson(json& obj,
 
 QString Settings::getUserSettingsPath(int settingType) {
   auto projPath = GlobalSession->GetCompiler()->ProjManager()->projectPath();
+  if (projPath.empty()) return QString{};
   switch (settingType) {
     case SettingType::SYN:
       return QU::ToQString(ProjectManager::projectSynthSettingsPath(projPath));

--- a/src/Main/Tasks.cpp
+++ b/src/Main/Tasks.cpp
@@ -269,12 +269,13 @@ void FOEDAG::handleTaskDialogRequested(const QString& category,
   if (GlobalSession->GetCompiler() &&
       GlobalSession->GetCompiler()->ProjManager()) {
     auto projPath = GlobalSession->GetCompiler()->ProjManager()->projectPath();
+    if (projPath.empty()) return;
     auto synthPath =
         QU::ToQString(ProjectManager::projectSynthSettingsPath(projPath));
     auto implPath =
         QU::ToQString(ProjectManager::projectImplSettingsPath(projPath));
-    static const QVector<SettingHelper> dependencies{
-        {SYNTH_SETTING_KEY, synthPath}, {PACKING_SETTING_KEY, implPath}};
+    const QVector<SettingHelper> dependencies{{SYNTH_SETTING_KEY, synthPath},
+                                              {PACKING_SETTING_KEY, implPath}};
     if (std::any_of(dependencies.begin(), dependencies.end(),
                     [category](const SettingHelper& helper) {
                       return helper.settingKey == category;

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -1875,6 +1875,7 @@ void MainWindow::setStatusAndProgressText(const QString& text) {
 
 void MainWindow::saveSettings() {
   if (m_taskManager && m_projectManager) {
+    if (m_projectManager->projectPath().empty()) return;
     const auto tasks = m_taskManager->tasks();
     for (const Task* const t : tasks) {
       if (!t->settingsKey().key.isEmpty()) {

--- a/tests/unittest/IPGenerator/IPGenerator_test.cpp
+++ b/tests/unittest/IPGenerator/IPGenerator_test.cpp
@@ -83,15 +83,15 @@ TEST(IPGenerate, IpInstanceDupes) {
   IPInstance* instance3 = new IPInstance("newName", "newVersion", def2, params2,
                                          "module_name", "newPath");
   ipGen->AddIPInstance(instance3);
-  EXPECT_EQ(ipGen->IPInstances().size(), 1)
-      << "Ensure the IPInstances count is still 1";
+  EXPECT_EQ(ipGen->IPInstances().size(), 2)
+      << "Ensure the IPInstances count is 2 bacause different versions";
 
   // Add IP same values, but diff module name
   IPInstance* instance4 = new IPInstance("duplicateName", "version_num", def,
                                          params, "NEW_MODULE_NAME", "out_file");
   ipGen->AddIPInstance(instance4);
-  EXPECT_EQ(ipGen->IPInstances().size(), 2)
-      << "Ensure the IPInstances count is now 2 ";
+  EXPECT_EQ(ipGen->IPInstances().size(), 3)
+      << "Ensure the IPInstances count is now 3";
 }
 
 TEST(IPGenerate, CheckAllIPPath) {


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Change list:
* Fixed creating run_1 folder when no project
* Fixed static path to settings files, this cause save files to wrong path.
* Fixed unit tests

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foredagcore, 
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts