### PR TITLE
Add few more reports to timing analysis which open log files

### DIFF
--- a/src/Compiler/Reports/IDataReport.h
+++ b/src/Compiler/Reports/IDataReport.h
@@ -35,6 +35,11 @@ struct ReportColumn {
   }
 };
 
+enum class DataReportType {
+  Default,
+  File,
+};
+
 struct LineMeta {
   QBrush forground = Qt::black;
 };
@@ -63,5 +68,6 @@ class IDataReport {
   virtual const QString &getName() const = 0;
   // Indicates whether report has any data
   virtual bool isEmpty() const = 0;
+  virtual DataReportType type() const { return DataReportType::Default; }
 };
 }  // namespace FOEDAG

--- a/src/Compiler/Reports/TableReport.cpp
+++ b/src/Compiler/Reports/TableReport.cpp
@@ -21,6 +21,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "TableReport.h"
 
+#include <QFileInfo>
+
+#include "Utils/FileUtils.h"
+
 namespace FOEDAG {
 
 TableReport::TableReport(const ColumnValues &columns,
@@ -47,6 +51,22 @@ bool TableReport::isEmpty() const {
 
 const IDataReport::TableMetaData &TableReport::getMetaData() const {
   return m_tableMetaData;
+}
+
+FileReport::FileReport(const QString &fileName)
+    : TableReport({}, {}, {}), m_fileName(fileName) {
+  m_tableData.push_back({QFileInfo{m_fileName}.fileName()});
+}
+
+bool FileReport::isEmpty() const {
+  return !FileUtils::FileExists(
+      std::filesystem::path{m_fileName.toStdString()});
+}
+
+const QString &FileReport::getName() const { return m_fileName; }
+
+const IDataReport::TableData &FileReport::getData() const {
+  return m_tableData;
 }
 
 }  // namespace FOEDAG

--- a/src/Compiler/Reports/TableReport.h
+++ b/src/Compiler/Reports/TableReport.h
@@ -48,4 +48,18 @@ class TableReport : public IDataReport {
   QString m_name;
 };
 
+class FileReport : public TableReport {
+ public:
+  explicit FileReport(const QString &fileName);
+
+ private:
+  bool isEmpty() const override;
+  DataReportType type() const override { return DataReportType::File; }
+  const QString &getName() const override;
+  const TableData &getData() const override;
+
+  QString m_fileName{};
+  TableData m_tableData;
+};
+
 }  // namespace FOEDAG

--- a/src/Compiler/Reports/TimingAnalysisReportManager.cpp
+++ b/src/Compiler/Reports/TimingAnalysisReportManager.cpp
@@ -35,6 +35,9 @@ namespace {
 static constexpr const char *DESIGN_STAT_REPORT_NAME{"STA - Design statistics"};
 static constexpr const char *RESOURCE_REPORT_NAME{"STA - Utilization report"};
 static constexpr const char *TIMING_REPORT{"Timing Summary"};
+static constexpr const char *SETUP_REPORT{"Setup report"};
+static constexpr const char *HOLD_REPORT{"Hold report"};
+static constexpr const char *TIMING_ANALISIS_REPORT{"Timing Analysis report"};
 
 static const QString LOAD_ARCH_SECTION{"# Loading Architecture Description"};
 static const QString BLOCK_GRAPH_BUILD_SECTION{
@@ -163,7 +166,8 @@ void TimingAnalysisReportManager::parseStatisticLine(const QString &line) {
 
 QStringList TimingAnalysisReportManager::getAvailableReportIds() const {
   if (isOpensta()) return {};
-  return AbstractReportManager::getAvailableReportIds();
+  return {getReportIdByType(ReportIdType::Timing), SETUP_REPORT, HOLD_REPORT,
+          TIMING_ANALISIS_REPORT};
 }
 
 QString TimingAnalysisReportManager::getReportIdByType(
@@ -202,6 +206,18 @@ std::unique_ptr<ITaskReport> TimingAnalysisReportManager::createReport(
         std::make_unique<TableReport>(m_ioColumns, m_ioData, QString{}));
     dataReports.push_back(
         std::make_unique<TableReport>(m_clockColumns, m_clockData, QString{}));
+  } else if (reportId == QString{SETUP_REPORT}) {
+    dataReports.push_back(std::make_unique<FileReport>(QString::fromStdString(
+        m_compiler->FilePath(Compiler::Action::STA, "report_timing.setup.rpt")
+            .string())));
+  } else if (reportId == QString{HOLD_REPORT}) {
+    dataReports.push_back(std::make_unique<FileReport>(QString::fromStdString(
+        m_compiler->FilePath(Compiler::Action::STA, "report_timing.hold.rpt")
+            .string())));
+  } else if (reportId == QString{TIMING_ANALISIS_REPORT}) {
+    dataReports.push_back(std::make_unique<FileReport>(QString::fromStdString(
+        m_compiler->FilePath(Compiler::Action::STA, "timing_analysis.rpt")
+            .string())));
   } else {
     dataReports.push_back(std::make_unique<TableReport>(
         m_totalDesignColumn, m_totalDesignTable, QString{}, m_totalDesignMeta));

--- a/src/Main/ReportGenerator.cpp
+++ b/src/Main/ReportGenerator.cpp
@@ -137,4 +137,23 @@ void FileReportGenerator::Generate() {
   file.close();
 }
 
+OpenFileReportGenerator::OpenFileReportGenerator(const ITaskReport& report,
+                                                 QBoxLayout* layout)
+    : ReportGenerator(report), m_layout(layout) {}
+
+void OpenFileReportGenerator::Generate() {
+  for (auto& dataReport : m_report.getDataReports()) {
+    if (dataReport->isEmpty()) {
+      auto tableData = dataReport->getData();
+      for (const auto& line : tableData) {
+        for (const auto& item : line) {
+          m_layout->addWidget(
+              new QLabel(QString{"Can't open file %1"}.arg(item)), 1,
+              Qt::AlignTop);
+        }
+      }
+    }
+  }
+}
+
 }  // namespace FOEDAG

--- a/src/Main/ReportGenerator.h
+++ b/src/Main/ReportGenerator.h
@@ -46,6 +46,19 @@ class TableReportGenerator : public ReportGenerator {
   QBoxLayout* m_layout{nullptr};
 };
 
+/*!
+ * \brief The OpenFileReportGenerator class generate message in case file can't
+ * be opened otherwise doing nothing
+ */
+class OpenFileReportGenerator : public ReportGenerator {
+ public:
+  OpenFileReportGenerator(const ITaskReport& report, QBoxLayout* layoput);
+  void Generate() override;
+
+ protected:
+  QBoxLayout* m_layout{nullptr};
+};
+
 class FileReportGenerator : public ReportGenerator {
  public:
   FileReportGenerator(const ITaskReport& report, const QString& fileName);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [x] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Change list:
* Add new feature to reports creation that allow open files instead of generating some report.
* Change list of the timing analysis reports 

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/3b07bcc3-f11b-44a1-870d-09a56c9076e9)

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/c8c279ee-5f5c-4f03-8e6e-5482990429d2)

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/58affe8f-1bf8-4e91-99d2-2f7848de0995)

![image](https://github.com/os-fpga/FOEDAG/assets/6624470/06290f89-65cc-4938-ad57-09ab4ca70762)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: compiler, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
