### PR TITLE
Disable actions from cotext menu of the Project table when compilation is running

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 411)
+set(VERSION_PATCH 412)
 
 
 option(

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -427,6 +427,7 @@ void MainWindow::startStopButtonsState() {
   recentMenu->setDisabled(isRunning());
   if (m_reportsDockWidget && m_reportsDockWidget->widget())
     m_reportsDockWidget->widget()->setDisabled(isRunning());
+  if (sourcesForm) sourcesForm->setEnableProjectActions(!isRunning());
 }
 
 DockWidget* MainWindow::PrepareTab(const QString& name, const QString& objName,

--- a/src/ProjNavigator/sources_form.cpp
+++ b/src/ProjNavigator/sources_form.cpp
@@ -603,6 +603,15 @@ QAction *SourcesForm::ProjectSettingsActions() const {
   return m_actProjectSettings;
 }
 
+void SourcesForm::setEnableProjectActions(bool enable) {
+  for (auto action :
+       {m_actProjectSettings, m_actAddIpToProject, m_addDesignFiles,
+        m_addConstraintFiles, m_addSimulationFiles, m_actCloseProject,
+        m_actReconfigureIp, m_actRemoveIp, m_actDeleteIp, m_simulateIp,
+        m_actRemoveFile})
+    action->setEnabled(enable);
+}
+
 void SourcesForm::SetTopModuleFile(const QString &file) {
   m_topModuleFile = file;
   UpdateSrcHierachyTree();

--- a/src/ProjNavigator/sources_form.h
+++ b/src/ProjNavigator/sources_form.h
@@ -48,6 +48,8 @@ class SourcesForm : public QWidget {
   void UpdateSrcHierachyTree();
   QAction* ProjectSettingsActions() const;
 
+  void setEnableProjectActions(bool enable);
+
  public slots:
   void SetTopModuleFile(const QString& file);
 


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Update list of actions which are disabled during compilation:

* Project Settings
* Add Design files.../Add Constraint files../Add Simulation files...
* Remove File
* Close Project
* Simulate IP
* Add IP to design
* Reconfigure IP
* Remove IP from Project
* Delete IP

![image](https://github.com/user-attachments/assets/b9f25e8c-942b-4f88-85a9-7851b00fdbcf)


 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [x] Library: projnavigator, foedagcore
 - [ ] Plug-in: <Specify the plugin name>
 - [ ] Engine
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continous Integration (CI) scripts
