### PR TITLE
Load data from config.json after project file loaded. This will fix clock names in the reports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MINOR 0)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
 
-set(VERSION_PATCH 381)
+set(VERSION_PATCH 382)
 
 option(
   WITH_LIBCXX

--- a/src/Main/ProjectFile/CompilerComponent.cpp
+++ b/src/Main/ProjectFile/CompilerComponent.cpp
@@ -51,4 +51,10 @@ ErrorCode CompilerComponent::Load(QXmlStreamReader *reader) {
   return {};
 }
 
+void CompilerComponent::LoadDone() {
+  std::filesystem::path configJsonPath =
+      m_compiler->FilePath(Compiler::Action::Synthesis) / "config.json";
+  m_compiler->getNetlistEditData()->ReadData(configJsonPath);
+}
+
 }  // namespace FOEDAG

--- a/src/Main/ProjectFile/CompilerComponent.h
+++ b/src/Main/ProjectFile/CompilerComponent.h
@@ -32,6 +32,7 @@ class CompilerComponent : public ProjectFileComponent {
   CompilerComponent(Compiler *cc);
   void Save(QXmlStreamWriter *writer) override;
   ErrorCode Load(QXmlStreamReader *reader) override;
+  void LoadDone() override;
 };
 
 }  // namespace FOEDAG


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Load data from config.json after project file loaded. This will fix clock names in the reports
![image](https://github.com/os-fpga/FOEDAG/assets/6624470/c98a2b05-e23e-45d9-ac7c-0eada6ab692d)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
