### PR TITLE
Fixed issue when launching PnR view from routing tasks re-runs the previous tasks again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 400)
+set(VERSION_PATCH 401)
 
 
 option(

--- a/src/Compiler/TaskManager.cpp
+++ b/src/Compiler/TaskManager.cpp
@@ -287,8 +287,10 @@ void TaskManager::startTask(Task *t) {
     // state machine
     for (auto &clearTask : getDownstreamCleanTasks(t))
       if (clearTask->isValid()) m_runStack.append(clearTask);
-  } else {
+  } else if (t->type() == TaskType::Action) {
     getUpstreamTasksForRun(t);
+  } else {
+    if (t->isValid()) m_runStack.append(t);
   }
   m_taskCount = m_runStack.count();
   counter = 0;


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fixed launching of the P&R View from Routing task.

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/1dd21a4a-56f0-4ea4-af13-e6f0369dffc8)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
