### PR TITLE
Fixed wrong json types for IP Catalog communication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 408)
+set(VERSION_PATCH 409)
 
 
 option(

--- a/src/Utils/CMakeLists.txt
+++ b/src/Utils/CMakeLists.txt
@@ -48,6 +48,7 @@ set (SRC_CPP_LIST
   QtUtils.cpp
   LogUtils.cpp
   ArgumentsMap.cpp
+  JsonWriter.cpp
 )
 
 set (SRC_H_INSTALL_LIST
@@ -58,6 +59,7 @@ set (SRC_H_INSTALL_LIST
   QtUtils.h
   LogUtils.h
   ArgumentsMap.h
+  JsonWriter.h
 )
 
 set (SRC_H_LIST

--- a/src/Utils/JsonWriter.cpp
+++ b/src/Utils/JsonWriter.cpp
@@ -18,12 +18,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "JsonWriter.h"
+#include "Utils/JsonWriter.h"
 
 #include <fstream>
 #include <iterator>
 
-#include "StringUtils.h"
+#include "Utils/StringUtils.h"
 
 namespace FOEDAG {
 

--- a/src/Utils/JsonWriter.cpp
+++ b/src/Utils/JsonWriter.cpp
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "JsonWriter.h"
+
+#include <fstream>
+#include <iterator>
+
+#include "StringUtils.h"
+
+namespace FOEDAG {
+
+const char *ending{",\n"};
+
+JsonStreamWriter::JsonStreamWriter(const std::filesystem::path &file,
+                                   int indent)
+    : m_file(file), m_indent(indent) {
+  start();
+}
+
+JsonStreamWriter::~JsonStreamWriter() { close(); }
+
+void JsonStreamWriter::insert(const std::string &key,
+                              const std::string &value) {
+  std::fill_n(std::ostream_iterator<char>(m_json), m_indent, ' ');
+  m_json << "\"" << key << "\": " << value << ending;
+}
+
+void JsonStreamWriter::insertString(const std::string &key,
+                                    const std::string &value) {
+  insert(key, "\"" + value + "\"");
+}
+
+void JsonStreamWriter::start() { m_json << "{\n"; }
+
+void JsonStreamWriter::close() {
+  if (!m_closed) {
+    auto content = m_json.str();
+    const std::string endingStr{ending};
+    if (!content.empty() && StringUtils::endsWith(content, endingStr))
+      content = content.substr(0, content.length() - endingStr.length());
+    content += "\n}\n";
+    std::ofstream steam{m_file};
+    steam << content;
+    steam.close();
+  }
+  m_closed = true;
+}
+
+JsonWriterIterator JsonStreamWriter::operator[](const std::string &key) {
+  std::fill_n(std::ostream_iterator<char>(m_json), m_indent, ' ');
+  m_json << "\"" << key << "\": ";
+  return JsonWriterIterator{m_json};
+}
+
+void JsonWriterIterator::operator=(const std::string &value) {
+  if (m_valid) m_stream << "\"" << value << "\"";
+  insertEnding();
+}
+
+void JsonWriterIterator::operator=(bool value) {
+  if (m_valid) m_stream << std::boolalpha << value;
+  insertEnding();
+}
+
+bool JsonWriterIterator::isValid() const { return m_valid; }
+
+JsonWriterIterator::JsonWriterIterator(std::ostringstream &stream)
+    : m_stream(stream) {}
+
+void JsonWriterIterator::insertEnding() {
+  m_stream << ending;
+  m_valid = false;
+}
+
+}  // namespace FOEDAG

--- a/src/Utils/JsonWriter.h
+++ b/src/Utils/JsonWriter.h
@@ -1,0 +1,96 @@
+/*
+Copyright 2022 The Foedag team
+
+GPL License
+
+Copyright (c) 2022 The Open-Source FPGA Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <filesystem>
+#include <sstream>
+
+namespace FOEDAG {
+
+class JsonWriterIterator {
+  friend class JsonStreamWriter;
+
+ public:
+  template <class T>
+  void operator=(const T &value) {
+    if (m_valid) m_stream << value;
+    insertEnding();
+  }
+  void operator=(const std::string &value);
+  void operator=(bool value);
+  bool isValid() const;
+
+ private:
+  explicit JsonWriterIterator(std::ostringstream &stream);
+  void insertEnding();
+
+ private:
+  std::ostringstream &m_stream;
+  bool m_valid{true};
+};
+
+/*!
+ * \brief The JsonStreamWriter class implement writing json dirrect to the file.
+ * Format of the json: object that has key-value pairs
+ */
+class JsonStreamWriter {
+ public:
+  /*!
+   * \brief JsonStreamWriter create instance that will write json to \a file
+   * \param indent, allows to set intent count for formatting
+   */
+  explicit JsonStreamWriter(const std::filesystem::path &file, int indent = 3);
+
+  /*!
+   * Close file before object deleted
+   */
+  ~JsonStreamWriter();
+
+  /*!
+   * \brief insert \param key - \param value pairs into json. Type of \param
+   * value will not be changed. E.g. if value type is integer then integer will
+   * be inserted.
+   */
+  void insert(const std::string &key, const std::string &value);
+  void insertString(const std::string &key, const std::string &value);
+
+  /*!
+   * \brief close dump all data to a file.
+   */
+  void close();
+
+  /*!
+   * \brief operator [] allow insert value for key \param key. This method will
+   * make sure that string will be inserted.
+   */
+  JsonWriterIterator operator[](const std::string &key);
+
+ private:
+  void start();
+
+ private:
+  std::ostringstream m_json{};
+  std::filesystem::path m_file{};
+  int m_indent{};
+  bool m_closed{false};
+};
+
+}  // namespace FOEDAG

--- a/tests/TestInstall/CMakeLists.txt
+++ b/tests/TestInstall/CMakeLists.txt
@@ -191,12 +191,12 @@ target_link_libraries(test_hellofoedag
   ipgenerate
   designquery
   devicemodeling
-  foedagutils
   QConsole
   tcl_stubb
   tcl_static
   zlib
   ipconfigurator
+  foedagutils
   pinassignment
   cfgcompiler
   modelconfig


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Replace `json` with `JsonStreamWriter`. 
`json` writes everything as string while `JsonStreamWriter` writes directly string to file. So if string contains number, the number type will be written into the file.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: foedagutils, ipconfigurator
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [x] Regression tests
 - [ ] Continous Integration (CI) scripts
