### PR TITLE
Remove top module auto-detect indication for simulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 409)
+set(VERSION_PATCH 410)
 
 
 option(

--- a/src/NewProject/add_source_form.cpp
+++ b/src/NewProject/add_source_form.cpp
@@ -22,6 +22,7 @@ addSourceForm::addSourceForm(GridType gt, QWidget *parent)
         tr("Specify simulation specific files, or directories containing "
            "HDL files, to add to your project. Create a new source file on "
            "disk and add it to your project. "));
+    ui->lineEditTopModule->setPlaceholderText({});
   }
 
   m_widgetGrid = new sourceGrid(ui->m_frame);


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Remove top module auto-detect indication for simulation. No other changes regarding auto-detect feature.

Simulation:
![image](https://github.com/user-attachments/assets/cdba0681-f0d7-467d-8d1a-bece343a99eb)

Design:
![image](https://github.com/user-attachments/assets/79a07915-c713-4a8b-97a2-c716d75801d5)



 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: newproject
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
