### PR TITLE
Remove label with curren path and add tool tip instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 392)
+set(VERSION_PATCH 393)
 
 
 option(

--- a/src/ProjNavigator/FileExplorer.h
+++ b/src/ProjNavigator/FileExplorer.h
@@ -24,7 +24,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class QFileSystemModel;
 class QTreeView;
-class QLabel;
 
 namespace FOEDAG {
 
@@ -32,7 +31,7 @@ class FileExplorer : public QObject {
   Q_OBJECT
 
  public:
-  FileExplorer(QObject *parent = nullptr);
+  explicit FileExplorer(QObject *parent = nullptr);
   void setRootPath(const QString &path);
   QWidget *widget();
 
@@ -45,8 +44,6 @@ class FileExplorer : public QObject {
  private:
   QFileSystemModel *m_model{};
   QTreeView *m_tree{};
-  QWidget *m_view{};
-  QLabel *m_path{};
 };
 
 }  // namespace FOEDAG


### PR DESCRIPTION
### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Change list:
* Remove label in file explorer with current path
* Add tool tip for ".." top level folder that shows full path

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/67de1fb4-dd1e-4d1e-a894-e00d4b224c8c)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: projnavigator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts