### PR TITLE
Specify Top Module for Pure VHDL Design Exclusively During Design Elaboration

### DIFF
--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -1461,12 +1461,21 @@ std::string CompilerOpenFPGA::GhdlDesignParsingCommmands() {
       verilogcmd += "read_verilog " + includes + verilogFiles + "\n";
     }
   }
-  fileList =
-      "plugin -i ghdl\nghdl -frelaxed-rules --no-formal -fsynopsys -fexplicit "
-      "--PREFIX=" +
-      prefixPackagePath.string() + " " + searchPath + lang + " " + fileList +
-      " -e " + designLibraries + "\n";
-  fileList += verilogcmd;
+  if (!verilogFiles.empty()){
+    fileList =
+        "plugin -i ghdl\nghdl -frelaxed-rules --no-formal -fsynopsys -fexplicit "
+        "--PREFIX=" +
+        prefixPackagePath.string() + " " + searchPath + lang + " " + fileList +
+        " -e " + designLibraries + "\n";
+    fileList += verilogcmd;
+  }
+  else{
+    fileList =
+        "plugin -i ghdl\nghdl -frelaxed-rules --no-formal -fsynopsys -fexplicit "
+        "--PREFIX=" +
+        prefixPackagePath.string() + " " + searchPath + lang + " " + fileList +
+        " -e " + ProjManager()->DesignTopModule() + " " + designLibraries + "\n";
+  }
 
   return fileList;
 }

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -1465,7 +1465,7 @@ std::string CompilerOpenFPGA::GhdlDesignParsingCommmands() {
       "plugin -i ghdl\nghdl -frelaxed-rules --no-formal -fsynopsys -fexplicit "
       "--PREFIX=" +
       prefixPackagePath.string() + " " + searchPath + lang + " " + fileList +
-      " -e " + ProjManager()->DesignTopModule() + " " + designLibraries + "\n";
+      " -e " + designLibraries + "\n";
   fileList += verilogcmd;
 
   return fileList;

--- a/src/Compiler/CompilerOpenFPGA.cpp
+++ b/src/Compiler/CompilerOpenFPGA.cpp
@@ -1461,20 +1461,20 @@ std::string CompilerOpenFPGA::GhdlDesignParsingCommmands() {
       verilogcmd += "read_verilog " + includes + verilogFiles + "\n";
     }
   }
-  if (!verilogFiles.empty()){
+  if (!verilogFiles.empty()) {
     fileList =
-        "plugin -i ghdl\nghdl -frelaxed-rules --no-formal -fsynopsys -fexplicit "
-        "--PREFIX=" +
+        "plugin -i ghdl\nghdl -frelaxed-rules --no-formal -fsynopsys "
+        "-fexplicit --PREFIX=" +
         prefixPackagePath.string() + " " + searchPath + lang + " " + fileList +
         " -e " + designLibraries + "\n";
     fileList += verilogcmd;
-  }
-  else{
+  } else {
     fileList =
-        "plugin -i ghdl\nghdl -frelaxed-rules --no-formal -fsynopsys -fexplicit "
-        "--PREFIX=" +
+        "plugin -i ghdl\nghdl -frelaxed-rules --no-formal -fsynopsys "
+        "-fexplicit --PREFIX=" +
         prefixPackagePath.string() + " " + searchPath + lang + " " + fileList +
-        " -e " + ProjManager()->DesignTopModule() + " " + designLibraries + "\n";
+        " -e " + ProjManager()->DesignTopModule() + " " + designLibraries +
+        "\n";
   }
 
   return fileList;


### PR DESCRIPTION
> ### Motivate of the pull request
> #### FOEDAG Limitation
> - [ ] We don't specify top module for VHDL design during elaboration which leads to ghdl error "no top module found"
> #### Solution
> - [ ] This feature will specify the top-module for pure vhdl design.

> #### PR Limitations
> - Top module is not specified for mixed language designs (Conflicting top module name for VHDL and Verilog/SystemVerilog designs).