### PR TITLE
Add context menu for IP that allow to add IP files to design

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 398)
+set(VERSION_PATCH 399)
 
 
 option(

--- a/etc/help.txt
+++ b/etc/help.txt
@@ -96,6 +96,7 @@ Tcl commands (Available in GUI or Batch console or Batch script):
    ipgenerate ?clean?         : Generates all IP instances set by ip_configure
      clean                    : Deletes files generated from this task
    simulate_ip  <module name> : Simulate IP with module name <module name>
+   ip_add_to_design <IP name> : Add IP <IP name> to the design. IP must be generated before
 
 ------------------
 --- Simulation ---

--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -191,7 +191,7 @@ class Compiler {
   std::string GetMessagePrefix() const;
   void SetParserType(ParserType type) { m_parserType = type; }
   ParserType GetParserType() { return m_parserType; }
-  void SetIPGenerator(IPGenerator* generator) { m_IPGenerator = generator; }
+  void SetIPGenerator(IPGenerator* generator);
   IPGenerator* GetIPGenerator() { return m_IPGenerator; }
   void SetSimulator(Simulator* simulator) { m_simulator = simulator; }
   Simulator* GetSimulator();

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -728,17 +728,34 @@ std::vector<std::filesystem::path> IPGenerator::GetDesignFiles(
   // Get this IP's build path
   auto buildPath = GetBuildDir(instance);
 
+  // Find any files in the ip src dir
+  auto srcPath = buildPath / "src";
+  if (FileUtils::FileExists(srcPath)) {
+    for (const auto& entry : std::filesystem::directory_iterator(srcPath)) {
+      paths.push_back(entry.path());
+    }
+  }
+
+  return paths;
+}
+
+std::vector<std::filesystem::path> IPGenerator::GetDesignAndCacheFiles(
+    IPInstance* instance) {
+  std::vector<std::filesystem::path> paths{};
+  paths += GetDesignFiles(instance);
+  paths += GetCacheFiles(instance);
+  return paths;
+}
+
+std::vector<std::filesystem::path> IPGenerator::GetCacheFiles(
+    IPInstance* instance) {
+  std::vector<std::filesystem::path> paths{};
+  // Get this IP's build path
+  auto buildPath = GetBuildDir(instance);
   if (FileUtils::FileExists(buildPath)) {
     // Find the ip cache json file
     for (const auto& entry : std::filesystem::directory_iterator(buildPath)) {
       if (entry.path().extension() == ".json") {
-        paths.push_back(entry.path());
-      }
-    }
-    // Find any files in the ip src dir
-    auto srcPath = buildPath / "src";
-    if (FileUtils::FileExists(srcPath)) {
-      for (const auto& entry : std::filesystem::directory_iterator(srcPath)) {
         paths.push_back(entry.path());
       }
     }

--- a/src/IPGenerate/IPGenerator.h
+++ b/src/IPGenerate/IPGenerator.h
@@ -71,6 +71,9 @@ class IPGenerator {
   std::filesystem::path GetMetaPath(const std::filesystem::path& base,
                                     IPInstance* inst) const;
   std::vector<std::filesystem::path> GetDesignFiles(IPInstance* instance);
+  std::vector<std::filesystem::path> GetDesignAndCacheFiles(
+      IPInstance* instance);
+  std::vector<std::filesystem::path> GetCacheFiles(IPInstance* instance);
 
  protected:
   std::pair<bool, std::string> SimulateIpTcl(const std::string& name);

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -91,6 +91,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QWebEngineView>
 #endif  // USE_MONACO_EDITOR
 #include "NewProject/CustomLayout.h"
+#include "Utils/StringUtils.h"
 
 using namespace FOEDAG;
 extern const char* release_version;
@@ -1258,6 +1259,8 @@ void MainWindow::ReShowWindow(QString strProject) {
           &MainWindow::handleSimulationIpRequested);
   connect(sourcesForm, &SourcesForm::IpWaveFormRequest, this,
           &MainWindow::handlewaveFormRequested);
+  connect(sourcesForm, &SourcesForm::IpAddToDesignRequest, this,
+          &MainWindow::handleIpAddToDesignRequested);
 
   delete findChild<TextEditor*>("textEditor");
   TextEditor* textEditor = new TextEditor(this);
@@ -1750,6 +1753,11 @@ void MainWindow::handlewaveFormRequested(const QString& moduleName) {
     auto [ok, mes] = ipGen->OpenWaveForm(module);
     if (!ok) QMessageBox::critical(this, title, QString::fromStdString(mes));
   }
+}
+
+void MainWindow::handleIpAddToDesignRequested(const QString& moduleName) {
+  m_interpreter->evalCmd(
+      StringUtils::format("ip_add_to_design %", moduleName.toStdString()));
 }
 
 void MainWindow::resetIps() {

--- a/src/MainWindow/main_window.h
+++ b/src/MainWindow/main_window.h
@@ -133,6 +133,7 @@ class MainWindow : public QMainWindow, public TopLevelInterface {
   void handleDeleteIpRequested(const QString& moduleName);
   void handleSimulationIpRequested(const QString& moduleName);
   void handlewaveFormRequested(const QString& moduleName);
+  void handleIpAddToDesignRequested(const QString& moduleName);
   void resetIps();
 
  signals:

--- a/src/NewProject/ProjectManager/DesignFileWatcher.cpp
+++ b/src/NewProject/ProjectManager/DesignFileWatcher.cpp
@@ -104,7 +104,7 @@ void DesignFileWatcher::updateDesignFileWatchers(ProjectManager* pManager) {
       (ipGen = compiler->GetIPGenerator())) {
     // Step through our IP Instance
     for (auto instance : ipGen->IPInstances()) {
-      auto ipPaths = ipGen->GetDesignFiles(instance);
+      auto ipPaths = ipGen->GetDesignAndCacheFiles(instance);
       // Loop through each design file of the IP
       for (const auto& file : ipPaths) {
         // Store file

--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -7,7 +7,6 @@
 #include <QXmlStreamWriter>
 #include <filesystem>
 #include <iostream>
-#include <set>
 
 #include "Compiler/CompilerDefines.h"
 #include "DesignFileWatcher.h"
@@ -846,23 +845,6 @@ ProjectManager::Libraries ProjectManager::DesignLibraries() const {
   }
 
   return result;
-}
-
-std::vector<std::pair<CompilationUnit, std::vector<std::string>>>
-ProjectManager::DesignFileList() const {
-  ProjectFileSet* tmpFileSet =
-      Project::Instance()->getProjectFileset(getDesignActiveFileSet());
-
-  std::vector<std::pair<CompilationUnit, std::vector<std::string>>> vec;
-  if (tmpFileSet && PROJECT_FILE_TYPE_DS == tmpFileSet->getSetType()) {
-    auto tmpMapFiles = tmpFileSet->Files();
-    for (auto iter = tmpMapFiles.begin(); iter != tmpMapFiles.end(); ++iter) {
-      std::vector<std::string> files;
-      for (const auto& f : iter->second) files.push_back(f.toStdString());
-      vec.push_back(std::make_pair(iter->first, files));
-    }
-  }
-  return vec;
 }
 
 ProjectManager::Libraries ProjectManager::SimulationLibraries() const {

--- a/src/NewProject/ProjectManager/project_manager.h
+++ b/src/NewProject/ProjectManager/project_manager.h
@@ -250,8 +250,6 @@ class ProjectManager : public QObject {
   // design
   Libraries DesignLibraries() const;
   CompilationUnits DesignFiles() const;
-  std::vector<std::pair<CompilationUnit, std::vector<std::string>>>
-  DesignFileList() const;
   // simulation
   Libraries SimulationLibraries() const;
   CompilationUnits SimulationFiles() const;

--- a/src/ProjNavigator/sources_form.h
+++ b/src/ProjNavigator/sources_form.h
@@ -63,6 +63,7 @@ class SourcesForm : public QWidget {
   void IpDeleteRequested(const QString& moduleName);
   void IpSimulationRequested(const QString& moduleName);
   void IpWaveFormRequest(const QString& moduleName);
+  void IpAddToDesignRequest(const QString& moduleName);
   void OpenProjectSettings();
 
  private slots:
@@ -87,6 +88,7 @@ class SourcesForm : public QWidget {
   void SlotDeleteIp();
   void SlotSimulateIp();
   void SlotWaveForm();
+  void SlotAddIPToDesign();
 
  private:
   Ui::SourcesForm* ui;
@@ -109,6 +111,7 @@ class SourcesForm : public QWidget {
   QAction* m_simulateIp;
   QAction* m_waveFormView;
   QAction* m_actProjectSettings;
+  QAction* m_actAddIpToProject;
   QMenu* m_menuOpenFileWith;
 
   ProjectManager* m_projManager;

--- a/src/ProjNavigator/tcl_command_integration.h
+++ b/src/ProjNavigator/tcl_command_integration.h
@@ -28,6 +28,7 @@ namespace FOEDAG {
 
 class ProjectManager;
 class SourcesForm;
+class IPGenerator;
 
 class TclCommandIntegration : public QObject {
   Q_OBJECT
@@ -56,6 +57,7 @@ class TclCommandIntegration : public QObject {
   bool TclClearSimulationFiles(std::ostream &out);
 
   bool TclSetTopTestBench(int argc, const char *argv[], std::ostream &out);
+  bool TclAddIpToDesign(const std::string &ipName, std::ostream &out);
 
   ProjectManager *GetProjectManager();
   void saveSettings();
@@ -63,6 +65,8 @@ class TclCommandIntegration : public QObject {
       const std::filesystem::path &path, bool &vhdl);
   void updateHierarchyView();
   void updateReportsView();
+
+  void setIPGenerator(IPGenerator *gen);
 
  signals:
   void newDesign(const QString &);
@@ -83,6 +87,7 @@ class TclCommandIntegration : public QObject {
  private:
   ProjectManager *m_projManager;
   SourcesForm *m_form;
+  IPGenerator *m_IPGenerator{nullptr};
 };
 
 }  // namespace FOEDAG

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -284,4 +284,13 @@ void StringUtils::setArgumentValue(StringVector& stringVector,
   }
 }
 
+std::vector<std::string> ToStringVector(
+    const std::vector<std::filesystem::path>& paths) {
+  StringVector stringVector{};
+  std::transform(
+      paths.cbegin(), paths.cend(), std::back_inserter(stringVector),
+      [](const std::filesystem::path& path) { return path.string(); });
+  return stringVector;
+}
+
 }  // namespace FOEDAG

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -44,6 +44,9 @@ std::vector<T>& operator+=(std::vector<T>& stringVector,
   return stringVector;
 }
 
+std::vector<std::string> ToStringVector(
+    const std::vector<std::filesystem::path>& paths);
+
 class StringUtils final {
  public:
   // Splits the input string with respect to given separator.

--- a/tests/Testcases/IPGenerate/test_ipgenerate_modules.tcl
+++ b/tests/Testcases/IPGenerate/test_ipgenerate_modules.tcl
@@ -68,6 +68,8 @@ if { $platform == "windows" } {
 
     # Generate only inst3 and inst4
     ipgenerate -modules {inst3 inst4}
+    
+    ip_add_to_design inst3 inst4
 
     set fp [open "foedag.log" r]
     set file_data [read $fp]


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Change list:
* Add context menu for ip instance: Add IP to Design. This menu is disabled in the Gate-level project type
* Add new tcl command: ip_add_to_design
* New command covered by tcl test
* Help updated

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/7e538595-cee8-4b4b-a225-043776b7698e)

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/22d3561b-d93b-40b5-adf6-10db4ab3907d)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, ipgenerate, foedagcore, projnavigator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts
