### PR TITLE
Improve create_design tcl command. Close prev design automaticaly before create new one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 390)
+set(VERSION_PATCH 391)
 
 
 option(

--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -257,8 +257,6 @@ class Compiler {
   void PnROpt(const std::string& opt) { m_pnrOpt = opt; }
   const std::string& PnROpt() { return m_pnrOpt; }
 
-  std::string& GetOutput() { return m_output; }
-
   bool BitstreamEnabled() { return m_bitstreamEnabled; }
   void BitstreamEnabled(bool enabled) { m_bitstreamEnabled = enabled; }
 
@@ -365,9 +363,9 @@ class Compiler {
   virtual bool VerifyTargetDevice() const;
   bool HasTargetDevice();
 
-  bool CreateDesign(const std::string& name,
-                    const std::string& type = std::string{},
-                    bool cleanup = false);
+  std::pair<bool, std::string> CreateDesign(
+      const std::string& name, const std::string& type = std::string{},
+      bool cleanup = false);
 
   /* Compiler class utilities */
   bool RunBatch();
@@ -415,7 +413,6 @@ class Compiler {
   TclCommandIntegration* m_tclCmdIntegration{nullptr};
   Constraints* m_constraints = nullptr;
   NetlistEditData* m_netlistEditData = nullptr;
-  std::string m_output;
   ParserType m_parserType{ParserType::Default};
 
   // Tasks generic options


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Change list:
* Update `create_design` tcl command. If project already exists, it will be closed automatically before new project created. No need to use close_project command. Now this command guaranty that new project will be created. 

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
