### PR TITLE
Fixed stop compilation

### DIFF
--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -512,21 +512,24 @@ void MainWindow::onRunProjectRequested(const QString& project) {
 }
 
 void MainWindow::stopCompilation() {
-  bool stop{true};
   if (m_askStopCompilation) {
-    QMessageBox question{QMessageBox::Question, "Stop compilation",
-                         "Do you want stop compilation?",
-                         QMessageBox::No | QMessageBox::Yes, this};
+    QMessageBox* question =
+        new QMessageBox{QMessageBox::Question, "Stop compilation",
+                        "Do you want stop compilation?",
+                        QMessageBox::No | QMessageBox::Yes, this};
+    question->setAttribute(Qt::WA_DeleteOnClose, true);
     auto combo = new QCheckBox("Do not show this message again");
     connect(combo, &QCheckBox::stateChanged, this, [this](int state) {
       stopCompileMessageAction->setChecked(state != Qt::Checked);
     });
-    question.setCheckBox(combo);
-    auto res{question.exec()};
-    stop = (res == QMessageBox::Yes);
-  }
-
-  if (stop) {
+    question->setCheckBox(combo);
+    connect(question, &QMessageBox::buttonClicked, this,
+            [this, yesBtn = question->button(QMessageBox::Yes)](
+                QAbstractButton* btn) {
+              if (btn == yesBtn) forceStopCompilation();
+            });
+    question->open();
+  } else {
     forceStopCompilation();
   }
 }


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed stop compilation after user press Stop button. Issue is related to `QMessageBox::exec()` behavior since this method does not recommend to use by the documentation.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: feodagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
