### PR TITLE
Support new core clock flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 413)
+set(VERSION_PATCH 414)
 
 
 option(

--- a/src/Configuration/ModelConfig/ModelConfig.cpp
+++ b/src/Configuration/ModelConfig/ModelConfig.cpp
@@ -350,6 +350,10 @@ class ModelConfig_DEVICE {
     CFG_ASSERT(attributes.is_object());
     CFG_ASSERT(attributes.size());
     std::map<std::string, std::string> object;
+    if (attributes.contains("__comment__")) {
+      attributes.erase("__comment__");
+      CFG_ASSERT(attributes.size());
+    }
     for (auto& str :
          std::vector<std::string>({"__location__", "__optional__"})) {
       if (attributes.contains(str)) {
@@ -628,7 +632,8 @@ class ModelConfig_DEVICE {
         mapped_block_name = CFG_replace_string(
             mapped_block_name, CFG_print("__{[%d]}__", i), block_names[i]);
       }
-      CFG_ASSERT(is_valid_block(mapped_block_name) || optional);
+      CFG_ASSERT_MSG(is_valid_block(mapped_block_name) || optional,
+                     "%s is invalid block name", mapped_block_name.c_str());
       if (is_valid_block(mapped_block_name)) {
         optional = false;
       }

--- a/src/Configuration/ModelConfig/ModelConfig_IO.h
+++ b/src/Configuration/ModelConfig/ModelConfig_IO.h
@@ -86,7 +86,7 @@ class ModelConfig_IO {
   void python_file(bool is_unittest);
   void read_resources();
   void validate_instances(nlohmann::json& instances);
-  void validate_instance(nlohmann::json& instance, bool is_final = false);
+  void validate_instance(const nlohmann::json& instance, bool is_final = false);
   void merge_property_instances(nlohmann::json property_instances);
   void merge_property_instance(nlohmann::json& netlist_instance,
                                nlohmann::json property_instances);
@@ -107,6 +107,8 @@ class ModelConfig_IO {
                                     const std::string& port);
   void allocate_pll_fclk_routing(nlohmann::json& instance,
                                  const std::string& port);
+  void allocate_root_bank_clkmux();
+  void allocate_root_bank_clkmux(nlohmann::json& instance, bool is_pll);
   void set_clkbuf_config_attributes();
   void set_clkbuf_config_attribute(nlohmann::json& instance);
   void allocate_pll();
@@ -180,6 +182,9 @@ class ModelConfig_IO {
                                       const std::string& gearbox_location);
   PIN_INFO get_pin_info(const std::string& name);
   uint32_t fclk_use_pll_resource(const std::string& name);
+  nlohmann::json get_combined_results(nlohmann::json& rules,
+                                      std::string targeted_result,
+                                      const std::string& instance_key);
   /*
     Functions to check sibling rules
   */
@@ -224,6 +229,7 @@ class ModelConfig_IO {
   std::map<std::string, std::string> m_global_args;
   ModelConfig_IO_RESOURCE* m_resource = nullptr;
   std::vector<ModelConfig_IO_MSG*> m_messages;
+  const nlohmann::json* m_current_instance = nullptr;
 };
 
 }  // namespace FOEDAG

--- a/src/Configuration/ModelConfig/ModelConfig_IO_resource.cpp
+++ b/src/Configuration/ModelConfig/ModelConfig_IO_resource.cpp
@@ -185,6 +185,28 @@ bool ModelConfig_IO_RESOURCE::use_resource(const std::string& resource,
 }
 
 /*
+  Entry function to try to use the resource
+*/
+std::pair<bool, std::string> ModelConfig_IO_RESOURCE::use_root_bank_clkmux(
+    const std::string& module, const std::string& location,
+    PIN_INFO& pin_info) {
+  std::pair<bool, std::string> status;
+  if (m_root_bank_clkmuxes.find(pin_info.root_bank_mux_location) !=
+      m_root_bank_clkmuxes.end()) {
+    status = std::make_pair(
+        false,
+        CFG_print(
+            "%s is already used by %s", pin_info.root_bank_mux_location.c_str(),
+            m_root_bank_clkmuxes.at(pin_info.root_bank_mux_location).c_str()));
+  } else {
+    m_root_bank_clkmuxes[pin_info.root_bank_mux_location] =
+        CFG_print("module %s (location: %s)", module.c_str(), location.c_str());
+    status = std::make_pair(true, pin_info.root_bank_mux_location);
+  }
+  return status;
+}
+
+/*
   Fail-safe mechanism
 */
 void ModelConfig_IO_RESOURCE::backup() {
@@ -193,6 +215,7 @@ void ModelConfig_IO_RESOURCE::backup() {
       item->backup();
     }
   }
+  m_backup_root_bank_clkmuxes = m_root_bank_clkmuxes;
 }
 
 /*
@@ -204,6 +227,7 @@ void ModelConfig_IO_RESOURCE::restore() {
       item->restore();
     }
   }
+  m_root_bank_clkmuxes = m_backup_root_bank_clkmuxes;
 }
 
 }  // namespace FOEDAG

--- a/src/Configuration/ModelConfig/ModelConfig_IO_resource.h
+++ b/src/Configuration/ModelConfig/ModelConfig_IO_resource.h
@@ -28,19 +28,31 @@ namespace FOEDAG {
 
 struct PIN_INFO {
   PIN_INFO(const std::string& in0, uint32_t in1, bool in2, uint32_t in3,
-           uint32_t in4, uint32_t in5)
+           uint32_t in4, uint32_t in5, const std::string& in6,
+           const std::string& in7, uint32_t in8, uint32_t in9)
       : type(in0),
         bank(in1),
         is_clock(in2),
         index(in3),
         pair_index(in4),
-        ab_io(in5) {}
+        ab_io(in5),
+        ab_name(in6),
+        root_bank_mux_location(in7),
+        root_bank_mux_core_input_index(in8),
+        root_mux_input_index(in9) {
+    CFG_ASSERT((type == "BOOT_CLOCK" && ab_name.size() == 0) ||
+               ab_name.size() == 1);
+  }
   const std::string type = "";
   const uint32_t bank = 0;
   const bool is_clock = false;
   const uint32_t index = 0;
   const uint32_t pair_index = 0;
   const uint32_t ab_io = 0;
+  const std::string ab_name = "";
+  const std::string root_bank_mux_location = "";
+  const uint32_t root_bank_mux_core_input_index = 0;
+  const uint32_t root_mux_input_index = 0;
 };
 
 struct ModelConfig_IO_MODEL {
@@ -81,10 +93,15 @@ struct ModelConfig_IO_RESOURCE {
                     const std::string& type);
   bool use_resource(const std::string& resource,
                     const std::string& instantiator, const std::string& name);
+  std::pair<bool, std::string> use_root_bank_clkmux(const std::string& module,
+                                                    const std::string& location,
+                                                    PIN_INFO& pin_info);
   // Fail-safe mechanism
   void backup();
   void restore();
   std::map<std::string, std::vector<const ModelConfig_IO_MODEL*>*> m_resources;
+  std::map<std::string, std::string> m_root_bank_clkmuxes;
+  std::map<std::string, std::string> m_backup_root_bank_clkmuxes;
   std::string m_msg = "";
 };
 

--- a/tests/unittest/ModelConfig/apis/config_attributes.mapping.json
+++ b/tests/unittest/ModelConfig/apis/config_attributes.mapping.json
@@ -191,16 +191,11 @@
         "pll_PLLEN" : "__pll_enable__"
       }
     },
-    "PLL.ROOT_MUX0" : {
+    "PLL.MUX0" : {
       "rules" : {
         "__connectivity__" : "CLK_OUT",
         "__index__" : "__argIndex{default:0}__",
         "OUT0_ROUTE_TO_FABRIC_CLK" : "__arg0__"
-      },
-      "results" : {
-        "__define__" : "parse_pll_root_mux",
-        "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg0__",
-        "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
       }
     },
     "PLL.ROOT_MUX1" : {
@@ -328,19 +323,11 @@
     "CLK_BUF.ROOT_BANK_CLKMUX" : {
       "rules" : {
         "ROUTE_TO_FABRIC_CLK" : "__arg0__"
-      },
-      "results" : {
-        "__location__" : "__{[0]}__.u_gbox_root_bank_clkmux___bank__",
-        "CLK_BUF" : "ROOT_BANK_SRC==__AB__ --#MUX=__ROOT_BANK_MUX__"
       }
     },
     "CLK_BUF.ROOT_MUX" : {
       "rules" : {
         "ROUTE_TO_FABRIC_CLK" : "__arg0__"
-      },
-      "results" : {
-        "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg0__",
-        "ROOT_MUX_SEL" : "__ROOT_MUX__"
       }
     }
   },
@@ -352,6 +339,10 @@
     "  index = 0",
     "  pair_index = 0",
     "  ab_io = 0",
+    "  ab_name = ''",
+    "  root_bank_mux_location = ''",
+    "  root_bank_mux_core_input_index = 0",
+    "  root_mux_input_index = 0",
     "  if name.find('BOOT_CLOCK#') == 0:",
     "    type = 'BOOT_CLOCK'",
     "    index = int(name[11:])",
@@ -365,7 +356,13 @@
     "    index = int(m.group(4))",
     "    pair_index = int(m.group(5))",
     "    ab_io = 0 if (pair_index < 10) else 1",
-    "  return [type, bank, is_clock, index, pair_index, ab_io]",
+    "    ab_name = '%c' % (ord('A') + ab_io)",
+    "    root_name = 'u_GBOX_HP_40X2' if type == 'HP' else ('u_GBOX_HV_40X2_VL' if type == 'HVL' else 'u_GBOX_HV_40X2_VR')",
+    "    root_bank_mux_location = '%s.u_gbox_root_bank_clkmux_%d' % (root_name, bank)",
+    "    root_bank_mux_core_input_index = index - (20 * ab_io)",
+    "    root_mux_input_index = 0 if type == 'HP' else (8 if type == 'HVL' else 16)",
+    "    root_mux_input_index += ((2 * bank) + ab_io)",
+    "  return [type, bank, is_clock, index, pair_index, ab_io, ab_name, root_bank_mux_location, root_bank_mux_core_input_index, root_mux_input_index]",
     "def fclk_use_pll_resource(fclk) :",
     "  pll_resource = 0", 
     "  if fclk.find('hvl_fclk_') == 0 :",

--- a/tests/unittest/ModelConfig/design_edit.sdc
+++ b/tests/unittest/ModelConfig/design_edit.sdc
@@ -3,26 +3,34 @@
 # Fabric clock assignment
 #
 #############
+# This is fabric clock needed by logic but also primitive core clock
 # set_clock_pin -device_clock clk[0] -design_clock clk0 (Physical port name)
 # set_clock_pin -device_clock clk[0] -design_clock $clk_buf_$ibuf_clk0 (Original clock primitive out-net to fabric)
 set_clock_pin   -device_clock clk[0] -design_clock $clk_buf_$ibuf_clk0
 
+# This is fabric clock needed by primitive core clock
 # set_clock_pin -device_clock clk[1] -design_clock clk1 (Physical port name)
-# set_clock_pin -device_clock clk[1] -design_clock pll_clk (Original clock primitive out-net to fabric)
-set_clock_pin   -device_clock clk[1] -design_clock pll_clk
 
-# set_clock_pin -device_clock clk[2] -design_clock clk2 (Physical port name)
-# set_clock_pin -device_clock clk[2] -design_clock $clk_buf_$ibuf_clk2 (Original clock primitive out-net to fabric)
-set_clock_pin   -device_clock clk[2] -design_clock $clk_buf_$ibuf_clk2
+# This is fabric clock needed by logic but also primitive core clock
+# set_clock_pin -device_clock clk[2] -design_clock clk1 (Physical port name)
+# set_clock_pin -device_clock clk[2] -design_clock pll_clk (Original clock primitive out-net to fabric)
+set_clock_pin   -device_clock clk[2] -design_clock pll_clk
 
-# Fail reason: Failed to find the mapped name
-# set_clock_pin -device_clock clk[3] -design_clock BOOT_CLOCK#0 (Physical port name)
-set_clock_pin   -device_clock clk[3] -design_clock osc_pll
+# This is fabric clock needed by primitive core clock
+# set_clock_pin -device_clock clk[3] -design_clock clk1 (Physical port name)
+
+# This is fabric clock needed by primitive core clock
+# set_clock_pin -device_clock clk[4] -design_clock BOOT_CLOCK#0 (Physical port name)
+
+# This is fabric clock needed by logic
+# set_clock_pin -device_clock clk[5] -design_clock clk2 (Physical port name)
+# set_clock_pin -device_clock clk[5] -design_clock $clk_buf_$ibuf_clk2 (Original clock primitive out-net to fabric)
+set_clock_pin   -device_clock clk[5] -design_clock $clk_buf_$ibuf_clk2
 
 # This is fabric clock buffer
-# set_clock_pin -device_clock clk[4] -design_clock FABRIC_CLKBUF#0 (Physical port name)
-# set_clock_pin -device_clock clk[4] -design_clock $fclk_buf_clk0_div (Original clock primitive out-net to fabric)
-set_clock_pin   -device_clock clk[4] -design_clock $fclk_buf_clk0_div
+# set_clock_pin -device_clock clk[6] -design_clock FABRIC_CLKBUF#0 (Physical port name)
+# set_clock_pin -device_clock clk[6] -design_clock $fclk_buf_clk0_div (Original clock primitive out-net to fabric)
+set_clock_pin   -device_clock clk[6] -design_clock $fclk_buf_clk0_div
 
 # For fabric clock buffer output
 # set_clock_out -device_clock clk[0] -design_clock clk0_div
@@ -34,121 +42,135 @@ set_clock_out   -device_clock clk[0] -design_clock clk0_div
 #
 #############
 # Clock data from object clk0 port O is not routed to fabric
-# Pin      clk0                                                                                       :: I_BUF |-> CLK_BUF
+# Pin      clk0                      :: I_BUF |-> CLK_BUF
 
 # Object clk1 is primitive \PLL but data signal is not defined
-# Pin      clk1                                                                                       :: I_BUF |-> CLK_BUF |-> PLL
+# Pin      clk1                      :: I_BUF |-> CLK_BUF |-> PLL
 
 # Clock data from object clk2 port O is not routed to fabric
-# Pin      clk2                                                                                       :: I_BUF |-> CLK_BUF
+# Pin      clk2                      :: I_BUF |-> CLK_BUF
 
-# Pin      din                                                                                        :: I_BUF |-> I_DELAY
-# set_mode MODE_BP_DIR_A_RX                                                                           HP_1_20_10P
-# set_io   din                                                                                        HP_1_20_10P                  --> (original)
-set_io     din_delay                                                                                  HP_1_20_10P                  -mode          MODE_BP_DIR_A_RX -internal_pin g2f_rx_in[0]_A
+# Pin      din                       :: I_BUF |-> I_DELAY
+# set_mode MODE_BP_DIR_A_RX          HP_1_20_10P
+# set_io   din                       HP_1_20_10P                  --> (original)
+set_io     din_delay                 HP_1_20_10P                  -mode          MODE_BP_DIR_A_RX -internal_pin g2f_rx_in[0]_A
 
-# Pin      din_clk2                                                                                   :: I_BUF
-# set_mode MODE_BP_DIR_A_RX                                                                           HR_5_0_0P
-# set_io   din_clk2                                                                                   HR_5_0_0P                    --> (original)
-set_io     $ibuf_din_clk2                                                                             HR_5_0_0P                    -mode          MODE_BP_DIR_A_RX -internal_pin g2f_rx_in[0]_A
+# Pin      din_clk2                  :: I_BUF
+# set_mode MODE_BP_DIR_A_RX          HR_5_0_0P
+# set_io   din_clk2                  HR_5_0_0P                    --> (original)
+set_io     $ibuf_din_clk2            HR_5_0_0P                    -mode          MODE_BP_DIR_A_RX -internal_pin g2f_rx_in[0]_A
 
-# Pin      din_serdes                                                                                 :: I_BUF |-> I_SERDES
-# set_mode MODE_RATE_8_A_RX                                                                           HR_2_0_0P
-# set_io   din_serdes                                                                                 HR_2_0_0P                    --> (original)
-set_io     serdes_data[0]                                                                             HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[0]_A
-set_io     serdes_data[1]                                                                             HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[1]_A
-set_io     serdes_data[2]                                                                             HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[2]_A
-set_io     serdes_data[3]                                                                             HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[3]_A
-set_io     serdes_data[4]                                                                             HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[4]_A
-set_io     serdes_data[5]                                                                             HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[5]_A
-set_io     serdes_data[6]                                                                             HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[6]_A
-set_io     serdes_data[7]                                                                             HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[7]_A
+# Pin      din_serdes                :: I_BUF |-> I_SERDES
+# set_mode MODE_RATE_8_A_RX          HR_2_0_0P
+# set_io   din_serdes                HR_2_0_0P                    --> (original)
+set_io     serdes_data[0]            HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[0]_A
+set_io     serdes_data[1]            HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[1]_A
+set_io     serdes_data[2]            HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[2]_A
+set_io     serdes_data[3]            HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[3]_A
+set_io     serdes_data[4]            HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[4]_A
+set_io     serdes_data[5]            HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[5]_A
+set_io     serdes_data[6]            HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[6]_A
+set_io     serdes_data[7]            HR_2_0_0P                    -mode          MODE_RATE_8_A_RX -internal_pin g2f_rx_in[7]_A
+
+# Pin      din_serdes_clk_out        :: I_BUF
+# set_mode MODE_BP_DIR_A_RX          HR_2_6_3P
+# set_io   din_serdes_clk_out        HR_2_6_3P                    --> (original)
+set_io     $ibuf_din_serdes_clk_out  HR_2_6_3P                    -mode          MODE_BP_DIR_A_RX -internal_pin g2f_rx_in[0]_A
 
 # Pin location is not assigned
-# Pin      enable                                                                                     :: I_BUF
+# Pin      enable                    :: I_BUF
 
-# Pin      reset                                                                                      :: I_BUF
-# set_mode MODE_BP_DIR_A_RX                                                                           HP_1_0_0P
-# set_io   reset                                                                                      HP_1_0_0P                    --> (original)
-set_io     $ibuf_reset                                                                                HP_1_0_0P                    -mode          MODE_BP_DIR_A_RX -internal_pin g2f_rx_in[0]_A
+# Pin      reset                     :: I_BUF
+# set_mode MODE_BP_DIR_A_RX          HP_1_0_0P
+# set_io   reset                     HP_1_0_0P                    --> (original)
+set_io     $ibuf_reset               HP_1_0_0P                    -mode          MODE_BP_DIR_A_RX -internal_pin g2f_rx_in[0]_A
 
 # Object clk_out is primitive \O_SERDES_CLK but data signal is not defined
-# Pin      clk_out                                                                                    :: O_SERDES_CLK |-> O_BUFT
+# Pin      clk_out                   :: O_SERDES_CLK |-> O_BUFT
 
-# Pin      delay_tap[0]                                                                               :: O_BUFT
-# set_mode MODE_BP_DIR_A_TX                                                                           HR_2_20_10P
-# set_io   delay_tap[0]                                                                               HR_2_20_10P                  --> (original)
-set_io     $obuf_delay_tap[0]                                                                         HR_2_20_10P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
+# Pin      delay_tap[0]              :: O_BUFT
+# set_mode MODE_BP_DIR_A_TX          HR_2_20_10P
+# set_io   delay_tap[0]              HR_2_20_10P                  --> (original)
+set_io     $obuf_delay_tap[0]        HR_2_20_10P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
 
-# Pin      delay_tap[1]                                                                               :: O_BUFT
-# set_mode MODE_BP_DIR_A_TX                                                                           HR_2_22_11P
-# set_io   delay_tap[1]                                                                               HR_2_22_11P                  --> (original)
-set_io     $obuf_delay_tap[1]                                                                         HR_2_22_11P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
+# Pin      delay_tap[1]              :: O_BUFT
+# set_mode MODE_BP_DIR_A_TX          HR_2_22_11P
+# set_io   delay_tap[1]              HR_2_22_11P                  --> (original)
+set_io     $obuf_delay_tap[1]        HR_2_22_11P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
 
-# Pin      delay_tap[2]                                                                               :: O_BUFT
-# set_mode MODE_BP_DIR_A_TX                                                                           HR_2_24_12P
-# set_io   delay_tap[2]                                                                               HR_2_24_12P                  --> (original)
-set_io     $obuf_delay_tap[2]                                                                         HR_2_24_12P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
+# Pin      delay_tap[2]              :: O_BUFT
+# set_mode MODE_BP_DIR_A_TX          HR_2_24_12P
+# set_io   delay_tap[2]              HR_2_24_12P                  --> (original)
+set_io     $obuf_delay_tap[2]        HR_2_24_12P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
 
-# Pin      delay_tap[3]                                                                               :: O_BUFT
-# set_mode MODE_BP_DIR_A_TX                                                                           HR_2_26_13P
-# set_io   delay_tap[3]                                                                               HR_2_26_13P                  --> (original)
-set_io     $obuf_delay_tap[3]                                                                         HR_2_26_13P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
+# Pin      delay_tap[3]              :: O_BUFT
+# set_mode MODE_BP_DIR_A_TX          HR_2_26_13P
+# set_io   delay_tap[3]              HR_2_26_13P                  --> (original)
+set_io     $obuf_delay_tap[3]        HR_2_26_13P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
 
-# Pin      delay_tap[4]                                                                               :: O_BUFT
-# set_mode MODE_BP_DIR_A_TX                                                                           HR_2_28_14P
-# set_io   delay_tap[4]                                                                               HR_2_28_14P                  --> (original)
-set_io     $obuf_delay_tap[4]                                                                         HR_2_28_14P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
+# Pin      delay_tap[4]              :: O_BUFT
+# set_mode MODE_BP_DIR_A_TX          HR_2_28_14P
+# set_io   delay_tap[4]              HR_2_28_14P                  --> (original)
+set_io     $obuf_delay_tap[4]        HR_2_28_14P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
 
-# Pin      delay_tap[5]                                                                               :: O_BUFT
-# set_mode MODE_BP_DIR_A_TX                                                                           HR_2_30_15P
-# set_io   delay_tap[5]                                                                               HR_2_30_15P                  --> (original)
-set_io     $obuf_delay_tap[5]                                                                         HR_2_30_15P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
+# Pin      delay_tap[5]              :: O_BUFT
+# set_mode MODE_BP_DIR_A_TX          HR_2_30_15P
+# set_io   delay_tap[5]              HR_2_30_15P                  --> (original)
+set_io     $obuf_delay_tap[5]        HR_2_30_15P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
 
-# Pin      dout                                                                                       :: O_DELAY |-> O_BUFT
-# set_mode MODE_BP_DIR_A_TX                                                                           HP_2_20_10P
-# set_io   dout                                                                                       HP_2_20_10P                  --> (original)
-set_io     dout_pre_delay                                                                             HP_2_20_10P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
+# Pin      dout                      :: O_DELAY |-> O_BUFT
+# set_mode MODE_BP_DIR_A_TX          HP_2_20_10P
+# set_io   dout                      HP_2_20_10P                  --> (original)
+set_io     dout_pre_delay            HP_2_20_10P                  -mode          MODE_BP_DIR_A_TX -internal_pin f2g_tx_out[0]_A
 
-# Pin      dout_clk2                                                                                  :: O_BUFT
-# set_mode MODE_BP_DIR_B_TX                                                                           HR_5_1_0N
-# set_io   dout_clk2                                                                                  HR_5_1_0N                    --> (original)
-set_io     $obuf_dout_clk2                                                                            HR_5_0_0P                    -mode          MODE_BP_DIR_B_TX -internal_pin f2g_tx_out[5]_A
+# Pin      dout_clk2                 :: O_BUFT
+# set_mode MODE_BP_DIR_B_TX          HR_5_1_0N
+# set_io   dout_clk2                 HR_5_1_0N                    --> (original)
+set_io     $obuf_dout_clk2           HR_5_0_0P                    -mode          MODE_BP_DIR_B_TX -internal_pin f2g_tx_out[5]_A
 
-# Pin      dout_serdes                                                                                :: O_SERDES |-> O_BUFT
-# set_mode MODE_RATE_4_A_TX                                                                           HR_2_2_1P
-# set_io   dout_serdes                                                                                HR_2_2_1P                    --> (original)
-set_io     $abc$194$xor$/home/cschai/desktop/raptor_projects/ppdb/foedag_unit_test/./top.v:199$5_Y[0] HR_2_2_1P                    -mode          MODE_RATE_4_A_TX -internal_pin f2g_tx_out[0]_A
-set_io     $abc$194$xor$/home/cschai/desktop/raptor_projects/ppdb/foedag_unit_test/./top.v:199$5_Y[1] HR_2_2_1P                    -mode          MODE_RATE_4_A_TX -internal_pin f2g_tx_out[1]_A
-set_io     $abc$194$xor$/home/cschai/desktop/raptor_projects/ppdb/foedag_unit_test/./top.v:199$5_Y[2] HR_2_2_1P                    -mode          MODE_RATE_4_A_TX -internal_pin f2g_tx_out[2]_A
-set_io     $abc$194$xor$/home/cschai/desktop/raptor_projects/ppdb/foedag_unit_test/./top.v:199$5_Y[3] HR_2_2_1P                    -mode          MODE_RATE_4_A_TX -internal_pin f2g_tx_out[3]_A
+# Pin      dout_serdes               :: O_SERDES |-> O_BUFT
+# set_mode MODE_RATE_8_A_TX          HR_2_2_1P
+# set_io   dout_serdes               HR_2_2_1P                    --> (original)
+set_io     $auto_540                 HR_2_2_1P                    -mode          MODE_RATE_8_A_TX -internal_pin f2g_tx_out[0]_A
+set_io     $auto_541                 HR_2_2_1P                    -mode          MODE_RATE_8_A_TX -internal_pin f2g_tx_out[1]_A
+set_io     $auto_542                 HR_2_2_1P                    -mode          MODE_RATE_8_A_TX -internal_pin f2g_tx_out[2]_A
+set_io     $auto_543                 HR_2_2_1P                    -mode          MODE_RATE_8_A_TX -internal_pin f2g_tx_out[3]_A
+set_io     $auto_544                 HR_2_2_1P                    -mode          MODE_RATE_8_A_TX -internal_pin f2g_tx_out[4]_A
+set_io     $auto_545                 HR_2_2_1P                    -mode          MODE_RATE_8_A_TX -internal_pin f2g_tx_out[5]_A
+set_io     $auto_546                 HR_2_2_1P                    -mode          MODE_RATE_8_A_TX -internal_pin f2g_tx_out[6]_A
+set_io     $auto_547                 HR_2_2_1P                    -mode          MODE_RATE_8_A_TX -internal_pin f2g_tx_out[7]_A
 
-# Skip this because 'This is secondary pin. But IO bitstream generation will still make sure it is used in pair. Otherwise the IO bitstream will be invalid'
-# Pin      din_n                                                                                      :: I_BUF_DS |-> I_DDR
-
-# Pin      din_p                                                                                      :: I_BUF_DS |-> I_DDR
-# set_mode MODE_BP_DDR_A_RX                                                                           HP_1_4_2P
-# set_io   din_p                                                                                      HP_1_4_2P                    --> (original)
-set_io     o_ddr_d[0]                                                                                 HP_1_4_2P                    -mode          MODE_BP_DDR_A_RX -internal_pin g2f_rx_in[0]_A
-set_io     o_ddr_d[1]                                                                                 HP_1_4_2P                    -mode          MODE_BP_DDR_A_RX -internal_pin g2f_rx_in[1]_A
-
-# Skip this because 'This is secondary pin. But IO bitstream generation will still make sure it is used in pair. Otherwise the IO bitstream will be invalid'
-# Pin      dout_n                                                                                     :: O_DDR |-> O_BUF_DS
-
-# Pin      dout_p                                                                                     :: O_DDR |-> O_BUF_DS
-# set_mode MODE_BP_DDR_A_TX                                                                           HP_1_8_4P
-# set_io   dout_p                                                                                     HP_1_8_4P                    --> (original)
-set_io     $auto_567                                                                                  HP_1_8_4P                    -mode          MODE_BP_DDR_A_TX -internal_pin f2g_tx_out[0]_A
-set_io     $auto_568                                                                                  HP_1_8_4P                    -mode          MODE_BP_DDR_A_TX -internal_pin f2g_tx_out[1]_A
+# Pin      dout_serdes_clk_out       :: O_BUFT
+# set_mode MODE_BP_DIR_B_TX          HR_2_7_3N
+# set_io   dout_serdes_clk_out       HR_2_7_3N                    --> (original)
+set_io     $obuf_dout_serdes_clk_out HR_2_6_3P                    -mode          MODE_BP_DIR_B_TX -internal_pin f2g_tx_out[5]_A
 
 # Skip this because 'This is secondary pin. But IO bitstream generation will still make sure it is used in pair. Otherwise the IO bitstream will be invalid'
-# Pin      dout_osc_n                                                                                 :: O_DDR |-> O_BUF_DS
+# Pin      din_n                     :: I_BUF_DS |-> I_DDR
 
-# Pin      dout_osc_p                                                                                 :: O_DDR |-> O_BUF_DS
-# set_mode MODE_BP_DDR_A_TX                                                                           HP_2_22_11P
-# set_io   dout_osc_p                                                                                 HP_2_22_11P                  --> (original)
-set_io     $auto_569                                                                                  HP_2_22_11P                  -mode          MODE_BP_DDR_A_TX -internal_pin f2g_tx_out[0]_A
-set_io     $auto_570                                                                                  HP_2_22_11P                  -mode          MODE_BP_DDR_A_TX -internal_pin f2g_tx_out[1]_A
+# Pin      din_p                     :: I_BUF_DS |-> I_DDR
+# set_mode MODE_BP_DDR_A_RX          HP_1_4_2P
+# set_io   din_p                     HP_1_4_2P                    --> (original)
+set_io     o_ddr_d[0]                HP_1_4_2P                    -mode          MODE_BP_DDR_A_RX -internal_pin g2f_rx_in[0]_A
+set_io     o_ddr_d[1]                HP_1_4_2P                    -mode          MODE_BP_DDR_A_RX -internal_pin g2f_rx_in[1]_A
+
+# Skip this because 'This is secondary pin. But IO bitstream generation will still make sure it is used in pair. Otherwise the IO bitstream will be invalid'
+# Pin      dout_n                    :: O_DDR |-> O_BUF_DS
+
+# Pin      dout_p                    :: O_DDR |-> O_BUF_DS
+# set_mode MODE_BP_DDR_A_TX          HP_1_8_4P
+# set_io   dout_p                    HP_1_8_4P                    --> (original)
+set_io     $auto_536                 HP_1_8_4P                    -mode          MODE_BP_DDR_A_TX -internal_pin f2g_tx_out[0]_A
+set_io     $auto_537                 HP_1_8_4P                    -mode          MODE_BP_DDR_A_TX -internal_pin f2g_tx_out[1]_A
+
+# Skip this because 'This is secondary pin. But IO bitstream generation will still make sure it is used in pair. Otherwise the IO bitstream will be invalid'
+# Pin      dout_osc_n                :: O_DDR |-> O_BUF_DS
+
+# Pin      dout_osc_p                :: O_DDR |-> O_BUF_DS
+# set_mode MODE_BP_DDR_A_TX          HP_2_22_11P
+# set_io   dout_osc_p                HP_2_22_11P                  --> (original)
+set_io     $auto_538                 HP_2_22_11P                  -mode          MODE_BP_DDR_A_TX -internal_pin f2g_tx_out[0]_A
+set_io     $auto_539                 HP_2_22_11P                  -mode          MODE_BP_DDR_A_TX -internal_pin f2g_tx_out[1]_A
 
 #############
 #
@@ -160,14 +182,14 @@ set_io     $auto_570                                                            
 # Location: HR_1_CC_18_9P
 # Port: EN
 # Signal: in:f2g_in_en_{A|B}
-set_io   $auto_531                        HR_1_CC_18_9P  -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
+set_io   $auto_500                        HR_1_CC_18_9P  -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
 
 # Module: I_BUF
 # LinkedObject: clk1
 # Location: HP_1_CC_18_9P
 # Port: EN
 # Signal: in:f2g_in_en_{A|B}
-set_io   $auto_532                        HP_1_CC_18_9P  -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
+set_io   $auto_501                        HP_1_CC_18_9P  -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
 
 # Module: PLL
 # LinkedObject: clk1
@@ -182,21 +204,21 @@ set_io   $auto_532                        HP_1_CC_18_9P  -mode MODE_BP_DIR_A_RX 
 # Port: PLL_EN
 # Signal: in:TO_BE_DETERMINED
 # Skip reason: TO_BE_DETERMINED
-# set_io $auto_565                        HP_1_CC_18_9P  -mode MODE_BP_DIR_A_RX -internal_pin TO_BE_DETERMINED
+# set_io $auto_534                        HP_1_CC_18_9P  -mode MODE_BP_DIR_A_RX -internal_pin TO_BE_DETERMINED
 
 # Module: I_BUF
 # LinkedObject: clk2
 # Location: HR_5_CC_38_19P
 # Port: EN
 # Signal: in:f2g_in_en_{A|B}
-set_io   $auto_533                        HR_5_CC_38_19P -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
+set_io   $auto_502                        HR_5_CC_38_19P -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
 
 # Module: I_BUF
 # LinkedObject: din
 # Location: HP_1_20_10P
 # Port: EN
 # Signal: in:f2g_in_en_{A|B}
-set_io   $auto_534                        HP_1_20_10P    -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
+set_io   $auto_503                        HP_1_20_10P    -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
 
 # Module: I_DELAY
 # LinkedObject: din
@@ -204,7 +226,7 @@ set_io   $auto_534                        HP_1_20_10P    -mode MODE_BP_DIR_A_RX 
 # Port: DLY_ADJ
 # Signal: in:rule=half-first:f2g_trx_dly_adj
 # Remap location from HP_1_20_10P to HP_1_20_10P
-set_io   $auto_550                        HP_1_20_10P    -mode MODE_BP_DIR_A_RX -internal_pin f2g_trx_dly_adj
+set_io   $auto_521                        HP_1_20_10P    -mode MODE_BP_DIR_A_RX -internal_pin f2g_trx_dly_adj
 
 # Module: I_DELAY
 # LinkedObject: din
@@ -212,7 +234,7 @@ set_io   $auto_550                        HP_1_20_10P    -mode MODE_BP_DIR_A_RX 
 # Port: DLY_INCDEC
 # Signal: in:rule=half-first:f2g_trx_dly_inc
 # Remap location from HP_1_20_10P to HP_1_20_10P
-set_io   $auto_551                        HP_1_20_10P    -mode MODE_BP_DIR_A_RX -internal_pin f2g_trx_dly_inc
+set_io   $auto_522                        HP_1_20_10P    -mode MODE_BP_DIR_A_RX -internal_pin f2g_trx_dly_inc
 
 # Module: I_DELAY
 # LinkedObject: din
@@ -220,7 +242,7 @@ set_io   $auto_551                        HP_1_20_10P    -mode MODE_BP_DIR_A_RX 
 # Port: DLY_LOAD
 # Signal: in:rule=half-first:f2g_trx_dly_ld
 # Remap location from HP_1_20_10P to HP_1_20_10P
-set_io   $auto_552                        HP_1_20_10P    -mode MODE_BP_DIR_A_RX -internal_pin f2g_trx_dly_ld
+set_io   $auto_523                        HP_1_20_10P    -mode MODE_BP_DIR_A_RX -internal_pin f2g_trx_dly_ld
 
 # Module: I_DELAY
 # LinkedObject: din
@@ -240,22 +262,22 @@ set_io   $ifab_$obuf_delay_tap[5]         HP_1_20_10P    -mode MODE_BP_DIR_A_RX 
 # Location: HR_5_0_0P
 # Port: EN
 # Signal: in:f2g_in_en_{A|B}
-set_io   $auto_535                        HR_5_0_0P      -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
+set_io   $auto_504                        HR_5_0_0P      -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
 
 # Module: I_BUF
 # LinkedObject: din_serdes
 # Location: HR_2_0_0P
 # Port: EN
 # Signal: in:f2g_in_en_{A|B}
-set_io   $auto_536                        HR_2_0_0P      -mode MODE_RATE_8_A_RX -internal_pin f2g_in_en_A
+set_io   $auto_505                        HR_2_0_0P      -mode MODE_RATE_8_A_RX -internal_pin f2g_in_en_A
 
 # Module: I_SERDES
 # LinkedObject: din_serdes
 # Location: HR_2_0_0P
 # Port: BITSLIP_ADJ
-# Signal: in:TO_BE_DETERMINED
-# Skip reason: TO_BE_DETERMINED
-# set_io $auto_553                        HR_2_0_0P      -mode MODE_RATE_8_A_RX -internal_pin TO_BE_DETERMINED
+# Signal: in:rule=half-first:f2g_rx_bitslip_adj
+# Remap location from HR_2_0_0P to HR_2_0_0P
+set_io   $auto_524                        HR_2_0_0P      -mode MODE_RATE_8_A_RX -internal_pin f2g_rx_bitslip_adj
 
 # Module: I_SERDES
 # LinkedObject: din_serdes
@@ -268,14 +290,14 @@ set_io   $auto_536                        HR_2_0_0P      -mode MODE_RATE_8_A_RX 
 # LinkedObject: din_serdes
 # Location: HR_2_0_0P
 # Port: DPA_ERROR
-# Signal: out:TO_BE_DETERMINED
+# Signal: out:rule=half-first:g2f_rx_dpa_error
 # Skip reason: User design does not utilize linked-object din_serdes wrapped-instance port DPA_ERROR
 
 # Module: I_SERDES
 # LinkedObject: din_serdes
 # Location: HR_2_0_0P
 # Port: DPA_LOCK
-# Signal: out:TO_BE_DETERMINED
+# Signal: out:rule=half-first:g2f_rx_dpa_lock
 # Skip reason: User design does not utilize linked-object din_serdes wrapped-instance port DPA_LOCK
 
 # Module: I_SERDES
@@ -284,21 +306,21 @@ set_io   $auto_536                        HR_2_0_0P      -mode MODE_RATE_8_A_RX 
 # Port: EN
 # Signal: in:TO_BE_DETERMINED
 # Skip reason: TO_BE_DETERMINED
-# set_io $auto_555                        HR_2_0_0P      -mode MODE_RATE_8_A_RX -internal_pin TO_BE_DETERMINED
-
-# Module: I_SERDES
-# LinkedObject: din_serdes
-# Location: HR_2_0_0P
-# Port: PLL_LOCK
-# Signal: in:TO_BE_DETERMINED
-# Skip reason: User design does not utilize linked-object din_serdes wrapped-instance port PLL_LOCK
+# set_io $auto_525                        HR_2_0_0P      -mode MODE_RATE_8_A_RX -internal_pin TO_BE_DETERMINED
 
 # Module: I_SERDES
 # LinkedObject: din_serdes
 # Location: HR_2_0_0P
 # Port: RST
 # Signal: in:f2g_trx_reset_n_{A|B}
-set_io   $auto_556                        HR_2_0_0P      -mode MODE_RATE_8_A_RX -internal_pin f2g_trx_reset_n_A
+set_io   $auto_526                        HR_2_0_0P      -mode MODE_RATE_8_A_RX -internal_pin f2g_trx_reset_n_A
+
+# Module: I_BUF
+# LinkedObject: din_serdes_clk_out
+# Location: HR_2_6_3P
+# Port: EN
+# Signal: in:f2g_in_en_{A|B}
+set_io   $auto_506                        HR_2_6_3P      -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
 
 # Module: I_BUF
 # LinkedObject: enable
@@ -312,78 +334,70 @@ set_io   $auto_556                        HR_2_0_0P      -mode MODE_RATE_8_A_RX 
 # Location: HP_1_0_0P
 # Port: EN
 # Signal: in:f2g_in_en_{A|B}
-set_io   $auto_538                        HP_1_0_0P      -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
+set_io   $auto_508                        HP_1_0_0P      -mode MODE_BP_DIR_A_RX -internal_pin f2g_in_en_A
 
 # Module: O_BUFT
 # LinkedObject: clk_out
 # Location: HR_2_4_2P
 # Port: T
 # Signal: in:f2g_tx_oe_{A|B}
-set_io   $auto_539                        HR_2_4_2P      -mode MODE_BP_SDR_A_TX -internal_pin f2g_tx_oe_A
+set_io   $auto_509                        HR_2_4_2P      -mode MODE_BP_SDR_A_TX -internal_pin f2g_tx_oe_A
 
 # Module: O_SERDES_CLK
 # LinkedObject: clk_out
 # Location: HR_2_4_2P
 # Port: CLK_EN
-# Signal: in:TO_BE_DETERMINED
-# Skip reason: TO_BE_DETERMINED
-# set_io $auto_564                        HR_2_4_2P      -mode MODE_BP_SDR_A_TX -internal_pin TO_BE_DETERMINED
-
-# Module: O_SERDES_CLK
-# LinkedObject: clk_out
-# Location: HR_2_4_2P
-# Port: PLL_LOCK
-# Signal: in:TO_BE_DETERMINED
-# Skip reason: User design does not utilize linked-object clk_out wrapped-instance port PLL_LOCK
+# Signal: in:f2g_tx_clk_en_{A|B} 
+set_io   $auto_533                        HR_2_4_2P      -mode MODE_BP_SDR_A_TX -internal_pin f2g_tx_clk_en_A 
 
 # Module: O_BUFT
 # LinkedObject: delay_tap[0]
 # Location: HR_2_20_10P
 # Port: T
 # Signal: in:f2g_tx_oe_{A|B}
-set_io   $auto_540                        HR_2_20_10P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
+set_io   $auto_510                        HR_2_20_10P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
 
 # Module: O_BUFT
 # LinkedObject: delay_tap[1]
 # Location: HR_2_22_11P
 # Port: T
 # Signal: in:f2g_tx_oe_{A|B}
-set_io   $auto_541                        HR_2_22_11P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
+set_io   $auto_511                        HR_2_22_11P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
 
 # Module: O_BUFT
 # LinkedObject: delay_tap[2]
 # Location: HR_2_24_12P
 # Port: T
 # Signal: in:f2g_tx_oe_{A|B}
-set_io   $auto_542                        HR_2_24_12P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
+set_io   $auto_512                        HR_2_24_12P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
 
 # Module: O_BUFT
 # LinkedObject: delay_tap[3]
 # Location: HR_2_26_13P
 # Port: T
 # Signal: in:f2g_tx_oe_{A|B}
-set_io   $auto_543                        HR_2_26_13P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
+set_io   $auto_513                        HR_2_26_13P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
 
 # Module: O_BUFT
 # LinkedObject: delay_tap[4]
 # Location: HR_2_28_14P
 # Port: T
 # Signal: in:f2g_tx_oe_{A|B}
-set_io   $auto_544                        HR_2_28_14P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
+set_io   $auto_514                        HR_2_28_14P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
 
 # Module: O_BUFT
 # LinkedObject: delay_tap[5]
 # Location: HR_2_30_15P
 # Port: T
 # Signal: in:f2g_tx_oe_{A|B}
-set_io   $auto_545                        HR_2_30_15P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
+set_io   $auto_515                        HR_2_30_15P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
 
 # Module: O_BUFT
 # LinkedObject: dout
 # Location: HP_2_20_10P
 # Port: T
 # Signal: in:f2g_tx_oe_{A|B}
-set_io   $auto_546                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
+set_io   $auto_516                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_tx_oe_A
 
 # Module: O_DELAY
 # LinkedObject: dout
@@ -391,7 +405,7 @@ set_io   $auto_546                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX 
 # Port: DLY_ADJ
 # Signal: in:rule=half-first:f2g_trx_dly_adj
 # Remap location from HP_2_20_10P to HP_2_20_10P
-set_io   $auto_557                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_trx_dly_adj
+set_io   $auto_527                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_trx_dly_adj
 
 # Module: O_DELAY
 # LinkedObject: dout
@@ -399,7 +413,7 @@ set_io   $auto_557                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX 
 # Port: DLY_INCDEC
 # Signal: in:rule=half-first:f2g_trx_dly_inc
 # Remap location from HP_2_20_10P to HP_2_20_10P
-set_io   $auto_558                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_trx_dly_inc
+set_io   $auto_528                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_trx_dly_inc
 
 # Module: O_DELAY
 # LinkedObject: dout
@@ -407,7 +421,7 @@ set_io   $auto_558                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX 
 # Port: DLY_LOAD
 # Signal: in:rule=half-first:f2g_trx_dly_ld
 # Remap location from HP_2_20_10P to HP_2_20_10P
-set_io   $auto_559                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_trx_dly_ld
+set_io   $auto_529                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX -internal_pin f2g_trx_dly_ld
 
 # Module: O_DELAY
 # LinkedObject: dout
@@ -421,14 +435,14 @@ set_io   $auto_559                        HP_2_20_10P    -mode MODE_BP_DIR_A_TX 
 # Location: HR_5_1_0N
 # Port: T
 # Signal: in:f2g_tx_oe_{A|B}
-set_io   $auto_547                        HR_5_1_0N      -mode MODE_BP_DIR_B_TX -internal_pin f2g_tx_oe_B
+set_io   $auto_517                        HR_5_1_0N      -mode MODE_BP_DIR_B_TX -internal_pin f2g_tx_oe_B
 
 # Module: O_BUFT
 # LinkedObject: dout_serdes
 # Location: HR_2_2_1P
 # Port: T
 # Signal: in:f2g_tx_oe_{A|B}
-set_io   $auto_548                        HR_2_2_1P      -mode MODE_RATE_4_A_TX -internal_pin f2g_tx_oe_A
+set_io   $auto_518                        HR_2_2_1P      -mode MODE_RATE_8_A_TX -internal_pin f2g_tx_oe_A
 
 # Module: O_SERDES
 # LinkedObject: dout_serdes
@@ -449,7 +463,7 @@ set_io   $auto_548                        HR_2_2_1P      -mode MODE_RATE_4_A_TX 
 # Location: HR_2_2_1P
 # Port: DATA_VALID
 # Signal: in:f2g_tx_dvalid_{A|B}
-set_io   $auto_561                        HR_2_2_1P      -mode MODE_RATE_4_A_TX -internal_pin f2g_tx_dvalid_A
+set_io   $auto_530                        HR_2_2_1P      -mode MODE_RATE_8_A_TX -internal_pin f2g_tx_dvalid_A
 
 # Module: O_SERDES
 # LinkedObject: dout_serdes
@@ -457,7 +471,7 @@ set_io   $auto_561                        HR_2_2_1P      -mode MODE_RATE_4_A_TX 
 # Port: OE_IN
 # Signal: in:TO_BE_DETERMINED
 # Skip reason: TO_BE_DETERMINED
-# set_io $auto_562                        HR_2_2_1P      -mode MODE_RATE_4_A_TX -internal_pin TO_BE_DETERMINED
+# set_io $auto_531                        HR_2_2_1P      -mode MODE_RATE_8_A_TX -internal_pin TO_BE_DETERMINED
 
 # Module: O_SERDES
 # LinkedObject: dout_serdes
@@ -478,7 +492,14 @@ set_io   $auto_561                        HR_2_2_1P      -mode MODE_RATE_4_A_TX 
 # Location: HR_2_2_1P
 # Port: RST
 # Signal: in:f2g_trx_reset_n_{A|B}
-set_io   $auto_563                        HR_2_2_1P      -mode MODE_RATE_4_A_TX -internal_pin f2g_trx_reset_n_A
+set_io   $auto_532                        HR_2_2_1P      -mode MODE_RATE_8_A_TX -internal_pin f2g_trx_reset_n_A
+
+# Module: O_BUFT
+# LinkedObject: dout_serdes_clk_out
+# Location: HR_2_7_3N
+# Port: T
+# Signal: in:f2g_tx_oe_{A|B}
+set_io   $auto_519                        HR_2_7_3N      -mode MODE_BP_DIR_B_TX -internal_pin f2g_tx_oe_B
 
 # Module: PLL
 # LinkedObject: BOOT_CLOCK#0
@@ -499,82 +520,114 @@ set_io   $auto_563                        HR_2_2_1P      -mode MODE_RATE_4_A_TX 
 # Location: HP_1_4_2P
 # Port: EN
 # Signal: in:f2g_in_en_{A|B}
-set_io   $auto_549                        HP_1_4_2P      -mode MODE_BP_DDR_A_RX -internal_pin f2g_in_en_A
+set_io   $auto_520                        HP_1_4_2P      -mode MODE_BP_DDR_A_RX -internal_pin f2g_in_en_A
 
 # Module: I_DDR
 # LinkedObject: din_n+din_p
-# Location: HP_1_5_2N
+# Location: HP_1_4_2P
 # Port: E
 # Signal: in:TO_BE_DETERMINED
 # Skip reason: TO_BE_DETERMINED
-# set_io $ofab_$ibuf_enable_4             HP_1_5_2N      -mode MODE_BP_DDR_B_RX -internal_pin TO_BE_DETERMINED
+# set_io $ofab_$ibuf_enable_4             HP_1_4_2P      -mode MODE_BP_DDR_A_RX -internal_pin TO_BE_DETERMINED
 
 # Module: I_DDR
 # LinkedObject: din_n+din_p
-# Location: HP_1_5_2N
+# Location: HP_1_4_2P
 # Port: R
 # Signal: in:TO_BE_DETERMINED
 # Skip reason: TO_BE_DETERMINED
-# set_io $f2g_trx_reset_n_A_$ibuf_reset_4 HP_1_5_2N      -mode MODE_BP_DDR_B_RX -internal_pin TO_BE_DETERMINED
+# set_io $f2g_trx_reset_n_A_$ibuf_reset_4 HP_1_4_2P      -mode MODE_BP_DDR_A_RX -internal_pin TO_BE_DETERMINED
 
 # Module: O_DDR
 # LinkedObject: dout_n+dout_p
-# Location: HP_1_9_4N
+# Location: HP_1_8_4P
 # Port: E
 # Signal: in:TO_BE_DETERMINED
 # Skip reason: TO_BE_DETERMINED
-# set_io $ofab_$ibuf_enable               HP_1_9_4N      -mode MODE_BP_DDR_B_TX -internal_pin TO_BE_DETERMINED
+# set_io $ofab_$ibuf_enable               HP_1_8_4P      -mode MODE_BP_DDR_A_TX -internal_pin TO_BE_DETERMINED
 
 # Module: O_DDR
 # LinkedObject: dout_n+dout_p
-# Location: HP_1_9_4N
+# Location: HP_1_8_4P
 # Port: R
 # Signal: in:TO_BE_DETERMINED
 # Skip reason: TO_BE_DETERMINED
-# set_io $f2g_trx_reset_n_A_$ibuf_reset   HP_1_9_4N      -mode MODE_BP_DDR_B_TX -internal_pin TO_BE_DETERMINED
+# set_io $f2g_trx_reset_n_A_$ibuf_reset   HP_1_8_4P      -mode MODE_BP_DDR_A_TX -internal_pin TO_BE_DETERMINED
 
 # Module: O_DDR
 # LinkedObject: dout_osc_n+dout_osc_p
-# Location: HP_2_23_11N
+# Location: HP_2_22_11P
 # Port: E
 # Signal: in:TO_BE_DETERMINED
 # Skip reason: TO_BE_DETERMINED
-# set_io $ofab_$ibuf_enable_2             HP_2_23_11N    -mode MODE_BP_DDR_B_TX -internal_pin TO_BE_DETERMINED
+# set_io $ofab_$ibuf_enable_2             HP_2_22_11P    -mode MODE_BP_DDR_A_TX -internal_pin TO_BE_DETERMINED
 
 # Module: O_DDR
 # LinkedObject: dout_osc_n+dout_osc_p
-# Location: HP_2_23_11N
+# Location: HP_2_22_11P
 # Port: R
 # Signal: in:TO_BE_DETERMINED
 # Skip reason: TO_BE_DETERMINED
-# set_io $f2g_trx_reset_n_A_$ibuf_reset_2 HP_2_23_11N    -mode MODE_BP_DDR_B_TX -internal_pin TO_BE_DETERMINED
+# set_io $f2g_trx_reset_n_A_$ibuf_reset_2 HP_2_22_11P    -mode MODE_BP_DDR_A_TX -internal_pin TO_BE_DETERMINED
 
 #############
 #
 # Each gearbox core clock
 #
 #############
-# Module: I_SERDES
+# Clock module: CLK_BUF
+# Clock module name: $clkbuf$top.$ibuf_clk0
+# Clock port: O
+# Clock port net: $clk_buf_$ibuf_clk0
+# Primitive module: $ibuf$top.$ibuf_din
+# Location: HP_1_20_10P
+set_core_clk HP_1_20_10P 0
+
+# Clock module: CLK_BUF
+# Clock module name: clk_buf
+# Clock port: O
+# Clock port net: clk1_buf
+# Primitive module: $obuf$top.$obuf_dout
+# Location: HP_2_20_10P
+set_core_clk HP_2_20_10P 1
+
+# Clock module: PLL
+# Clock module name: pll
+# Clock port: CLK_OUT
+# Clock port net: pll_clk
+# Primitive module: $ibuf$top.$ibuf_din_serdes
 # Location: HR_2_0_0P
-# Port: CLK_IN
-# Net: 1'1
-# Fail reason: Cannot locate the fabric clock
+set_core_clk HR_2_0_0P   2
 
-# Module: O_SERDES
+# Clock module: PLL
+# Clock module name: pll
+# Clock port: CLK_OUT
+# Clock port net: pll_clk
+# Primitive module: $obuf$top.$obuf_dout_serdes
 # Location: HR_2_2_1P
-# Port: CLK_IN
-# Net: 1'1
-# Fail reason: Cannot locate the fabric clock
+set_core_clk HR_2_2_1P   2
 
-# Module: O_DDR
-# Location: HP_1_9_4N
-# Port: C
-# Net: pll_clk
-set_core_clk HP_1_9_4N   1
+# Clock module: PLL
+# Clock module name: pll
+# Clock port: CLK_OUT
+# Clock port net: pll_clk
+# Primitive module: i_buf_ds
+# Location: HP_1_4_2P
+set_core_clk HP_1_4_2P   3
 
-# Module: O_DDR
-# Location: HP_2_23_11N
-# Port: C
-# Net: osc_pll
-set_core_clk HP_2_23_11N 3
+# Clock module: PLL
+# Clock module name: pll
+# Clock port: CLK_OUT
+# Clock port net: pll_clk
+# Primitive module: o_buf_ds
+# Location: HP_1_8_4P
+set_core_clk HP_1_8_4P   3
+
+# Clock module: PLL
+# Clock module name: pll_osc
+# Clock port: CLK_OUT
+# Clock port net: osc_pll
+# Primitive module: o_buf_ds_osc
+# Location: HP_2_22_11P
+set_core_clk HP_2_22_11P 4
 

--- a/tests/unittest/ModelConfig/golden/bitstream_setting.xml
+++ b/tests/unittest/ModelConfig/golden/bitstream_setting.xml
@@ -1,11 +1,24 @@
 <!-- Original XML: Unit Test Input -->
 <openfpga_bitstream_setting>
   <overwrite_bitstream>
-    <!-- Location: HP_1_9_4N, Value: 1, X: 7, Y: 1 -->
+    <!-- Location: HP_1_20_10P, Value: 0, X: 13, Y: 1 -->
+    <bit value="0" path="fpga_top.grid_io_bottom_13__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[0]"/>
+    <bit value="0" path="fpga_top.grid_io_bottom_13__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[1]"/>
+    <bit value="0" path="fpga_top.grid_io_bottom_13__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[2]"/>
+    <bit value="0" path="fpga_top.grid_io_bottom_13__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[3]"/>
+    <!-- Location: HP_1_4_2P, Value: 3, X: 5, Y: 1 -->
+    <bit value="1" path="fpga_top.grid_io_bottom_5__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[0]"/>
+    <bit value="1" path="fpga_top.grid_io_bottom_5__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[1]"/>
+    <bit value="0" path="fpga_top.grid_io_bottom_5__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[2]"/>
+    <bit value="0" path="fpga_top.grid_io_bottom_5__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[3]"/>
+    <!-- Location: HP_1_8_4P, Value: 3, X: 7, Y: 1 -->
     <bit value="1" path="fpga_top.grid_io_bottom_7__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[0]"/>
-    <bit value="0" path="fpga_top.grid_io_bottom_7__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[1]"/>
+    <bit value="1" path="fpga_top.grid_io_bottom_7__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[1]"/>
     <bit value="0" path="fpga_top.grid_io_bottom_7__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[2]"/>
     <bit value="0" path="fpga_top.grid_io_bottom_7__1_.logical_tile_io_mode_io__0.mem_iopad_0_clk_0[3]"/>
-    <!-- Unknown location: HP_2_23_11N, Value: 3, X: 0, Y: 0 -->
+    <!-- Unknown location: HP_2_20_10P, Value: 1, X: 0, Y: 0 -->
+    <!-- Unknown location: HP_2_22_11P, Value: 4, X: 0, Y: 0 -->
+    <!-- Unknown location: HR_2_0_0P, Value: 2, X: 0, Y: 0 -->
+    <!-- Unknown location: HR_2_2_1P, Value: 2, X: 0, Y: 0 -->
   </overwrite_bitstream>
 </openfpga_bitstream_setting>

--- a/tests/unittest/ModelConfig/golden/config.py
+++ b/tests/unittest/ModelConfig/golden/config.py
@@ -5,6 +5,10 @@ def get_pin_info(name) :
   index = 0
   pair_index = 0
   ab_io = 0
+  ab_name = ''
+  root_bank_mux_location = ''
+  root_bank_mux_core_input_index = 0
+  root_mux_input_index = 0
   if name.find('BOOT_CLOCK#') == 0:
     type = 'BOOT_CLOCK'
     index = int(name[11:])
@@ -18,7 +22,13 @@ def get_pin_info(name) :
     index = int(m.group(4))
     pair_index = int(m.group(5))
     ab_io = 0 if (pair_index < 10) else 1
-  return [type, bank, is_clock, index, pair_index, ab_io]
+    ab_name = '%c' % (ord('A') + ab_io)
+    root_name = 'u_GBOX_HP_40X2' if type == 'HP' else ('u_GBOX_HV_40X2_VL' if type == 'HVL' else 'u_GBOX_HV_40X2_VR')
+    root_bank_mux_location = '%s.u_gbox_root_bank_clkmux_%d' % (root_name, bank)
+    root_bank_mux_core_input_index = index - (20 * ab_io)
+    root_mux_input_index = 0 if type == 'HP' else (8 if type == 'HVL' else 16)
+    root_mux_input_index += ((2 * bank) + ab_io)
+  return [type, bank, is_clock, index, pair_index, ab_io, ab_name, root_bank_mux_location, root_bank_mux_core_input_index, root_mux_input_index]
 def fclk_use_pll_resource(fclk) :
   pll_resource = 0
   if fclk.find('hvl_fclk_') == 0 :

--- a/tests/unittest/ModelConfig/golden/model_config.negative.ppdb.json
+++ b/tests/unittest/ModelConfig/golden/model_config.negative.ppdb.json
@@ -9,14 +9,19 @@
     "Validation using '__primary_validation__' rule",
     "Internal error validations",
     "Assign instance-without-location",
-    "  Object: BOOT_CLOCK#0",
-    "    Assign location for child from instance-without-location",
+    "  Instance: boot_clock",
+    "    Object: BOOT_CLOCK#0",
+    "      Assign location for child from instance-without-location",
     "Allocate FCLK routing resource",
     "  CLKBUF clk_buf00 (location:HP_1_CC_18_9P)",
     "    Route to gearbox module i_ddr00 (location:HP_1_20_10P)",
     "      Use FCLK: hp_fclk_0_B",
+    "    Route to gearbox module o_ddr00 (location:HP_1_22_11P)",
+    "      Use FCLK: hp_fclk_0_B",
     "  PLL pll00 Port CLK_OUT (location:HP_1_CC_18_9P)",
     "    Route to gearbox module i_ddr01 (location:HR_1_20_10P)",
+    "      Use FCLK: hvl_fclk_0_B",
+    "    Route to gearbox module o_ddr01 (location:HR_1_22_11P)",
     "      Use FCLK: hvl_fclk_0_B",
     "  CLKBUF clk_buf10 (location:HR_1_CC_18_9P)",
     "    Route to gearbox module i_ddr10 (location:)",
@@ -25,6 +30,12 @@
     "      Warning: Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module i_ddr11 clock (module:I_DDR) (location:HR_5_2_1P). Reason: They are not in same physical bank",
     "    Route to gearbox module i_ddr12 (location:HR_1_24_12P)",
     "      Warning: Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module i_ddr12 clock (module:I_DDR) (location:HR_1_24_12P). Reason: Attemp to use FCLK: hvl_fclk_0_B, but it had been used by PLL:HP_1_CC_18_9P",
+    "    Route to gearbox module o_ddr10 (location:)",
+    "      Warning: Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module o_ddr10 clock. Reason: Module usage is invalid in the first place",
+    "    Route to gearbox module o_ddr11 (location:HR_5_4_2P)",
+    "      Warning: Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module o_ddr11 clock (module:O_DDR) (location:HR_5_4_2P). Reason: They are not in same physical bank",
+    "    Route to gearbox module o_ddr12 (location:HR_1_26_13P)",
+    "      Warning: Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module o_ddr12 clock (module:O_DDR) (location:HR_1_26_13P). Reason: Attemp to use FCLK: hvl_fclk_0_B, but it had been used by PLL:HP_1_CC_18_9P",
     "  CLKBUF $clkbuf$top.$ibuf_clk20 (location:HP_1_CC_38_19P)",
     "  PLL pllosc0 Port CLK_OUT (location:BOOT_CLOCK#0)",
     "    Route to gearbox module i_ddr_osc0 (location:HR_2_20_10P)",
@@ -40,20 +51,37 @@
     "      Warning: Not able to route clock-capable pin pllosc2 (location:BOOT_CLOCK#0) to gearbox module i_ddr_osc4 clock (module:I_DDR) (location:HR_1_30_15P). Reason: Attemp to use FCLK: hvl_fclk_0_B, but it had been used by PLL:HP_1_CC_18_9P",
     "  CLKBUF clk_buf30 (location:HR_1_CC_38_19P)",
     "  PLL pll30 Port CLK_OUT (location:HR_1_CC_38_19P)",
-    "    Route to gearbox module i_ddr30 (location:HR_2_1_0N)",
+    "    Route to gearbox module i_ddr30 (location:HR_2_0_0P)",
     "      Use FCLK: hvl_fclk_1_A",
     "  CLKBUF clk_buf31 (location:HR_3_CC_38_19P)",
     "  PLL pll31 Port CLK_OUT (location:HR_3_CC_38_19P)",
-    "    Route to gearbox module i_ddr31 (location:HR_2_3_1N)",
-    "      Warning: Not able to route PLL pll31 Port CLK_OUT (location:HR_3_CC_38_19P) to gearbox module i_ddr31 clock (module:I_DDR) (location:HR_2_3_1N). Reason: PLL #1 (needed by HVR) cannot route to HVL",
+    "    Route to gearbox module i_ddr31 (location:HR_2_2_1P)",
+    "      Warning: Not able to route PLL pll31 Port CLK_OUT (location:HR_3_CC_38_19P) to gearbox module i_ddr31 clock (module:I_DDR) (location:HR_2_2_1P). Reason: PLL #1 (needed by HVR) cannot route to HVL",
+    "    Route to gearbox module o_ddr3x (location:)",
+    "      Warning: Not able to route PLL pll31 Port CLK_OUT (location:HR_3_CC_38_19P) to gearbox module o_ddr3x clock. Reason: Module usage is invalid in the first place",
     "  CLKBUF clk_buf40 (location:HR_2_CC_38_19P)",
     "    Route to gearbox module o_serdes_clk (location:HR_2_8_4P)",
     "      Warning: Not able to route clock-capable pin clk_buf40 (location:HR_2_CC_38_19P) to gearbox module o_serdes_clk clock (module:O_SERDES_CLK) (location:HR_2_8_4P). Reason: Attemp to use FCLK: hvl_fclk_1_A, but it had been used by PLL:HR_1_CC_38_19P",
+    "Allocate ROOT BANK CLKMUX resource",
+    "  CLKBUF clk_buf00 (location: HP_1_CC_18_9P) try to route clock to clock tree slot #0",
+    "    Used by gearbox module i_ddr00 (location: HP_1_20_10P)",
+    "      Resource: u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0",
+    "  CLKBUF clk_buf00 (location: HP_1_CC_18_9P) try to route clock to clock tree slot #0",
+    "    Used by gearbox module o_ddr00 (location: HP_1_22_11P)",
+    "  PLL pll00 try to route clock to clock tree slot #1",
+    "    Used by gearbox module i_ddr01 (location: HR_1_20_10P)",
+    "      Resource: u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_0",
+    "  PLL pll00 try to route clock to clock tree slot #1",
+    "    Used by gearbox module o_ddr01 (location: HR_1_22_11P)",
+    "  CLKBUF $clkbuf$top.$ibuf_clk20 (location: HP_1_CC_38_19P) try to route clock to clock tree slot #10",
+    "    Used by fabric logic only",
+    "      Warning: Fail to route the clock. Reason: u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0 is already used by module i_ddr00 (location: HP_1_20_10P)",
+    "  PLL pll30 try to route clock to clock tree slot #5",
+    "    Used by gearbox module i_ddr30 (location: HR_2_0_0P)",
+    "      Resource: u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_1",
     "Set CLKBUF configuration attributes",
     "  Set FCLK configuration attributes",
     "    CLKBUF clk_buf00 (location:HP_1_CC_18_9P) use hp_fclk_0_B",
-    "  Set FCLK configuration attributes",
-    "    Skip for HP_1_CC_38_19P",
     "Allocate PLL resource (and set PLLREF configuration attributes)",
     "  PLL pll00 (location:HP_1_CC_18_9P) uses FCLK 'hvl_fclk_0_B'",
     "    Pin resource: 3, PLL FCLK requested resource: 1, PLL availability: 3",
@@ -88,14 +116,13 @@
     "  Module: PLL (pll00)",
     "    Object: clk00",
     "      Parameter",
+    "        Rule PLL.MUX0",
+    "          Match",
     "        Rule PLL.PLL",
     "          Match",
     "            Defined function: parse_pll_parameter",
     "        Rule PLL.PLLREF_MUX",
     "          Match",
-    "        Rule PLL.ROOT_MUX0",
-    "          Match",
-    "            Defined function: parse_pll_root_mux",
     "        Rule PLL.ROOT_MUX1",
     "          Match",
     "            Defined function: parse_pll_root_mux",
@@ -122,16 +149,6 @@
     "      Property",
     "        Rule I_BUF.IOSTANDARD",
     "          Mismatch",
-    "  Module: CLK_BUF ($clkbuf$top.$ibuf_clk20)",
-    "    Object: clk20",
-    "      Parameter",
-    "      Property",
-    "        Rule CLK_BUF.GBOX_TOP",
-    "          Match",
-    "        Rule CLK_BUF.ROOT_BANK_CLKMUX",
-    "          Match",
-    "        Rule CLK_BUF.ROOT_MUX",
-    "          Match",
     "  Module: I_BUF ($ibuf$top.$ibuf_din00)",
     "    Object: din00",
     "      Parameter",
@@ -252,6 +269,21 @@
     "          Mismatch",
     "  Module: O_SERDES_CLK (o_serdes_clk)",
     "    Object: clk_out",
+    "      Parameter",
+    "        Rule O_SERDES_CLK.CLK_PHASE",
+    "          Match",
+    "            Defined function: parse_o_serdes_clk_phase_parameter",
+    "        Rule O_SERDES_CLK.DDR_MODE",
+    "          Match",
+    "      Property",
+    "  Module: O_BUFT ($obuf$top.$obuf_clk_out_osc)",
+    "    Object: clk_out_osc",
+    "      Parameter",
+    "      Property",
+    "        Rule O_BUFT.IOSTANDARD",
+    "          Mismatch",
+    "  Module: O_SERDES_CLK (o_serdes_clk_osc)",
+    "    Object: clk_out_osc",
     "      Parameter",
     "        Rule O_SERDES_CLK.CLK_PHASE",
     "          Match",
@@ -421,6 +453,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk00",
+      "location_object" : "clk00",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk00",
       "linked_objects" : {
         "clk00" : {
@@ -460,12 +494,14 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf00",
+      "location_object" : "clk00",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk00",
       "linked_objects" : {
         "clk00" : {
           "location" : "HP_1_CC_18_9P",
           "properties" : {
-            "ROUTE_TO_FABRIC_CLK" : "0"
+            "ROUTE_TO_FABRIC_CLK" : "i_ddr00=0;o_ddr00=0"
           },
           "config_attributes" : [
             {
@@ -484,11 +520,13 @@
               "CLK_BUF" : "GBOX_TOP_SRC==DEFAULT"
             },
             {
-              "CLK_BUF" : "ROOT_BANK_SRC==A --#MUX=18",
-              "__location__" : "__{[0]}__.u_gbox_root_bank_clkmux_0"
+              "CLK_BUF" : "ROOT_BANK_SRC==B --#MUX=0",
+              "__comment__" : "Used by gearbox module i_ddr00 (location: HP_1_20_10P)",
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0"
             },
             {
-              "ROOT_MUX_SEL" : "0",
+              "ROOT_MUX_SEL" : "1",
+              "__comment__" : "From u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0",
               "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_0"
             }
           ]
@@ -499,7 +537,7 @@
         "O" : "clkbuf00"
       },
       "parameters" : {
-        "ROUTE_TO_FABRIC_CLK" : "0"
+        "ROUTE_TO_FABRIC_CLK" : "i_ddr00=0;o_ddr00=0"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -507,35 +545,35 @@
       ],
       "route_clock_to" : {
         "O" : [
-          "i_ddr00"
+          "i_ddr00",
+          "o_ddr00"
         ]
       },
       "route_clock_result" : {
         "O" : [
+          "Use FCLK: hp_fclk_0_B",
           "Use FCLK: hp_fclk_0_B"
         ]
       },
       "errors" : [
       ],
-      "__AB__" : "A",
-      "__ROOT_BANK_MUX__" : "18",
-      "__ROOT_MUX__" : "0",
-      "__bank__" : "0",
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__clock_pin_is_valid__,__check_fabric_clock_resource__,__update_fabric_clock_resource__"
     },
     {
       "module" : "PLL",
       "name" : "pll00",
+      "location_object" : "clk00",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk00",
       "linked_objects" : {
         "clk00" : {
           "location" : "HP_1_CC_18_9P",
           "properties" : {
-            "OUT0_ROUTE_TO_FABRIC_CLK" : "1",
-            "OUT1_ROUTE_TO_FABRIC_CLK" : "2",
-            "OUT2_ROUTE_TO_FABRIC_CLK" : "3",
-            "OUT3_ROUTE_TO_FABRIC_CLK" : "4"
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr01=1;o_ddr01=1",
+            "OUT1_ROUTE_TO_FABRIC_CLK" : "7",
+            "OUT2_ROUTE_TO_FABRIC_CLK" : "8",
+            "OUT3_ROUTE_TO_FABRIC_CLK" : "9"
           },
           "config_attributes" : [
             {
@@ -551,6 +589,16 @@
               "cfg_vco_clk_sel_B_0" : "1"
             },
             {
+              "PLL" : "ROOT_BANK_SRC==B --#MUX=0",
+              "__comment__" : "Used by gearbox module i_ddr01 (location: HR_1_20_10P)",
+              "__location__" : "u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_0"
+            },
+            {
+              "ROOT_MUX_SEL" : "9",
+              "__comment__" : "Used by gearbox module i_ddr01 (location: HR_1_20_10P). From u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_0",
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_1"
+            },
+            {
               "PLL" : "PLL_SRC==DEFAULT",
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_0",
               "pll_FBDIV" : "16",
@@ -564,20 +612,16 @@
               "__location__" : "u_GBOX_HP_40X2.u_gbox_pll_refmux_0"
             },
             {
-              "ROOT_MUX_SEL" : "32",
-              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_1"
-            },
-            {
               "ROOT_MUX_SEL" : "33",
-              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_2"
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_7"
             },
             {
               "ROOT_MUX_SEL" : "34",
-              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_3"
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_8"
             },
             {
               "ROOT_MUX_SEL" : "35",
-              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_4"
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_9"
             }
           ]
         }
@@ -592,10 +636,10 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
-        "OUT0_ROUTE_TO_FABRIC_CLK" : "1",
-        "OUT1_ROUTE_TO_FABRIC_CLK" : "2",
-        "OUT2_ROUTE_TO_FABRIC_CLK" : "3",
-        "OUT3_ROUTE_TO_FABRIC_CLK" : "4",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr01=1;o_ddr01=1",
+        "OUT1_ROUTE_TO_FABRIC_CLK" : "7",
+        "OUT2_ROUTE_TO_FABRIC_CLK" : "8",
+        "OUT3_ROUTE_TO_FABRIC_CLK" : "9",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -606,11 +650,13 @@
       ],
       "route_clock_to" : {
         "CLK_OUT" : [
-          "i_ddr01"
+          "i_ddr01",
+          "o_ddr01"
         ]
       },
       "route_clock_result" : {
         "CLK_OUT" : [
+          "Use FCLK: hvl_fclk_0_B",
           "Use FCLK: hvl_fclk_0_B"
         ]
       },
@@ -628,6 +674,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk10",
+      "location_object" : "clk10",
+      "location" : "HR_1_CC_18_9P",
       "linked_object" : "clk10",
       "linked_objects" : {
         "clk10" : {
@@ -667,12 +715,14 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf10",
+      "location_object" : "clk10",
+      "location" : "HR_1_CC_18_9P",
       "linked_object" : "clk10",
       "linked_objects" : {
         "clk10" : {
           "location" : "HR_1_CC_18_9P",
           "properties" : {
-            "ROUTE_TO_FABRIC_CLK" : "5"
+            "ROUTE_TO_FABRIC_CLK" : "i_ddr10=2;i_ddr11=2;i_ddr12=2;o_ddr10=2;o_ddr11=2;o_ddr12=2"
           },
           "config_attributes" : [
           ]
@@ -683,7 +733,7 @@
         "O" : "clkbuf10"
       },
       "parameters" : {
-        "ROUTE_TO_FABRIC_CLK" : "5"
+        "ROUTE_TO_FABRIC_CLK" : "i_ddr10=2;i_ddr11=2;i_ddr12=2;o_ddr10=2;o_ddr11=2;o_ddr12=2"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -692,14 +742,20 @@
         "O" : [
           "i_ddr10",
           "i_ddr11",
-          "i_ddr12"
+          "i_ddr12",
+          "o_ddr10",
+          "o_ddr11",
+          "o_ddr12"
         ]
       },
       "route_clock_result" : {
         "O" : [
           "Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module i_ddr10 clock. Reason: Module usage is invalid in the first place",
           "Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module i_ddr11 clock (module:I_DDR) (location:HR_5_2_1P). Reason: They are not in same physical bank",
-          "Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module i_ddr12 clock (module:I_DDR) (location:HR_1_24_12P). Reason: Attemp to use FCLK: hvl_fclk_0_B, but it had been used by PLL:HP_1_CC_18_9P"
+          "Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module i_ddr12 clock (module:I_DDR) (location:HR_1_24_12P). Reason: Attemp to use FCLK: hvl_fclk_0_B, but it had been used by PLL:HP_1_CC_18_9P",
+          "Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module o_ddr10 clock. Reason: Module usage is invalid in the first place",
+          "Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module o_ddr11 clock (module:O_DDR) (location:HR_5_4_2P). Reason: They are not in same physical bank",
+          "Not able to route clock-capable pin clk_buf10 (location:HR_1_CC_18_9P) to gearbox module o_ddr12 clock (module:O_DDR) (location:HR_1_26_13P). Reason: Attemp to use FCLK: hvl_fclk_0_B, but it had been used by PLL:HP_1_CC_18_9P"
         ]
       },
       "errors" : [
@@ -710,6 +766,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk20",
+      "location_object" : "clk20",
+      "location" : "HP_1_CC_38_19P",
       "linked_object" : "clk20",
       "linked_objects" : {
         "clk20" : {
@@ -749,25 +807,16 @@
     {
       "module" : "CLK_BUF",
       "name" : "$clkbuf$top.$ibuf_clk20",
+      "location_object" : "clk20",
+      "location" : "HP_1_CC_38_19P",
       "linked_object" : "clk20",
       "linked_objects" : {
         "clk20" : {
           "location" : "HP_1_CC_38_19P",
           "properties" : {
-            "ROUTE_TO_FABRIC_CLK" : "6"
+            "ROUTE_TO_FABRIC_CLK" : "10"
           },
           "config_attributes" : [
-            {
-              "CLK_BUF" : "GBOX_TOP_SRC==DEFAULT"
-            },
-            {
-              "CLK_BUF" : "ROOT_BANK_SRC==B --#MUX=18",
-              "__location__" : "__{[0]}__.u_gbox_root_bank_clkmux_0"
-            },
-            {
-              "ROOT_MUX_SEL" : "1",
-              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_6"
-            }
           ]
         }
       },
@@ -776,7 +825,7 @@
         "O" : "$clk_buf_$ibuf_clk20"
       },
       "parameters" : {
-        "ROUTE_TO_FABRIC_CLK" : "6"
+        "ROUTE_TO_FABRIC_CLK" : "10"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -787,16 +836,14 @@
       },
       "errors" : [
       ],
-      "__AB__" : "B",
-      "__ROOT_BANK_MUX__" : "18",
-      "__ROOT_MUX__" : "1",
-      "__bank__" : "0",
-      "__validation__" : "TRUE",
-      "__validation_msg__" : "Pass:__clock_pin_is_valid__,__check_fabric_clock_resource__,__update_fabric_clock_resource__"
+      "__validation__" : "FALSE",
+      "__validation_msg__" : "Fail to route the clock. Reason: u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0 is already used by module i_ddr00 (location: HP_1_20_10P)"
     },
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din00",
+      "location_object" : "din00",
+      "location" : "HP_1_20_10P",
       "linked_object" : "din00",
       "linked_objects" : {
         "din00" : {
@@ -836,6 +883,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr00",
+      "location_object" : "din00",
+      "location" : "HP_1_20_10P",
       "linked_object" : "din00",
       "linked_objects" : {
         "din00" : {
@@ -870,6 +919,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din01",
+      "location_object" : "din01",
+      "location" : "HR_1_20_10P",
       "linked_object" : "din01",
       "linked_objects" : {
         "din01" : {
@@ -909,6 +960,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr01",
+      "location_object" : "din01",
+      "location" : "HR_1_20_10P",
       "linked_object" : "din01",
       "linked_objects" : {
         "din01" : {
@@ -943,6 +996,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din10",
+      "location_object" : "din10",
+      "location" : "",
       "linked_object" : "din10",
       "linked_objects" : {
         "din10" : {
@@ -976,6 +1031,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr10",
+      "location_object" : "din10",
+      "location" : "",
       "linked_object" : "din10",
       "linked_objects" : {
         "din10" : {
@@ -1007,6 +1064,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din11",
+      "location_object" : "din11",
+      "location" : "HR_5_2_1P",
       "linked_object" : "din11",
       "linked_objects" : {
         "din11" : {
@@ -1046,6 +1105,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr11",
+      "location_object" : "din11",
+      "location" : "HR_5_2_1P",
       "linked_object" : "din11",
       "linked_objects" : {
         "din11" : {
@@ -1080,6 +1141,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din12",
+      "location_object" : "din12",
+      "location" : "HR_1_24_12P",
       "linked_object" : "din12",
       "linked_objects" : {
         "din12" : {
@@ -1119,6 +1182,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr12",
+      "location_object" : "din12",
+      "location" : "HR_1_24_12P",
       "linked_object" : "din12",
       "linked_objects" : {
         "din12" : {
@@ -1153,6 +1218,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din20",
+      "location_object" : "din20",
+      "location" : "",
       "linked_object" : "din20",
       "linked_objects" : {
         "din20" : {
@@ -1185,6 +1252,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_dinosc0",
+      "location_object" : "dinosc0",
+      "location" : "HR_2_20_10P",
       "linked_object" : "dinosc0",
       "linked_objects" : {
         "dinosc0" : {
@@ -1224,6 +1293,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr_osc0",
+      "location_object" : "dinosc0",
+      "location" : "HR_2_20_10P",
       "linked_object" : "dinosc0",
       "linked_objects" : {
         "dinosc0" : {
@@ -1258,6 +1329,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_dinosc1",
+      "location_object" : "dinosc1",
+      "location" : "HR_5_20_10P",
       "linked_object" : "dinosc1",
       "linked_objects" : {
         "dinosc1" : {
@@ -1297,6 +1370,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr_osc1",
+      "location_object" : "dinosc1",
+      "location" : "HR_5_20_10P",
       "linked_object" : "dinosc1",
       "linked_objects" : {
         "dinosc1" : {
@@ -1331,6 +1406,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_dinosc2",
+      "location_object" : "dinosc2",
+      "location" : "",
       "linked_object" : "dinosc2",
       "linked_objects" : {
         "dinosc2" : {
@@ -1364,6 +1441,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr_osc2",
+      "location_object" : "dinosc2",
+      "location" : "",
       "linked_object" : "dinosc2",
       "linked_objects" : {
         "dinosc2" : {
@@ -1395,6 +1474,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_dinosc3",
+      "location_object" : "dinosc3",
+      "location" : "HR_5_22_11P",
       "linked_object" : "dinosc3",
       "linked_objects" : {
         "dinosc3" : {
@@ -1434,6 +1515,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr_osc3",
+      "location_object" : "dinosc3",
+      "location" : "HR_5_22_11P",
       "linked_object" : "dinosc3",
       "linked_objects" : {
         "dinosc3" : {
@@ -1468,6 +1551,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_dinosc4",
+      "location_object" : "dinosc4",
+      "location" : "HR_1_30_15P",
       "linked_object" : "dinosc4",
       "linked_objects" : {
         "dinosc4" : {
@@ -1507,6 +1592,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr_osc4",
+      "location_object" : "dinosc4",
+      "location" : "HR_1_30_15P",
       "linked_object" : "dinosc4",
       "linked_objects" : {
         "dinosc4" : {
@@ -1541,6 +1628,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_clk_out",
+      "location_object" : "clk_out",
+      "location" : "HR_2_8_4P",
       "linked_object" : "clk_out",
       "linked_objects" : {
         "clk_out" : {
@@ -1576,6 +1665,8 @@
     {
       "module" : "O_SERDES_CLK",
       "name" : "o_serdes_clk",
+      "location_object" : "clk_out",
+      "location" : "HR_2_8_4P",
       "linked_object" : "clk_out",
       "linked_objects" : {
         "clk_out" : {
@@ -1615,6 +1706,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_clk_out_osc",
+      "location_object" : "clk_out_osc",
+      "location" : "HR_2_9_4N",
       "linked_object" : "clk_out_osc",
       "linked_objects" : {
         "clk_out_osc" : {
@@ -1622,6 +1715,9 @@
           "properties" : {
           },
           "config_attributes" : [
+            {
+              "O_BUFT" : "IOSTANDARD==DEFAULT"
+            }
           ]
         }
       },
@@ -1641,12 +1737,14 @@
       },
       "errors" : [
       ],
-      "__validation__" : "FALSE",
-      "__validation_msg__" : "Invalidated because other instance in the chain is invalid"
+      "__validation__" : "TRUE",
+      "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
     },
     {
       "module" : "O_SERDES_CLK",
       "name" : "o_serdes_clk_osc",
+      "location_object" : "clk_out_osc",
+      "location" : "HR_2_9_4N",
       "linked_object" : "clk_out_osc",
       "linked_objects" : {
         "clk_out_osc" : {
@@ -1654,6 +1752,12 @@
           "properties" : {
           },
           "config_attributes" : [
+            {
+              "TX_CLK_PHASE" : "TX_phase_180"
+            },
+            {
+              "O_SERDES_CLK" : "DDR_MODE==DDR"
+            }
           ]
         }
       },
@@ -1673,14 +1777,15 @@
       "route_clock_result" : {
       },
       "errors" : [
-        "Not able to route signal \\osc to port \\PLL_CLK"
       ],
-      "__validation__" : "FALSE",
-      "__validation_msg__" : "Fail:internal_error"
+      "__validation__" : "TRUE",
+      "__validation_msg__" : "Pass:__check_data_rate_parameter__,__check_clock_phase_parameter__"
     },
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dinoutosc",
+      "location_object" : "dinoutosc",
+      "location" : "HR_2_22_11P",
       "linked_object" : "dinoutosc",
       "linked_objects" : {
         "dinoutosc" : {
@@ -1715,6 +1820,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout00",
+      "location_object" : "dout00",
+      "location" : "HP_1_22_11P",
       "linked_object" : "dout00",
       "linked_objects" : {
         "dout00" : {
@@ -1750,6 +1857,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr00",
+      "location_object" : "dout00",
+      "location" : "HP_1_22_11P",
       "linked_object" : "dout00",
       "linked_objects" : {
         "dout00" : {
@@ -1784,6 +1893,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout01",
+      "location_object" : "dout01",
+      "location" : "HR_1_22_11P",
       "linked_object" : "dout01",
       "linked_objects" : {
         "dout01" : {
@@ -1819,6 +1930,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr01",
+      "location_object" : "dout01",
+      "location" : "HR_1_22_11P",
       "linked_object" : "dout01",
       "linked_objects" : {
         "dout01" : {
@@ -1853,6 +1966,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout10",
+      "location_object" : "dout10",
+      "location" : "",
       "linked_object" : "dout10",
       "linked_objects" : {
         "dout10" : {
@@ -1885,6 +2000,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr10",
+      "location_object" : "dout10",
+      "location" : "",
       "linked_object" : "dout10",
       "linked_objects" : {
         "dout10" : {
@@ -1916,6 +2033,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout11",
+      "location_object" : "dout11",
+      "location" : "HR_5_4_2P",
       "linked_object" : "dout11",
       "linked_objects" : {
         "dout11" : {
@@ -1951,6 +2070,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr11",
+      "location_object" : "dout11",
+      "location" : "HR_5_4_2P",
       "linked_object" : "dout11",
       "linked_objects" : {
         "dout11" : {
@@ -1985,6 +2106,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout12",
+      "location_object" : "dout12",
+      "location" : "HR_1_26_13P",
       "linked_object" : "dout12",
       "linked_objects" : {
         "dout12" : {
@@ -2020,6 +2143,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr12",
+      "location_object" : "dout12",
+      "location" : "HR_1_26_13P",
       "linked_object" : "dout12",
       "linked_objects" : {
         "dout12" : {
@@ -2054,6 +2179,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout20",
+      "location_object" : "dout20",
+      "location" : "",
       "linked_object" : "dout20",
       "linked_objects" : {
         "dout20" : {
@@ -2085,6 +2212,8 @@
     {
       "module" : "BOOT_CLOCK",
       "name" : "boot_clock",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "__SKIP_LOCATION_CHECK__:BOOT_CLOCK#0",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
@@ -2119,11 +2248,14 @@
     {
       "module" : "PLL",
       "name" : "pllosc0",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "__SKIP_LOCATION_CHECK__:BOOT_CLOCK#0",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
           "location" : "__SKIP_LOCATION_CHECK__:BOOT_CLOCK#0",
           "properties" : {
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr_osc0=3;i_ddr_osc1=3;i_ddr_osc2=3"
           },
           "config_attributes" : [
           ]
@@ -2136,6 +2268,7 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr_osc0=3;i_ddr_osc1=3;i_ddr_osc2=3",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -2166,6 +2299,8 @@
     {
       "module" : "PLL",
       "name" : "pllosc1",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "__SKIP_LOCATION_CHECK__:BOOT_CLOCK#0",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
@@ -2209,11 +2344,14 @@
     {
       "module" : "PLL",
       "name" : "pllosc2",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "__SKIP_LOCATION_CHECK__:BOOT_CLOCK#0",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
           "location" : "__SKIP_LOCATION_CHECK__:BOOT_CLOCK#0",
           "properties" : {
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr_osc4=4"
           },
           "config_attributes" : [
           ]
@@ -2226,6 +2364,7 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr_osc4=4",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -2252,6 +2391,8 @@
     {
       "module" : "I_BUF",
       "name" : "i_buf30",
+      "location_object" : "clk30",
+      "location" : "HR_1_CC_38_19P",
       "linked_object" : "clk30",
       "linked_objects" : {
         "clk30" : {
@@ -2290,6 +2431,8 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf30",
+      "location_object" : "clk30",
+      "location" : "HR_1_CC_38_19P",
       "linked_object" : "clk30",
       "linked_objects" : {
         "clk30" : {
@@ -2325,11 +2468,14 @@
     {
       "module" : "PLL",
       "name" : "pll30",
+      "location_object" : "clk30",
+      "location" : "HR_1_CC_38_19P",
       "linked_object" : "clk30",
       "linked_objects" : {
         "clk30" : {
           "location" : "HR_1_CC_38_19P",
           "properties" : {
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr30=5"
           },
           "config_attributes" : [
           ]
@@ -2342,6 +2488,7 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr30=5",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -2368,6 +2515,8 @@
     {
       "module" : "I_BUF",
       "name" : "i_buf31",
+      "location_object" : "clk31",
+      "location" : "HR_3_CC_38_19P",
       "linked_object" : "clk31",
       "linked_objects" : {
         "clk31" : {
@@ -2406,6 +2555,8 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf31",
+      "location_object" : "clk31",
+      "location" : "HR_3_CC_38_19P",
       "linked_object" : "clk31",
       "linked_objects" : {
         "clk31" : {
@@ -2441,12 +2592,14 @@
     {
       "module" : "PLL",
       "name" : "pll31",
+      "location_object" : "clk31",
+      "location" : "HR_3_CC_38_19P",
       "linked_object" : "clk31",
       "linked_objects" : {
         "clk31" : {
           "location" : "HR_3_CC_38_19P",
           "properties" : {
-            "OUT0_ROUTE_TO_FABRIC_CLK" : "7"
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr31=6;o_ddr3x=6"
           },
           "config_attributes" : [
           ]
@@ -2459,7 +2612,7 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
-        "OUT0_ROUTE_TO_FABRIC_CLK" : "7",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr31=6;o_ddr3x=6",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -2470,12 +2623,14 @@
       ],
       "route_clock_to" : {
         "CLK_OUT" : [
-          "i_ddr31"
+          "i_ddr31",
+          "o_ddr3x"
         ]
       },
       "route_clock_result" : {
         "CLK_OUT" : [
-          "Not able to route PLL pll31 Port CLK_OUT (location:HR_3_CC_38_19P) to gearbox module i_ddr31 clock (module:I_DDR) (location:HR_2_3_1N). Reason: PLL #1 (needed by HVR) cannot route to HVL"
+          "Not able to route PLL pll31 Port CLK_OUT (location:HR_3_CC_38_19P) to gearbox module i_ddr31 clock (module:I_DDR) (location:HR_2_2_1P). Reason: PLL #1 (needed by HVR) cannot route to HVL",
+          "Not able to route PLL pll31 Port CLK_OUT (location:HR_3_CC_38_19P) to gearbox module o_ddr3x clock. Reason: Module usage is invalid in the first place"
         ]
       },
       "errors" : [
@@ -2486,6 +2641,8 @@
     {
       "module" : "I_BUF",
       "name" : "i_buf40",
+      "location_object" : "clk40",
+      "location" : "HR_2_CC_38_19P",
       "linked_object" : "clk40",
       "linked_objects" : {
         "clk40" : {
@@ -2524,6 +2681,8 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf40",
+      "location_object" : "clk40",
+      "location" : "HR_2_CC_38_19P",
       "linked_object" : "clk40",
       "linked_objects" : {
         "clk40" : {
@@ -2561,6 +2720,8 @@
     {
       "module" : "I_BUF_DS",
       "name" : "i_buf_ds30",
+      "location_object" : "din30_p",
+      "location" : "HR_2_0_0P",
       "linked_object" : "din30_n+din30_p",
       "linked_objects" : {
         "din30_n" : {
@@ -2616,6 +2777,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr30",
+      "location_object" : "din30_p",
+      "location" : "HR_2_0_0P",
       "linked_object" : "din30_n+din30_p",
       "linked_objects" : {
         "din30_n" : {
@@ -2660,6 +2823,8 @@
     {
       "module" : "I_BUF_DS",
       "name" : "i_buf_ds31",
+      "location_object" : "din31_p",
+      "location" : "HR_2_2_1P",
       "linked_object" : "din31_n+din31_p",
       "linked_objects" : {
         "din31_n" : {
@@ -2715,6 +2880,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr31",
+      "location_object" : "din31_p",
+      "location" : "HR_2_2_1P",
       "linked_object" : "din31_n+din31_p",
       "linked_objects" : {
         "din31_n" : {
@@ -2759,6 +2926,8 @@
     {
       "module" : "O_BUF_DS",
       "name" : "o_buf_ds",
+      "location_object" : "dout30_p",
+      "location" : "HR_2_4_2P",
       "linked_object" : "dout30_n+dout30_p",
       "linked_objects" : {
         "dout30_n" : {
@@ -2799,6 +2968,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr3x",
+      "location_object" : "dout30_p",
+      "location" : "HR_2_4_2P",
       "linked_object" : "dout30_n+dout30_p",
       "linked_objects" : {
         "dout30_n" : {

--- a/tests/unittest/ModelConfig/golden/model_config.ppdb.json
+++ b/tests/unittest/ModelConfig/golden/model_config.ppdb.json
@@ -17,20 +17,28 @@
     "  Assign Property:IOSTANDARD value:LVCMOS_18_HR to \"o_delay\"",
     "  Assign Property:PACKAGE_PIN value:HR_1_6_3P to \"o_delay\"",
     "Re-location instances",
-    "  Overwrite location value:$ibuf$top.$ibuf_clk0 to \"HR_1_CC_38_19P\" (value existing: HR_1_CC_18_9P)",
-    "  Overwrite location value:$clkbuf$top.$ibuf_clk0 to \"HR_1_CC_38_19P\" (value existing: HR_1_CC_18_9P)",
-    "  Overwrite location value:$ibuf$top.$ibuf_din to \"HR_1_4_2P\" (value existing: HP_1_20_10P)",
-    "  Overwrite location value:i_delay to \"HR_1_4_2P\" (value existing: HP_1_20_10P)",
-    "  Overwrite location value:$obuf$top.$obuf_dout to \"HR_1_6_3P\" (value existing: HP_2_20_10P)",
-    "  Overwrite location value:o_delay to \"HR_1_6_3P\" (value existing: HP_2_20_10P)",
+    "  Overwrite Instance-Object:location value:$ibuf$top.$ibuf_clk0 to \"HR_1_CC_38_19P\" (value existing: HR_1_CC_18_9P)",
+    "  Overwrite Instance:location value:$ibuf$top.$ibuf_clk0 to \"HR_1_CC_38_19P\" (value existing: HR_1_CC_18_9P)",
+    "  Overwrite Instance-Object:location value:$clkbuf$top.$ibuf_clk0 to \"HR_1_CC_38_19P\" (value existing: HR_1_CC_18_9P)",
+    "  Overwrite Instance:location value:$clkbuf$top.$ibuf_clk0 to \"HR_1_CC_38_19P\" (value existing: HR_1_CC_18_9P)",
+    "  Overwrite Instance-Object:location value:$ibuf$top.$ibuf_din to \"HR_1_4_2P\" (value existing: HP_1_20_10P)",
+    "  Overwrite Instance:location value:$ibuf$top.$ibuf_din to \"HR_1_4_2P\" (value existing: HP_1_20_10P)",
+    "  Overwrite Instance-Object:location value:i_delay to \"HR_1_4_2P\" (value existing: HP_1_20_10P)",
+    "  Overwrite Instance:location value:i_delay to \"HR_1_4_2P\" (value existing: HP_1_20_10P)",
+    "  Overwrite Instance-Object:location value:$obuf$top.$obuf_dout to \"HR_1_6_3P\" (value existing: HP_2_20_10P)",
+    "  Overwrite Instance:location value:$obuf$top.$obuf_dout to \"HR_1_6_3P\" (value existing: HP_2_20_10P)",
+    "  Overwrite Instance-Object:location value:o_delay to \"HR_1_6_3P\" (value existing: HP_2_20_10P)",
+    "  Overwrite Instance:location value:o_delay to \"HR_1_6_3P\" (value existing: HP_2_20_10P)",
     "Configure Mapping file initialization",
     "Validation using '__primary_validation__' rule",
     "Internal error validations",
     "Assign instance-without-location",
-    "  Object: BOOT_CLOCK#0",
-    "    Assign location for child from instance-without-location",
-    "  Object: FABRIC_CLKBUF#0",
-    "    Assign location for child from instance-without-location",
+    "  Instance: boot_clock",
+    "    Object: BOOT_CLOCK#0",
+    "      Assign location for child from instance-without-location",
+    "  Instance: $clkbuf$top.clk0_div",
+    "    Object: FABRIC_CLKBUF#0",
+    "      Assign location for child from instance-without-location",
     "Allocate FCLK routing resource",
     "  CLKBUF $clkbuf$top.$ibuf_clk0 (location:HR_1_CC_38_19P)",
     "    Route to gearbox module i_delay (location:HR_1_4_2P)",
@@ -41,13 +49,40 @@
     "  PLL pll Port CLK_OUT (location:HP_1_CC_18_9P)",
     "    Route to gearbox module i_serdes (location:HR_2_0_0P)",
     "      Use FCLK: hvl_fclk_1_A",
-    "    Route to gearbox module i_ddr (location:HP_1_5_2N)",
+    "    Route to gearbox module i_ddr (location:HP_1_4_2P)",
     "      Use FCLK: hp_fclk_0_A",
     "    Route to gearbox module o_serdes (location:HR_2_2_1P)",
     "      Use FCLK: hvl_fclk_1_A",
+    "    Route to gearbox module o_ddr (location:HP_1_8_4P)",
+    "      Use FCLK: hp_fclk_0_A",
     "    Route to gearbox module o_serdes_clk (location:HR_2_4_2P)",
     "      Use FCLK: hvl_fclk_1_A",
     "  CLKBUF $clkbuf$top.$ibuf_clk2 (location:HR_5_CC_38_19P)",
+    "  PLL pll_osc Port CLK_OUT (location:BOOT_CLOCK#0)",
+    "    Route to gearbox module o_ddr_osc (location:HP_2_22_11P)",
+    "      Use FCLK: hp_fclk_1_B",
+    "Allocate ROOT BANK CLKMUX resource",
+    "  CLKBUF $clkbuf$top.$ibuf_clk0 (location: HR_1_CC_38_19P) try to route clock to clock tree slot #0",
+    "    Used by gearbox module i_delay (location: HR_1_4_2P)",
+    "      Resource: u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_0",
+    "  CLKBUF $clkbuf$top.$ibuf_clk0 (location: HR_1_CC_38_19P) try to route clock to clock tree slot #0",
+    "    Used by fabric logic only",
+    "  PLL pll try to route clock to clock tree slot #2",
+    "    Used by gearbox module i_serdes (location: HR_2_0_0P)",
+    "      Resource: u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_1",
+    "  PLL pll try to route clock to clock tree slot #3",
+    "    Used by gearbox module i_ddr (location: HP_1_4_2P)",
+    "      Resource: u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0",
+    "  PLL pll try to route clock to clock tree slot #2",
+    "    Used by gearbox module o_serdes (location: HR_2_2_1P)",
+    "  PLL pll try to route clock to clock tree slot #3",
+    "    Used by gearbox module o_ddr (location: HP_1_8_4P)",
+    "  CLKBUF $clkbuf$top.$ibuf_clk2 (location: HR_5_CC_38_19P) try to route clock to clock tree slot #5",
+    "    Used by fabric logic only",
+    "      Resource: u_GBOX_HV_40X2_VR.u_gbox_root_bank_clkmux_1",
+    "  PLL pll_osc try to route clock to clock tree slot #4",
+    "    Used by gearbox module o_ddr_osc (location: HP_2_22_11P)",
+    "      Resource: u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_1",
     "Set CLKBUF configuration attributes",
     "  Set FCLK configuration attributes",
     "    CLKBUF $clkbuf$top.$ibuf_clk0 (location:HR_1_CC_38_19P) use hvl_fclk_0_A",
@@ -58,9 +93,8 @@
     "    Pin resource: 3, PLL FCLK requested resource: 1, PLL availability: 3",
     "      Use PLL: pll_0",
     "        Set PLLREF configuration attributes",
-    "  PLL pll_osc (location:BOOT_CLOCK#0) uses FCLK ''",
-    "    Pin resource: 3, PLL FCLK requested resource: 0, PLL availability: 2",
-    "      Warning: PLL request resource is 0 - does not need to route PLL output to FCLK. Only need to configure PLLREF configuration attributes",
+    "  PLL pll_osc (location:BOOT_CLOCK#0) uses FCLK 'hp_fclk_1_B'",
+    "    Pin resource: 3, PLL FCLK requested resource: 2, PLL availability: 2",
     "      Use PLL: pll_1",
     "        Set PLLREF configuration attributes",
     "Set PLL remaining configuration attributes",
@@ -68,7 +102,7 @@
     "    PLL pll (location:HP_1_CC_18_9P) use hp_fclk_0_A",
     "    PLL pll (location:HP_1_CC_18_9P) use hvl_fclk_1_A",
     "  Set FCLK configuration attributes",
-    "    Skip for PLL:BOOT_CLOCK#0",
+    "    PLL pll_osc (location:BOOT_CLOCK#0) use hp_fclk_1_B",
     "Validation using '__secondary_validation__' rule",
     "Set configuration attributes",
     "  Module: I_BUF ($ibuf$top.$ibuf_clk0)",
@@ -100,14 +134,13 @@
     "  Module: PLL (pll)",
     "    Object: clk1",
     "      Parameter",
+    "        Rule PLL.MUX0",
+    "          Match",
     "        Rule PLL.PLL",
     "          Match",
     "            Defined function: parse_pll_parameter",
     "        Rule PLL.PLLREF_MUX",
     "          Match",
-    "        Rule PLL.ROOT_MUX0",
-    "          Match",
-    "            Defined function: parse_pll_root_mux",
     "        Rule PLL.ROOT_MUX1",
     "          Mismatch",
     "        Rule PLL.ROOT_MUX2",
@@ -173,6 +206,14 @@
     "        Rule I_SERDES.DPA_MODE",
     "          Match",
     "      Property",
+    "  Module: I_BUF ($ibuf$top.$ibuf_din_serdes_clk_out)",
+    "    Object: din_serdes_clk_out",
+    "      Parameter",
+    "        Rule I_BUF.WEAK_KEEPER",
+    "          Match",
+    "      Property",
+    "        Rule I_BUF.IOSTANDARD",
+    "          Mismatch",
     "  Module: I_BUF ($ibuf$top.$ibuf_reset)",
     "    Object: reset",
     "      Parameter",
@@ -265,6 +306,12 @@
     "        Rule O_SERDES.DDR_MODE",
     "          Match",
     "      Property",
+    "  Module: O_BUFT ($obuf$top.$obuf_dout_serdes_clk_out)",
+    "    Object: dout_serdes_clk_out",
+    "      Parameter",
+    "      Property",
+    "        Rule O_BUFT.IOSTANDARD",
+    "          Mismatch",
     "  Module: BOOT_CLOCK (boot_clock)",
     "    Object: BOOT_CLOCK#0",
     "      Parameter",
@@ -274,14 +321,13 @@
     "  Module: PLL (pll_osc)",
     "    Object: BOOT_CLOCK#0",
     "      Parameter",
+    "        Rule PLL.MUX0",
+    "          Match",
     "        Rule PLL.PLL",
     "          Match",
     "            Defined function: parse_pll_parameter",
     "        Rule PLL.PLLREF_MUX",
     "          Match",
-    "        Rule PLL.ROOT_MUX0",
-    "          Match",
-    "            Defined function: parse_pll_root_mux",
     "        Rule PLL.ROOT_MUX1",
     "          Mismatch",
     "        Rule PLL.ROOT_MUX2",
@@ -372,6 +418,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk0",
+      "location_object" : "clk0",
+      "location" : "HR_1_CC_38_19P",
       "linked_object" : "clk0",
       "linked_objects" : {
         "clk0" : {
@@ -413,6 +461,8 @@
     {
       "module" : "CLK_BUF",
       "name" : "$clkbuf$top.$ibuf_clk0",
+      "location_object" : "clk0",
+      "location" : "HR_1_CC_38_19P",
       "linked_object" : "clk0",
       "linked_objects" : {
         "clk0" : {
@@ -420,7 +470,7 @@
           "properties" : {
             "IOSTANDARD" : "LVCMOS_18_HP",
             "PACKAGE_PIN" : "HR_1_CC_38_19P",
-            "ROUTE_TO_FABRIC_CLK" : "0"
+            "ROUTE_TO_FABRIC_CLK" : "i_delay=0;0"
           },
           "config_attributes" : [
             {
@@ -439,11 +489,13 @@
               "CLK_BUF" : "GBOX_TOP_SRC==DEFAULT"
             },
             {
-              "CLK_BUF" : "ROOT_BANK_SRC==B --#MUX=18",
-              "__location__" : "__{[0]}__.u_gbox_root_bank_clkmux_0"
+              "CLK_BUF" : "ROOT_BANK_SRC==A --#MUX=4",
+              "__comment__" : "Used by gearbox module i_delay (location: HR_1_4_2P)",
+              "__location__" : "u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_0"
             },
             {
-              "ROOT_MUX_SEL" : "9",
+              "ROOT_MUX_SEL" : "8",
+              "__comment__" : "From u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_0",
               "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_0"
             }
           ]
@@ -454,7 +506,7 @@
         "O" : "$clk_buf_$ibuf_clk0"
       },
       "parameters" : {
-        "ROUTE_TO_FABRIC_CLK" : "0"
+        "ROUTE_TO_FABRIC_CLK" : "i_delay=0;0"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -471,16 +523,14 @@
       },
       "errors" : [
       ],
-      "__AB__" : "B",
-      "__ROOT_BANK_MUX__" : "18",
-      "__ROOT_MUX__" : "9",
-      "__bank__" : "0",
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__clock_pin_is_valid__,__check_fabric_clock_resource__,__update_fabric_clock_resource__"
     },
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk1",
+      "location_object" : "clk1",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk1",
       "linked_objects" : {
         "clk1" : {
@@ -520,11 +570,14 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf",
+      "location_object" : "clk1",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk1",
       "linked_objects" : {
         "clk1" : {
           "location" : "HP_1_CC_18_9P",
           "properties" : {
+            "ROUTE_TO_FABRIC_CLK" : "o_delay=1"
           },
           "config_attributes" : [
           ]
@@ -535,6 +588,7 @@
         "O" : "clk1_buf"
       },
       "parameters" : {
+        "ROUTE_TO_FABRIC_CLK" : "o_delay=1"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -558,12 +612,14 @@
     {
       "module" : "PLL",
       "name" : "pll",
+      "location_object" : "clk1",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk1",
       "linked_objects" : {
         "clk1" : {
           "location" : "HP_1_CC_18_9P",
           "properties" : {
-            "OUT0_ROUTE_TO_FABRIC_CLK" : "1"
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_serdes=2;i_ddr=3;o_serdes=2;o_ddr=3"
           },
           "config_attributes" : [
             {
@@ -591,6 +647,26 @@
               "cfg_vco_clk_sel_A_1" : "1"
             },
             {
+              "PLL" : "ROOT_BANK_SRC==A --#MUX=0",
+              "__comment__" : "Used by gearbox module i_serdes (location: HR_2_0_0P)",
+              "__location__" : "u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_1"
+            },
+            {
+              "ROOT_MUX_SEL" : "10",
+              "__comment__" : "Used by gearbox module i_serdes (location: HR_2_0_0P). From u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_1",
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_2"
+            },
+            {
+              "PLL" : "ROOT_BANK_SRC==A --#MUX=4",
+              "__comment__" : "Used by gearbox module i_ddr (location: HP_1_4_2P)",
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0"
+            },
+            {
+              "ROOT_MUX_SEL" : "0",
+              "__comment__" : "Used by gearbox module i_ddr (location: HP_1_4_2P). From u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0",
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_3"
+            },
+            {
               "PLL" : "PLL_SRC==DEFAULT",
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_0",
               "pll_FBDIV" : "16",
@@ -602,10 +678,6 @@
             {
               "PLL" : "PLLREF_SRC==HP --#PIN=0 --#BANK=0 --#DIV=0",
               "__location__" : "u_GBOX_HP_40X2.u_gbox_pll_refmux_0"
-            },
-            {
-              "ROOT_MUX_SEL" : "32",
-              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_1"
             }
           ]
         }
@@ -613,12 +685,12 @@
       "connectivity" : {
         "CLK_IN" : "clk1_buf",
         "CLK_OUT" : "pll_clk",
-        "CLK_OUT_DIV4" : "$delete_wire$530"
+        "CLK_OUT_DIV4" : "$delete_wire$499"
       },
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
-        "OUT0_ROUTE_TO_FABRIC_CLK" : "1",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_serdes=2;i_ddr=3;o_serdes=2;o_ddr=3",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -632,6 +704,7 @@
           "i_serdes",
           "i_ddr",
           "o_serdes",
+          "o_ddr",
           "o_serdes_clk"
         ]
       },
@@ -640,6 +713,7 @@
           "Use FCLK: hvl_fclk_1_A",
           "Use FCLK: hp_fclk_0_A",
           "Use FCLK: hvl_fclk_1_A",
+          "Use FCLK: hp_fclk_0_A",
           "Use FCLK: hvl_fclk_1_A"
         ]
       },
@@ -657,6 +731,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk2",
+      "location_object" : "clk2",
+      "location" : "HR_5_CC_38_19P",
       "linked_object" : "clk2",
       "linked_objects" : {
         "clk2" : {
@@ -696,12 +772,14 @@
     {
       "module" : "CLK_BUF",
       "name" : "$clkbuf$top.$ibuf_clk2",
+      "location_object" : "clk2",
+      "location" : "HR_5_CC_38_19P",
       "linked_object" : "clk2",
       "linked_objects" : {
         "clk2" : {
           "location" : "HR_5_CC_38_19P",
           "properties" : {
-            "ROUTE_TO_FABRIC_CLK" : "2"
+            "ROUTE_TO_FABRIC_CLK" : "5"
           },
           "config_attributes" : [
             {
@@ -709,11 +787,13 @@
             },
             {
               "CLK_BUF" : "ROOT_BANK_SRC==B --#MUX=18",
-              "__location__" : "__{[0]}__.u_gbox_root_bank_clkmux_1"
+              "__comment__" : "Used by fabric logic only",
+              "__location__" : "u_GBOX_HV_40X2_VR.u_gbox_root_bank_clkmux_1"
             },
             {
               "ROOT_MUX_SEL" : "19",
-              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_2"
+              "__comment__" : "From u_GBOX_HV_40X2_VR.u_gbox_root_bank_clkmux_1",
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_5"
             }
           ]
         }
@@ -723,7 +803,7 @@
         "O" : "$clk_buf_$ibuf_clk2"
       },
       "parameters" : {
-        "ROUTE_TO_FABRIC_CLK" : "2"
+        "ROUTE_TO_FABRIC_CLK" : "5"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -734,16 +814,14 @@
       },
       "errors" : [
       ],
-      "__AB__" : "B",
-      "__ROOT_BANK_MUX__" : "18",
-      "__ROOT_MUX__" : "19",
-      "__bank__" : "1",
       "__validation__" : "TRUE",
       "__validation_msg__" : "Pass:__clock_pin_is_valid__,__check_fabric_clock_resource__,__update_fabric_clock_resource__"
     },
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din",
+      "location_object" : "din",
+      "location" : "HR_1_4_2P",
       "linked_object" : "din",
       "linked_objects" : {
         "din" : {
@@ -785,6 +863,8 @@
     {
       "module" : "I_DELAY",
       "name" : "i_delay",
+      "location_object" : "din",
+      "location" : "HR_1_4_2P",
       "linked_object" : "din",
       "linked_objects" : {
         "din" : {
@@ -823,6 +903,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din_clk2",
+      "location_object" : "din_clk2",
+      "location" : "HR_5_0_0P",
       "linked_object" : "din_clk2",
       "linked_objects" : {
         "din_clk2" : {
@@ -861,6 +943,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din_serdes",
+      "location_object" : "din_serdes",
+      "location" : "HR_2_0_0P",
       "linked_object" : "din_serdes",
       "linked_objects" : {
         "din_serdes" : {
@@ -897,11 +981,14 @@
     {
       "module" : "I_SERDES",
       "name" : "i_serdes",
+      "location_object" : "din_serdes",
+      "location" : "HR_2_0_0P",
       "linked_object" : "din_serdes",
       "linked_objects" : {
         "din_serdes" : {
           "location" : "HR_2_0_0P",
           "properties" : {
+            "ROUTE_TO_FABRIC_CLK" : "2"
           },
           "config_attributes" : [
             {
@@ -919,13 +1006,15 @@
         }
       },
       "connectivity" : {
-        "CLK_IN" : "1'1",
+        "CLK_IN" : "pll_clk",
+        "CLK_OUT" : "iserdes_clk_out",
         "D" : "$ibuf_din_serdes",
         "PLL_CLK" : "pll_clk"
       },
       "parameters" : {
         "DATA_RATE" : "SDR",
         "DPA_MODE" : "DPA",
+        "ROUTE_TO_FABRIC_CLK" : "2",
         "WIDTH" : "8"
       },
       "pre_primitive" : "I_BUF",
@@ -942,7 +1031,49 @@
     },
     {
       "module" : "I_BUF",
+      "name" : "$ibuf$top.$ibuf_din_serdes_clk_out",
+      "location_object" : "din_serdes_clk_out",
+      "location" : "HR_2_6_3P",
+      "linked_object" : "din_serdes_clk_out",
+      "linked_objects" : {
+        "din_serdes_clk_out" : {
+          "location" : "HR_2_6_3P",
+          "properties" : {
+          },
+          "config_attributes" : [
+            {
+              "I_BUF" : "WEAK_KEEPER==NONE"
+            },
+            {
+              "I_BUF" : "IOSTANDARD==DEFAULT"
+            }
+          ]
+        }
+      },
+      "connectivity" : {
+        "I" : "din_serdes_clk_out",
+        "O" : "$ibuf_din_serdes_clk_out"
+      },
+      "parameters" : {
+        "WEAK_KEEPER" : "NONE"
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+      },
+      "route_clock_result" : {
+      },
+      "errors" : [
+      ],
+      "__validation__" : "TRUE",
+      "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
+    },
+    {
+      "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_enable",
+      "location_object" : "enable",
+      "location" : "",
       "linked_object" : "enable",
       "linked_objects" : {
         "enable" : {
@@ -975,6 +1106,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_reset",
+      "location_object" : "reset",
+      "location" : "HP_1_0_0P",
       "linked_object" : "reset",
       "linked_objects" : {
         "reset" : {
@@ -1013,6 +1146,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_clk_out",
+      "location_object" : "clk_out",
+      "location" : "HR_2_4_2P",
       "linked_object" : "clk_out",
       "linked_objects" : {
         "clk_out" : {
@@ -1048,6 +1183,8 @@
     {
       "module" : "O_SERDES_CLK",
       "name" : "o_serdes_clk",
+      "location_object" : "clk_out",
+      "location" : "HR_2_4_2P",
       "linked_object" : "clk_out",
       "linked_objects" : {
         "clk_out" : {
@@ -1087,6 +1224,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap",
+      "location_object" : "delay_tap[0]",
+      "location" : "HR_2_20_10P",
       "linked_object" : "delay_tap[0]",
       "linked_objects" : {
         "delay_tap[0]" : {
@@ -1121,6 +1260,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap_1",
+      "location_object" : "delay_tap[1]",
+      "location" : "HR_2_22_11P",
       "linked_object" : "delay_tap[1]",
       "linked_objects" : {
         "delay_tap[1]" : {
@@ -1155,6 +1296,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap_2",
+      "location_object" : "delay_tap[2]",
+      "location" : "HR_2_24_12P",
       "linked_object" : "delay_tap[2]",
       "linked_objects" : {
         "delay_tap[2]" : {
@@ -1189,6 +1332,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap_3",
+      "location_object" : "delay_tap[3]",
+      "location" : "HR_2_26_13P",
       "linked_object" : "delay_tap[3]",
       "linked_objects" : {
         "delay_tap[3]" : {
@@ -1223,6 +1368,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap_4",
+      "location_object" : "delay_tap[4]",
+      "location" : "HR_2_28_14P",
       "linked_object" : "delay_tap[4]",
       "linked_objects" : {
         "delay_tap[4]" : {
@@ -1257,6 +1404,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap_5",
+      "location_object" : "delay_tap[5]",
+      "location" : "HR_2_30_15P",
       "linked_object" : "delay_tap[5]",
       "linked_objects" : {
         "delay_tap[5]" : {
@@ -1291,6 +1440,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout",
+      "location_object" : "dout",
+      "location" : "HR_1_6_3P",
       "linked_object" : "dout",
       "linked_objects" : {
         "dout" : {
@@ -1328,6 +1479,8 @@
     {
       "module" : "O_DELAY",
       "name" : "o_delay",
+      "location_object" : "dout",
+      "location" : "HR_1_6_3P",
       "linked_object" : "dout",
       "linked_objects" : {
         "dout" : {
@@ -1366,6 +1519,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout_clk2",
+      "location_object" : "dout_clk2",
+      "location" : "HR_5_1_0N",
       "linked_object" : "dout_clk2",
       "linked_objects" : {
         "dout_clk2" : {
@@ -1400,6 +1555,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout_serdes",
+      "location_object" : "dout_serdes",
+      "location" : "HR_2_2_1P",
       "linked_object" : "dout_serdes",
       "linked_objects" : {
         "dout_serdes" : {
@@ -1435,6 +1592,8 @@
     {
       "module" : "O_SERDES",
       "name" : "o_serdes",
+      "location_object" : "dout_serdes",
+      "location" : "HR_2_2_1P",
       "linked_object" : "dout_serdes",
       "linked_objects" : {
         "dout_serdes" : {
@@ -1443,8 +1602,8 @@
           },
           "config_attributes" : [
             {
-              "PEER_IS_ON" : "PEER_on",
-              "RATE" : "4",
+              "PEER_IS_ON" : "PEER_off",
+              "RATE" : "8",
               "TX_BYPASS" : "TX_gear_on"
             },
             {
@@ -1454,13 +1613,13 @@
         }
       },
       "connectivity" : {
-        "CLK_IN" : "1'1",
+        "CLK_IN" : "pll_clk",
         "PLL_CLK" : "pll_clk",
         "Q" : "$obuf_dout_serdes"
       },
       "parameters" : {
         "DATA_RATE" : "DDR",
-        "WIDTH" : "4"
+        "WIDTH" : "8"
       },
       "pre_primitive" : "O_BUFT",
       "post_primitives" : [
@@ -1475,8 +1634,46 @@
       "__validation_msg__" : "Pass:__check_data_rate_parameter__"
     },
     {
+      "module" : "O_BUFT",
+      "name" : "$obuf$top.$obuf_dout_serdes_clk_out",
+      "location_object" : "dout_serdes_clk_out",
+      "location" : "HR_2_7_3N",
+      "linked_object" : "dout_serdes_clk_out",
+      "linked_objects" : {
+        "dout_serdes_clk_out" : {
+          "location" : "HR_2_7_3N",
+          "properties" : {
+          },
+          "config_attributes" : [
+            {
+              "O_BUFT" : "IOSTANDARD==DEFAULT"
+            }
+          ]
+        }
+      },
+      "connectivity" : {
+        "I" : "$obuf_dout_serdes_clk_out",
+        "O" : "dout_serdes_clk_out"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+      },
+      "route_clock_result" : {
+      },
+      "errors" : [
+      ],
+      "__validation__" : "TRUE",
+      "__validation_msg__" : "Pass:__pin_is_valid__,__check_pin_resource__"
+    },
+    {
       "module" : "BOOT_CLOCK",
       "name" : "boot_clock",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "__SKIP_LOCATION_CHECK__:BOOT_CLOCK#0",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
@@ -1509,14 +1706,38 @@
     {
       "module" : "PLL",
       "name" : "pll_osc",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "__SKIP_LOCATION_CHECK__:BOOT_CLOCK#0",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
           "location" : "__SKIP_LOCATION_CHECK__:BOOT_CLOCK#0",
           "properties" : {
-            "OUT0_ROUTE_TO_FABRIC_CLK" : "3"
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "o_ddr_osc=4"
           },
           "config_attributes" : [
+            {
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_fclk_mux_all",
+              "cfg_rx_fclkio_sel_B_1" : "0"
+            },
+            {
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_fclk_mux_all",
+              "cfg_rxclk_phase_sel_B_1" : "0"
+            },
+            {
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_fclk_mux_all",
+              "cfg_vco_clk_sel_B_1" : "1"
+            },
+            {
+              "PLL" : "ROOT_BANK_SRC==B --#MUX=2",
+              "__comment__" : "Used by gearbox module o_ddr_osc (location: HP_2_22_11P)",
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_1"
+            },
+            {
+              "ROOT_MUX_SEL" : "3",
+              "__comment__" : "Used by gearbox module o_ddr_osc (location: HP_2_22_11P). From u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_1",
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_4"
+            },
             {
               "PLL" : "PLL_SRC==DEFAULT",
               "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF_1",
@@ -1529,10 +1750,6 @@
             {
               "PLL" : "PLLREF_SRC==BOOT_CLOCK --#PIN=UNKNOWN --#BANK=UNKNOWN --#DIV=1",
               "__location__" : "u_GBOX_HP_40X2.u_gbox_pll_refmux_1"
-            },
-            {
-              "ROOT_MUX_SEL" : "36",
-              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_3"
             }
           ]
         }
@@ -1544,7 +1761,7 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "TRUE",
-        "OUT0_ROUTE_TO_FABRIC_CLK" : "3",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "o_ddr_osc=4",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -1554,8 +1771,14 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
+        "CLK_OUT" : [
+          "o_ddr_osc"
+        ]
       },
       "route_clock_result" : {
+        "CLK_OUT" : [
+          "Use FCLK: hp_fclk_1_B"
+        ]
       },
       "errors" : [
       ],
@@ -1571,6 +1794,8 @@
     {
       "module" : "I_BUF_DS",
       "name" : "i_buf_ds",
+      "location_object" : "din_p",
+      "location" : "HP_1_4_2P",
       "linked_object" : "din_n+din_p",
       "linked_objects" : {
         "din_n" : {
@@ -1626,6 +1851,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr",
+      "location_object" : "din_p",
+      "location" : "HP_1_4_2P",
       "linked_object" : "din_n+din_p",
       "linked_objects" : {
         "din_n" : {
@@ -1670,6 +1897,8 @@
     {
       "module" : "O_BUF_DS",
       "name" : "o_buf_ds",
+      "location_object" : "dout_p",
+      "location" : "HP_1_8_4P",
       "linked_object" : "dout_n+dout_p",
       "linked_objects" : {
         "dout_n" : {
@@ -1716,6 +1945,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr",
+      "location_object" : "dout_p",
+      "location" : "HP_1_8_4P",
       "linked_object" : "dout_n+dout_p",
       "linked_objects" : {
         "dout_n" : {
@@ -1760,6 +1991,8 @@
     {
       "module" : "O_BUF_DS",
       "name" : "o_buf_ds_osc",
+      "location_object" : "dout_osc_p",
+      "location" : "HP_2_22_11P",
       "linked_object" : "dout_osc_n+dout_osc_p",
       "linked_objects" : {
         "dout_osc_n" : {
@@ -1806,6 +2039,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr_osc",
+      "location_object" : "dout_osc_p",
+      "location" : "HP_2_22_11P",
       "linked_object" : "dout_osc_n+dout_osc_p",
       "linked_objects" : {
         "dout_osc_n" : {
@@ -1850,18 +2085,20 @@
     {
       "module" : "FCLK_BUF",
       "name" : "$clkbuf$top.clk0_div",
+      "location_object" : "FABRIC_CLKBUF#0",
+      "location" : "__SKIP_LOCATION_CHECK__:FABRIC_CLKBUF#0",
       "linked_object" : "FABRIC_CLKBUF#0",
       "linked_objects" : {
         "FABRIC_CLKBUF#0" : {
           "location" : "__SKIP_LOCATION_CHECK__:FABRIC_CLKBUF#0",
           "properties" : {
             "ROUTE_FROM_FABRIC_CLK" : "0",
-            "ROUTE_TO_FABRIC_CLK" : "4"
+            "ROUTE_TO_FABRIC_CLK" : "6"
           },
           "config_attributes" : [
             {
               "ROOT_MUX_SEL" : "44",
-              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_4"
+              "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_6"
             }
           ]
         }
@@ -1872,7 +2109,7 @@
       },
       "parameters" : {
         "ROUTE_FROM_FABRIC_CLK" : "0",
-        "ROUTE_TO_FABRIC_CLK" : "4"
+        "ROUTE_TO_FABRIC_CLK" : "6"
       },
       "pre_primitive" : "",
       "post_primitives" : [

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.backdoor.txt
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.backdoor.txt
@@ -233,10 +233,10 @@ force u_dut.u_gbox_hv_VR_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[1].control
 force u_dut.u_gbox_hv_VR_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[1].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_B_0 [Customer Name: HR_5_1_0N]
-force u_dut.u_gbox_hv_VR_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[0].control = 42'b000100000001000000000000000000001000100011;
+force u_dut.u_gbox_hv_VR_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[0].control = 42'b000100000001000000000100000000001000100011;
 
 // u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_0 [Customer Name: HR_5_0_0P]
-force u_dut.u_gbox_hv_VR_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[0].control = 42'b000100000010000000000100000000000000100011;
+force u_dut.u_gbox_hv_VR_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[0].control = 42'b000100000010000000000100000000001000100011;
 
 // u_GBOX_HV_40X2_VR.u_HV_PGEN_dummy [Customer Name: ]
 force u_dut.u_gbox_hv_VR_EW_BANK_x2.u_gbox_pgen_cfg.control = 2'b00;
@@ -299,10 +299,10 @@ force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_1.u_gbox_io_cfg_B[12].control =
 force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_1.u_gbox_io_cfg_A[12].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK1_B_11 [Customer Name: HP_2_23_11N]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_1.u_gbox_io_cfg_B[11].control = 42'b000100001001000000000000000000001010100011;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_1.u_gbox_io_cfg_B[11].control = 42'b000100001001000000000100000000001010100011;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK1_A_11 [Customer Name: HP_2_22_11P]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_1.u_gbox_io_cfg_A[11].control = 42'b000100001001000000000000000000001010100011;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_1.u_gbox_io_cfg_A[11].control = 42'b000100001001000000000100000000001010100011;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK1_B_10 [Customer Name: HP_2_21_10N]
 force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_1.u_gbox_io_cfg_B[10].control = 42'b000000000000000000000000000000000000000000;
@@ -434,7 +434,7 @@ force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[10].control =
 force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_B[9].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_9 [Customer Name: HP_1_CC_18_9P]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[9].control = 42'b000100000010000000000100000000000000100011;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[9].control = 42'b000100000010000000000100000000001000100011;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK0_B_8 [Customer Name: HP_1_17_8N]
 force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_B[8].control = 42'b000000000000000000000000000000000000000000;
@@ -461,10 +461,10 @@ force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_B[5].control = 
 force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[5].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK0_B_4 [Customer Name: HP_1_9_4N]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_B[4].control = 42'b000100001001000000000000000000001010100011;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_B[4].control = 42'b000100001001000000000100000000001010100011;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_4 [Customer Name: HP_1_8_4P]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[4].control = 42'b000100001001000000000000000000001010100011;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[4].control = 42'b000100001001000000000100000000001010100011;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK0_B_3 [Customer Name: HP_1_7_3N]
 force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_B[3].control = 42'b000000000000000000000000000000000000000000;
@@ -473,10 +473,10 @@ force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_B[3].control = 
 force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[3].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK0_B_2 [Customer Name: HP_1_5_2N]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_B[2].control = 42'b000110001010000000000101000000000000100011;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_B[2].control = 42'b000110001010000000000101000000001000100011;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_2 [Customer Name: HP_1_4_2P]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[2].control = 42'b000110001010000000000101000000000000100011;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[2].control = 42'b000110001010000000000101000000001000100011;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK0_B_1 [Customer Name: HP_1_3_1N]
 force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_B[1].control = 42'b000000000000000000000000000000000000000000;
@@ -488,40 +488,40 @@ force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[1].control = 
 force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_B[0].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_0 [Customer Name: HP_1_0_0P]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[0].control = 42'b000100000010000000000100000000000000100011;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_hp_40_NS_0.u_gbox_io_cfg_A[0].control = 42'b000100000010000000000100000000001000100011;
 
 // u_GBOX_HP_40X2.u_HP_PGEN_dummy [Customer Name: ]
 force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_pgen_cfg0.control = 6'b000000;
 
 // u_GBOX_HP_40X2.u_gbox_fclk_mux_all [Customer Name: ]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[11:0] = 12'b010000000000;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[11:0] = 12'b011000000000;
 
 // u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0 [Customer Name: ]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[31:12] = 20'b00000000000000000000;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[31:12] = 20'b00100000000000000000;
 
 // u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_1 [Customer Name: ]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[51:32] = 20'b00000000000000000000;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[51:32] = 20'b00000000100000000000;
 
 // u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_0 [Customer Name: ]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[57:52] = 6'b001001;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[57:52] = 6'b001000;
 
 // u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_1 [Customer Name: ]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[63:58] = 6'b100000;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[63:58] = 6'b111111;
 
 // u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_2 [Customer Name: ]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[69:64] = 6'b010011;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[69:64] = 6'b001010;
 
 // u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_3 [Customer Name: ]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[75:70] = 6'b100100;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[75:70] = 6'b000000;
 
 // u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_4 [Customer Name: ]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[81:76] = 6'b101100;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[81:76] = 6'b000011;
 
 // u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_5 [Customer Name: ]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[87:82] = 6'b111111;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[87:82] = 6'b010011;
 
 // u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_6 [Customer Name: ]
-force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[93:88] = 6'b111111;
+force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[93:88] = 6'b101100;
 
 // u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_7 [Customer Name: ]
 force u_dut.u_gbox_hp_NS_BANK_x2.u_gbox_vco_fask_cfg.control[99:94] = 6'b111111;
@@ -665,13 +665,13 @@ force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_0.u_gbox_io_cfg_A[4].control
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_0.u_gbox_io_cfg_B[3].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_3 [Customer Name: HR_1_6_3P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_0.u_gbox_io_cfg_A[3].control = 42'b000100000001000000000000111100001000100011;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_0.u_gbox_io_cfg_A[3].control = 42'b000100000001000000000100111100001000100011;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_B_2 [Customer Name: HR_1_5_2N]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_0.u_gbox_io_cfg_B[2].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_2 [Customer Name: HR_1_4_2P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_0.u_gbox_io_cfg_A[2].control = 42'b000100000010000110010100000000000000100011;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_0.u_gbox_io_cfg_A[2].control = 42'b000100000010000110010100000000001000100011;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_B_1 [Customer Name: HR_1_3_1N]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_0.u_gbox_io_cfg_B[1].control = 42'b000000000000000000000000000000000000000000;
@@ -713,37 +713,37 @@ force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[16].contro
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[15].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_15 [Customer Name: HR_2_30_15P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[15].control = 42'b000100000001000000000000000000001000100011;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[15].control = 42'b000100000001000000000100000000001000100011;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_14 [Customer Name: HR_2_29_14N]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[14].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_14 [Customer Name: HR_2_28_14P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[14].control = 42'b000100000001000000000000000000001000100011;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[14].control = 42'b000100000001000000000100000000001000100011;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_13 [Customer Name: HR_2_27_13N]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[13].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_13 [Customer Name: HR_2_26_13P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[13].control = 42'b000100000001000000000000000000001000100011;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[13].control = 42'b000100000001000000000100000000001000100011;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_12 [Customer Name: HR_2_25_12N]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[12].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_12 [Customer Name: HR_2_24_12P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[12].control = 42'b000100000001000000000000000000001000100011;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[12].control = 42'b000100000001000000000100000000001000100011;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_11 [Customer Name: HR_2_23_11N]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[11].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_11 [Customer Name: HR_2_22_11P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[11].control = 42'b000100000001000000000000000000001000100011;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[11].control = 42'b000100000001000000000100000000001000100011;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_10 [Customer Name: HR_2_21_10N]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[10].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_10 [Customer Name: HR_2_20_10P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[10].control = 42'b000100000001000000000000000000001000100011;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[10].control = 42'b000100000001000000000100000000001000100011;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_9 [Customer Name: HR_2_CC_19_9N]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[9].control = 42'b000000000000000000000000000000000000000000;
@@ -782,28 +782,28 @@ force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[4].control
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[4].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_3 [Customer Name: HR_2_7_3N]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[3].control = 42'b000000000000000000000000000000000000000000;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[3].control = 42'b000100000001000000000100000000001000100011;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_3 [Customer Name: HR_2_6_3P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[3].control = 42'b000000000000000000000000000000000000000000;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[3].control = 42'b000100000010000000000100000000001000100011;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_2 [Customer Name: HR_2_5_2N]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[2].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_2 [Customer Name: HR_2_4_2P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[2].control = 42'b000100000001000000000000000000111100100011;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[2].control = 42'b000100000001000000000100000000111100100011;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_1 [Customer Name: HR_2_3_1N]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[1].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_1 [Customer Name: HR_2_2_1P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[1].control = 42'b000100000001000000000000000000000010100100;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[1].control = 42'b000100000001000000000100000000000010001000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_0 [Customer Name: HR_2_1_0N]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_B[0].control = 42'b000000000000000000000000000000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_0 [Customer Name: HR_2_0_0P]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[0].control = 42'b000100000010010000000010000000000000001000;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_hv_40_EW_1.u_gbox_io_cfg_A[0].control = 42'b000100000010010000000010000000001000001000;
 
 // u_GBOX_HV_40X2_VL.u_HV_PGEN_dummy [Customer Name: ]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_pgen_cfg.control = 2'b00;
@@ -812,7 +812,7 @@ force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_pgen_cfg.control = 2'b00;
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_vco_fask_cfg.control[11:0] = 12'b100001000100;
 
 // u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_0 [Customer Name: ]
-force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_vco_fask_cfg.control[31:12] = 20'b00000100100000000000;
+force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_vco_fask_cfg.control[31:12] = 20'b00100000000000000000;
 
 // u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_1 [Customer Name: ]
 force u_dut.u_gbox_hv_VL_EW_BANK_x2.u_gbox_vco_fask_cfg.control[51:32] = 20'b00000000000000000000;

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
@@ -996,13 +996,13 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_19 [HR_5_CC_38_19P]
                      TX_DDR_MODE - Addr: 0x000006C1, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x000006C3, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], $clkbuf$top.$ibuf_clk2 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x000006C4, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x000006C6, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x000006C6, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x000006CC, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x000006CE, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], $clkbuf$top.$ibuf_clk2 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                           RX_DLY - Addr: 0x000006CF, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x000006D5, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000006D7, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x000006D8, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x000006D8, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x000006D9, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x000006DA, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], $clkbuf$top.$ibuf_clk2 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                             DFEN - Addr: 0x000006DB, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -1887,16 +1887,16 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_B_0 [HR_5_1_0N]
                           TX_DLY - Addr: 0x00000CD8, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00000CDE, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00000CE0, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x00000CE1, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x00000CE1, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00000CE7, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00000CE9, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x00000CEA, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x00000CEB, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00000CEC, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00000CEB, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00000CEC, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x00000CED, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x00000CEE, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x00000CEF, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x00000CF0, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00000CEF, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x00000CF0, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x00000CF1, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x00000CF2, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_0 [HR_5_0_0P]
@@ -1908,13 +1908,13 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_0 [HR_5_0_0P]
                      TX_DDR_MODE - Addr: 0x00000CFD, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00000CFF, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00000D00, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00000D02, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00000D02, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00000D08, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00000D0A, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00000D0B, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00000D11, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00000D13, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00000D14, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00000D14, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00000D15, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00000D16, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00000D17, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -3426,13 +3426,13 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_9 [HP_1_CC_18_9P]
                      TX_DDR_MODE - Addr: 0x0000175F, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00001761, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001762, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00001764, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00001764, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000176A, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x0000176C, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x0000176D, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001773, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001775, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00001776, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00001776, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00001777, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00001778, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00001779, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -3858,13 +3858,13 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_0 [HP_1_0_0P]
                      TX_DDR_MODE - Addr: 0x00001A53, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00001A55, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001A56, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00001A58, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00001A58, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001A5E, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00001A60, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001A61, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001A67, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001A69, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00001A6A, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00001A6A, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00001A6B, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00001A6C, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00001A6D, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -4043,13 +4043,13 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_19 [HR_1_CC_38_19P]
                      TX_DDR_MODE - Addr: 0x00001BEC, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
                        TX_BYPASS - Addr: 0x00001BEE, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP], $clkbuf$top.$ibuf_clk0 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001BEF, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
-                          TX_DLY - Addr: 0x00001BF1, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
+                          TX_DLY - Addr: 0x00001BF1, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001BF7, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
                        RX_BYPASS - Addr: 0x00001BF9, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP], $clkbuf$top.$ibuf_clk0 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                           RX_DLY - Addr: 0x00001BFA, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001C00, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
                     RX_MIPI_MODE - Addr: 0x00001C02, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
-                         TX_MODE - Addr: 0x00001C03, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
+                         TX_MODE - Addr: 0x00001C03, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00001C04, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
                      RX_CLOCK_IO - Addr: 0x00001C05, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP], $clkbuf$top.$ibuf_clk0 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                             DFEN - Addr: 0x00001C06, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk0 [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HP] }
@@ -4814,16 +4814,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_3 [HR_1_6_3P]
                           TX_DLY - Addr: 0x00002131, Size:  6, Value: (0x0000003C) 60 { o_delay [O_DELAY] [TX_DLY:60] }
                      RX_DDR_MODE - Addr: 0x00002137, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
                        RX_BYPASS - Addr: 0x00002139, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
-                          RX_DLY - Addr: 0x0000213A, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
+                          RX_DLY - Addr: 0x0000213A, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00002140, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
                     RX_MIPI_MODE - Addr: 0x00002142, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
                          TX_MODE - Addr: 0x00002143, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
-                         RX_MODE - Addr: 0x00002144, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
-                     RX_CLOCK_IO - Addr: 0x00002145, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
+                         RX_MODE - Addr: 0x00002144, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00002145, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x00002146, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
                               SR - Addr: 0x00002147, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
-                              PE - Addr: 0x00002148, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
-                             PUD - Addr: 0x00002149, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
+                              PE - Addr: 0x00002148, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x00002149, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x0000214A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
                               MC - Addr: 0x0000214B, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_B_2 [HR_1_5_2N]
@@ -4859,13 +4859,13 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_2 [HR_1_4_2P]
                      TX_DDR_MODE - Addr: 0x00002180, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                        TX_BYPASS - Addr: 0x00002182, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                     TX_CLK_PHASE - Addr: 0x00002183, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
-                          TX_DLY - Addr: 0x00002185, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
+                          TX_DLY - Addr: 0x00002185, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000218B, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                        RX_BYPASS - Addr: 0x0000218D, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                           RX_DLY - Addr: 0x0000218E, Size:  6, Value: (0x00000032) 50 { i_delay [I_DELAY] [RX_DLY:50] }
                      RX_DPA_MODE - Addr: 0x00002194, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                     RX_MIPI_MODE - Addr: 0x00002196, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
-                         TX_MODE - Addr: 0x00002197, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
+                         TX_MODE - Addr: 0x00002197, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00002198, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                      RX_CLOCK_IO - Addr: 0x00002199, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                             DFEN - Addr: 0x0000219A, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
@@ -5198,16 +5198,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_15 [HR_2_30_15P]
                           TX_DLY - Addr: 0x000023D1, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x000023D7, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x000023D9, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x000023DA, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x000023DA, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x000023E0, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000023E2, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x000023E3, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x000023E4, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x000023E5, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x000023E4, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x000023E5, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x000023E6, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x000023E7, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x000023E8, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x000023E9, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x000023E8, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x000023E9, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x000023EA, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x000023EB, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_14 [HR_2_29_14N]
@@ -5246,16 +5246,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_14 [HR_2_28_14P]
                           TX_DLY - Addr: 0x00002425, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000242B, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x0000242D, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x0000242E, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x0000242E, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00002434, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002436, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x00002437, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x00002438, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00002439, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00002438, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00002439, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x0000243A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x0000243B, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x0000243C, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x0000243D, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x0000243C, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x0000243D, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x0000243E, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x0000243F, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_13 [HR_2_27_13N]
@@ -5294,16 +5294,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_13 [HR_2_26_13P]
                           TX_DLY - Addr: 0x00002479, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000247F, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00002481, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x00002482, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x00002482, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00002488, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x0000248A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x0000248B, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x0000248C, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x0000248D, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x0000248C, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x0000248D, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x0000248E, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x0000248F, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x00002490, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x00002491, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00002490, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x00002491, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x00002492, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x00002493, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_12 [HR_2_25_12N]
@@ -5342,16 +5342,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_12 [HR_2_24_12P]
                           TX_DLY - Addr: 0x000024CD, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x000024D3, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x000024D5, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x000024D6, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x000024D6, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x000024DC, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000024DE, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x000024DF, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x000024E0, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x000024E1, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x000024E0, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x000024E1, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x000024E2, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x000024E3, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x000024E4, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x000024E5, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x000024E4, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x000024E5, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x000024E6, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x000024E7, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_11 [HR_2_23_11N]
@@ -5390,16 +5390,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_11 [HR_2_22_11P]
                           TX_DLY - Addr: 0x00002521, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00002527, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00002529, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x0000252A, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x0000252A, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00002530, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002532, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x00002533, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x00002534, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00002535, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00002534, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00002535, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x00002536, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x00002537, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x00002538, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x00002539, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00002538, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x00002539, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x0000253A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x0000253B, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_10 [HR_2_21_10N]
@@ -5438,16 +5438,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_10 [HR_2_20_10P]
                           TX_DLY - Addr: 0x00002575, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000257B, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x0000257D, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x0000257E, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x0000257E, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00002584, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002586, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x00002587, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x00002588, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00002589, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00002588, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00002589, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x0000258A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x0000258B, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x0000258C, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x0000258D, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x0000258C, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x0000258D, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x0000258E, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x0000258F, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_9 [HR_2_CC_19_9N]
@@ -5750,16 +5750,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_3 [HR_2_7_3N]
                           TX_DLY - Addr: 0x00002797, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000279D, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x0000279F, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x000027A0, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x000027A0, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x000027A6, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000027A8, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x000027A9, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x000027AA, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x000027AB, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x000027AA, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x000027AB, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x000027AC, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x000027AD, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x000027AE, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x000027AF, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x000027AE, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x000027AF, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x000027B0, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x000027B1, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_3 [HR_2_6_3P]
@@ -5771,13 +5771,13 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_3 [HR_2_6_3P]
                      TX_DDR_MODE - Addr: 0x000027BC, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x000027BE, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x000027BF, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x000027C1, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x000027C1, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x000027C7, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x000027C9, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x000027CA, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x000027D0, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000027D2, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x000027D3, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x000027D3, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x000027D4, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x000027D5, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x000027D6, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -5822,16 +5822,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_2 [HR_2_4_2P]
                           TX_DLY - Addr: 0x00002815, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000281B, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x0000281D, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x0000281E, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x0000281E, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00002824, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002826, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x00002827, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x00002828, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00002829, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00002828, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00002829, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x0000282A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x0000282B, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x0000282C, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x0000282D, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x0000282C, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x0000282D, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x0000282E, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x0000282F, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_1 [HR_2_3_1N]
@@ -5870,16 +5870,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_1 [HR_2_2_1P]
                           TX_DLY - Addr: 0x00002869, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000286F, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00002871, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x00002872, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x00002872, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00002878, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x0000287A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x0000287B, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x0000287C, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x0000287D, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x0000287C, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x0000287D, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x0000287E, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x0000287F, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x00002880, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x00002881, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00002880, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x00002881, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x00002882, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x00002883, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_0 [HR_2_1_0N]
@@ -5915,13 +5915,13 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_0 [HR_2_0_0P]
                      TX_DDR_MODE - Addr: 0x000028B8, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x000028BA, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x000028BB, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x000028BD, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x000028BD, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x000028C3, Size:  2, Value: (0x00000002) 2 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_serdes [I_SERDES] [I_SERDES:DDR_MODE==SDR] }
                        RX_BYPASS - Addr: 0x000028C5, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_serdes [I_SERDES] [RX_BYPASS:RX_gear_on] }
                           RX_DLY - Addr: 0x000028C6, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x000028CC, Size:  2, Value: (0x00000002) 2 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_serdes [I_SERDES] [I_SERDES:DPA_MODE==DPA] }
                     RX_MIPI_MODE - Addr: 0x000028CE, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x000028CF, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x000028CF, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x000028D0, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x000028D1, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x000028D2, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.detail.bit
@@ -1886,7 +1886,7 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_B_0 [HR_5_1_0N]
                     TX_CLK_PHASE - Addr: 0x00000CD6, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00000CD8, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00000CDE, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00000CE0, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00000CE0, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00000CE1, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00000CE7, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00000CE9, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_clk2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -1906,7 +1906,7 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_0 [HR_5_0_0P]
                       PEER_IS_ON - Addr: 0x00000CFB, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00000CFC, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00000CFD, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00000CFF, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00000CFF, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00000D00, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00000D02, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00000D08, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_clk2 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -2348,7 +2348,7 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK1_B_11 [HP_2_23_11N]
                     TX_CLK_PHASE - Addr: 0x00001000, Size:  2, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001002, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001008, Size:  2, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x0000100A, Size:  1, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x0000100A, Size:  1, Value: (0x00000001) 1 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x0000100B, Size:  6, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00001011, Size:  2, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001013, Size:  1, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
@@ -2372,7 +2372,7 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK1_A_11 [HP_2_22_11P]
                     TX_CLK_PHASE - Addr: 0x0000102A, Size:  2, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x0000102C, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001032, Size:  2, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00001034, Size:  1, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00001034, Size:  1, Value: (0x00000001) 1 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001035, Size:  6, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x0000103B, Size:  2, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x0000103D, Size:  1, Value: (0x00000000) 0 { o_buf_ds_osc [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
@@ -3424,7 +3424,7 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_9 [HP_1_CC_18_9P]
                       PEER_IS_ON - Addr: 0x0000175D, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x0000175E, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x0000175F, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00001761, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00001761, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001762, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001764, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x0000176A, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -3644,7 +3644,7 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_B_4 [HP_1_9_4N]
                     TX_CLK_PHASE - Addr: 0x000018DC, Size:  2, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x000018DE, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x000018E4, Size:  2, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x000018E6, Size:  1, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x000018E6, Size:  1, Value: (0x00000001) 1 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x000018E7, Size:  6, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x000018ED, Size:  2, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000018EF, Size:  1, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
@@ -3668,7 +3668,7 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_4 [HP_1_8_4P]
                     TX_CLK_PHASE - Addr: 0x00001906, Size:  2, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001908, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000190E, Size:  2, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00001910, Size:  1, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00001910, Size:  1, Value: (0x00000001) 1 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001911, Size:  6, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00001917, Size:  2, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001919, Size:  1, Value: (0x00000000) 0 { o_buf_ds [O_BUF_DS] [O_BUF_DS:IOSTANDARD==DEFAULT] }
@@ -3736,7 +3736,7 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_B_2 [HP_1_5_2N]
                       PEER_IS_ON - Addr: 0x0000197F, Size:  1, Value: (0x00000001) 1 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00001980, Size:  1, Value: (0x00000000) 0 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00001981, Size:  2, Value: (0x00000000) 0 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00001983, Size:  1, Value: (0x00000000) 0 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00001983, Size:  1, Value: (0x00000001) 1 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001984, Size:  2, Value: (0x00000000) 0 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001986, Size:  6, Value: (0x00000000) 0 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x0000198C, Size:  2, Value: (0x00000001) 1 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT], i_ddr [I_DDR] [I_DDR:MODE==DDR] }
@@ -3760,7 +3760,7 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_2 [HP_1_4_2P]
                       PEER_IS_ON - Addr: 0x000019A9, Size:  1, Value: (0x00000001) 1 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x000019AA, Size:  1, Value: (0x00000000) 0 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x000019AB, Size:  2, Value: (0x00000000) 0 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x000019AD, Size:  1, Value: (0x00000000) 0 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x000019AD, Size:  1, Value: (0x00000001) 1 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x000019AE, Size:  2, Value: (0x00000000) 0 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x000019B0, Size:  6, Value: (0x00000000) 0 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x000019B6, Size:  2, Value: (0x00000001) 1 { i_buf_ds [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT], i_ddr [I_DDR] [I_DDR:MODE==DDR] }
@@ -3856,7 +3856,7 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_0 [HP_1_0_0P]
                       PEER_IS_ON - Addr: 0x00001A51, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00001A52, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00001A53, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00001A55, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00001A55, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001A56, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001A58, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00001A5E, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_reset [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -3884,15 +3884,15 @@ Block u_GBOX_HP_40X2.u_HP_PGEN_dummy []
 Block u_GBOX_HP_40X2.u_gbox_fclk_mux_all []
   Attributes:
          cfg_rxclk_phase_sel_B_0 - Addr: 0x00001A7C, Size:  1, Value: (0x00000000) 0
-         cfg_rxclk_phase_sel_B_1 - Addr: 0x00001A7D, Size:  1, Value: (0x00000000) 0
+         cfg_rxclk_phase_sel_B_1 - Addr: 0x00001A7D, Size:  1, Value: (0x00000000) 0 { pll_osc [PLL] [cfg_rxclk_phase_sel_B_1:0] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
          cfg_rxclk_phase_sel_A_0 - Addr: 0x00001A7E, Size:  1, Value: (0x00000000) 0 { pll [PLL] [cfg_rxclk_phase_sel_A_0:0] [from HP_1_CC_18_9P] }
          cfg_rxclk_phase_sel_A_1 - Addr: 0x00001A7F, Size:  1, Value: (0x00000000) 0
            cfg_rx_fclkio_sel_B_0 - Addr: 0x00001A80, Size:  1, Value: (0x00000000) 0
-           cfg_rx_fclkio_sel_B_1 - Addr: 0x00001A81, Size:  1, Value: (0x00000000) 0
+           cfg_rx_fclkio_sel_B_1 - Addr: 0x00001A81, Size:  1, Value: (0x00000000) 0 { pll_osc [PLL] [cfg_rx_fclkio_sel_B_1:0] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
            cfg_rx_fclkio_sel_A_0 - Addr: 0x00001A82, Size:  1, Value: (0x00000000) 0 { pll [PLL] [cfg_rx_fclkio_sel_A_0:0] [from HP_1_CC_18_9P] }
            cfg_rx_fclkio_sel_A_1 - Addr: 0x00001A83, Size:  1, Value: (0x00000000) 0
              cfg_vco_clk_sel_B_0 - Addr: 0x00001A84, Size:  1, Value: (0x00000000) 0
-             cfg_vco_clk_sel_B_1 - Addr: 0x00001A85, Size:  1, Value: (0x00000000) 0
+             cfg_vco_clk_sel_B_1 - Addr: 0x00001A85, Size:  1, Value: (0x00000001) 1 { pll_osc [PLL] [cfg_vco_clk_sel_B_1:1] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
              cfg_vco_clk_sel_A_0 - Addr: 0x00001A86, Size:  1, Value: (0x00000001) 1 { pll [PLL] [cfg_vco_clk_sel_A_0:1] [from HP_1_CC_18_9P] }
              cfg_vco_clk_sel_A_1 - Addr: 0x00001A87, Size:  1, Value: (0x00000000) 0
 Block u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0 []
@@ -3900,34 +3900,34 @@ Block u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0 []
               CDR_CLK_ROOT_SEL_B - Addr: 0x00001A88, Size:  5, Value: (0x00000000) 0
               CDR_CLK_ROOT_SEL_A - Addr: 0x00001A8D, Size:  5, Value: (0x00000000) 0
              CORE_CLK_ROOT_SEL_B - Addr: 0x00001A92, Size:  5, Value: (0x00000000) 0
-             CORE_CLK_ROOT_SEL_A - Addr: 0x00001A97, Size:  5, Value: (0x00000000) 0
+             CORE_CLK_ROOT_SEL_A - Addr: 0x00001A97, Size:  5, Value: (0x00000004) 4 { pll [PLL] [PLL:ROOT_BANK_SRC==A --#MUX=4] [from HP_1_CC_18_9P] }
 Block u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_1 []
   Attributes:
               CDR_CLK_ROOT_SEL_B - Addr: 0x00001A9C, Size:  5, Value: (0x00000000) 0
               CDR_CLK_ROOT_SEL_A - Addr: 0x00001AA1, Size:  5, Value: (0x00000000) 0
-             CORE_CLK_ROOT_SEL_B - Addr: 0x00001AA6, Size:  5, Value: (0x00000000) 0
+             CORE_CLK_ROOT_SEL_B - Addr: 0x00001AA6, Size:  5, Value: (0x00000002) 2 { pll_osc [PLL] [PLL:ROOT_BANK_SRC==B --#MUX=2] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
              CORE_CLK_ROOT_SEL_A - Addr: 0x00001AAB, Size:  5, Value: (0x00000000) 0
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_0 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AB0, Size:  6, Value: (0x00000009) 9 { $clkbuf$top.$ibuf_clk0 [CLK_BUF] [ROOT_MUX_SEL:9] [from HR_1_CC_38_19P] }
+                    ROOT_MUX_SEL - Addr: 0x00001AB0, Size:  6, Value: (0x00000008) 8 { $clkbuf$top.$ibuf_clk0 [CLK_BUF] [ROOT_MUX_SEL:8] [from HR_1_CC_38_19P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_1 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AB6, Size:  6, Value: (0x00000020) 32 { pll [PLL] [ROOT_MUX_SEL:32] [from HP_1_CC_18_9P] }
+                    ROOT_MUX_SEL - Addr: 0x00001AB6, Size:  6, Value: (0x0000003F) 63
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_2 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001ABC, Size:  6, Value: (0x00000013) 19 { $clkbuf$top.$ibuf_clk2 [CLK_BUF] [ROOT_MUX_SEL:19] [from HR_5_CC_38_19P] }
+                    ROOT_MUX_SEL - Addr: 0x00001ABC, Size:  6, Value: (0x0000000A) 10 { pll [PLL] [ROOT_MUX_SEL:10] [from HP_1_CC_18_9P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_3 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AC2, Size:  6, Value: (0x00000024) 36 { pll_osc [PLL] [ROOT_MUX_SEL:36] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
+                    ROOT_MUX_SEL - Addr: 0x00001AC2, Size:  6, Value: (0x00000000) 0 { pll [PLL] [ROOT_MUX_SEL:0] [from HP_1_CC_18_9P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_4 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AC8, Size:  6, Value: (0x0000002C) 44 { $clkbuf$top.clk0_div [FCLK_BUF] [ROOT_MUX_SEL:44] [from __SKIP_LOCATION_CHECK__:FABRIC_CLKBUF#0] }
+                    ROOT_MUX_SEL - Addr: 0x00001AC8, Size:  6, Value: (0x00000003) 3 { pll_osc [PLL] [ROOT_MUX_SEL:3] [from __SKIP_LOCATION_CHECK__:BOOT_CLOCK#0] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_5 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001ACE, Size:  6, Value: (0x0000003F) 63
+                    ROOT_MUX_SEL - Addr: 0x00001ACE, Size:  6, Value: (0x00000013) 19 { $clkbuf$top.$ibuf_clk2 [CLK_BUF] [ROOT_MUX_SEL:19] [from HR_5_CC_38_19P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_6 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AD4, Size:  6, Value: (0x0000003F) 63
+                    ROOT_MUX_SEL - Addr: 0x00001AD4, Size:  6, Value: (0x0000002C) 44 { $clkbuf$top.clk0_div [FCLK_BUF] [ROOT_MUX_SEL:44] [from __SKIP_LOCATION_CHECK__:FABRIC_CLKBUF#0] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_7 []
   Attributes:
                     ROOT_MUX_SEL - Addr: 0x00001ADA, Size:  6, Value: (0x0000003F) 63
@@ -4813,7 +4813,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_3 [HR_1_6_3P]
                     TX_CLK_PHASE - Addr: 0x0000212F, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
                           TX_DLY - Addr: 0x00002131, Size:  6, Value: (0x0000003C) 60 { o_delay [O_DELAY] [TX_DLY:60] }
                      RX_DDR_MODE - Addr: 0x00002137, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
-                       RX_BYPASS - Addr: 0x00002139, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
+                       RX_BYPASS - Addr: 0x00002139, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
                           RX_DLY - Addr: 0x0000213A, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
                      RX_DPA_MODE - Addr: 0x00002140, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
                     RX_MIPI_MODE - Addr: 0x00002142, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout [O_BUFT] [O_BUFT:IOSTANDARD==LVCMOS_18_HR] }
@@ -4857,7 +4857,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_2 [HR_1_4_2P]
                       PEER_IS_ON - Addr: 0x0000217E, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                      TX_CLOCK_IO - Addr: 0x0000217F, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                      TX_DDR_MODE - Addr: 0x00002180, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
-                       TX_BYPASS - Addr: 0x00002182, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
+                       TX_BYPASS - Addr: 0x00002182, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                     TX_CLK_PHASE - Addr: 0x00002183, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                           TX_DLY - Addr: 0x00002185, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
                      RX_DDR_MODE - Addr: 0x0000218B, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din [I_BUF] [I_BUF:IOSTANDARD==LVCMOS_18_HR] }
@@ -5197,7 +5197,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_15 [HR_2_30_15P]
                     TX_CLK_PHASE - Addr: 0x000023CF, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x000023D1, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x000023D7, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x000023D9, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x000023D9, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x000023DA, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x000023E0, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000023E2, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_5 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -5245,7 +5245,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_14 [HR_2_28_14P]
                     TX_CLK_PHASE - Addr: 0x00002423, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002425, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000242B, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x0000242D, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x0000242D, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x0000242E, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00002434, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002436, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_4 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -5293,7 +5293,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_13 [HR_2_26_13P]
                     TX_CLK_PHASE - Addr: 0x00002477, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002479, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000247F, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00002481, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00002481, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00002482, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00002488, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x0000248A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_3 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -5341,7 +5341,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_12 [HR_2_24_12P]
                     TX_CLK_PHASE - Addr: 0x000024CB, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x000024CD, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x000024D3, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x000024D5, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x000024D5, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x000024D6, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x000024DC, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000024DE, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_2 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -5389,7 +5389,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_11 [HR_2_22_11P]
                     TX_CLK_PHASE - Addr: 0x0000251F, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002521, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00002527, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00002529, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00002529, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x0000252A, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00002530, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002532, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap_1 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -5437,7 +5437,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_10 [HR_2_20_10P]
                     TX_CLK_PHASE - Addr: 0x00002573, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002575, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000257B, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x0000257D, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x0000257D, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x0000257E, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00002584, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002586, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_delay_tap [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -5740,52 +5740,52 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_4 [HR_2_8_4P]
                               MC - Addr: 0x00002787, Size:  4, Value: (0x00000000) 0
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_3 [HR_2_7_3N]
   Attributes:
-                            RATE - Addr: 0x0000278B, Size:  4, Value: (0x00000000) 0
-                    MASTER_SLAVE - Addr: 0x0000278F, Size:  1, Value: (0x00000000) 0
-                      PEER_IS_ON - Addr: 0x00002790, Size:  1, Value: (0x00000000) 0
-                     TX_CLOCK_IO - Addr: 0x00002791, Size:  1, Value: (0x00000000) 0
-                     TX_DDR_MODE - Addr: 0x00002792, Size:  2, Value: (0x00000000) 0
-                       TX_BYPASS - Addr: 0x00002794, Size:  1, Value: (0x00000000) 0
-                    TX_CLK_PHASE - Addr: 0x00002795, Size:  2, Value: (0x00000000) 0
+                            RATE - Addr: 0x0000278B, Size:  4, Value: (0x00000003) 3 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                    MASTER_SLAVE - Addr: 0x0000278F, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                      PEER_IS_ON - Addr: 0x00002790, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                     TX_CLOCK_IO - Addr: 0x00002791, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                     TX_DDR_MODE - Addr: 0x00002792, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00002794, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                    TX_CLK_PHASE - Addr: 0x00002795, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002797, Size:  6, Value: (0x00000000) 0
-                     RX_DDR_MODE - Addr: 0x0000279D, Size:  2, Value: (0x00000000) 0
-                       RX_BYPASS - Addr: 0x0000279F, Size:  1, Value: (0x00000000) 0
-                          RX_DLY - Addr: 0x000027A0, Size:  6, Value: (0x00000000) 0
-                     RX_DPA_MODE - Addr: 0x000027A6, Size:  2, Value: (0x00000000) 0
-                    RX_MIPI_MODE - Addr: 0x000027A8, Size:  1, Value: (0x00000000) 0
-                         TX_MODE - Addr: 0x000027A9, Size:  1, Value: (0x00000000) 0
-                         RX_MODE - Addr: 0x000027AA, Size:  1, Value: (0x00000000) 0
-                     RX_CLOCK_IO - Addr: 0x000027AB, Size:  1, Value: (0x00000000) 0
-                            DFEN - Addr: 0x000027AC, Size:  1, Value: (0x00000000) 0
-                              SR - Addr: 0x000027AD, Size:  1, Value: (0x00000000) 0
-                              PE - Addr: 0x000027AE, Size:  1, Value: (0x00000000) 0
-                             PUD - Addr: 0x000027AF, Size:  1, Value: (0x00000000) 0
-                         DFODTEN - Addr: 0x000027B0, Size:  1, Value: (0x00000000) 0
-                              MC - Addr: 0x000027B1, Size:  4, Value: (0x00000000) 0
+                     RX_DDR_MODE - Addr: 0x0000279D, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x0000279F, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x000027A0, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                     RX_DPA_MODE - Addr: 0x000027A6, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                    RX_MIPI_MODE - Addr: 0x000027A8, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x000027A9, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x000027AA, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                     RX_CLOCK_IO - Addr: 0x000027AB, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                            DFEN - Addr: 0x000027AC, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              SR - Addr: 0x000027AD, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x000027AE, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                             PUD - Addr: 0x000027AF, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         DFODTEN - Addr: 0x000027B0, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              MC - Addr: 0x000027B1, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_3 [HR_2_6_3P]
   Attributes:
-                            RATE - Addr: 0x000027B5, Size:  4, Value: (0x00000000) 0
-                    MASTER_SLAVE - Addr: 0x000027B9, Size:  1, Value: (0x00000000) 0
-                      PEER_IS_ON - Addr: 0x000027BA, Size:  1, Value: (0x00000000) 0
-                     TX_CLOCK_IO - Addr: 0x000027BB, Size:  1, Value: (0x00000000) 0
-                     TX_DDR_MODE - Addr: 0x000027BC, Size:  2, Value: (0x00000000) 0
-                       TX_BYPASS - Addr: 0x000027BE, Size:  1, Value: (0x00000000) 0
-                    TX_CLK_PHASE - Addr: 0x000027BF, Size:  2, Value: (0x00000000) 0
-                          TX_DLY - Addr: 0x000027C1, Size:  6, Value: (0x00000000) 0
-                     RX_DDR_MODE - Addr: 0x000027C7, Size:  2, Value: (0x00000000) 0
-                       RX_BYPASS - Addr: 0x000027C9, Size:  1, Value: (0x00000000) 0
+                            RATE - Addr: 0x000027B5, Size:  4, Value: (0x00000003) 3 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                    MASTER_SLAVE - Addr: 0x000027B9, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                      PEER_IS_ON - Addr: 0x000027BA, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                     TX_CLOCK_IO - Addr: 0x000027BB, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                     TX_DDR_MODE - Addr: 0x000027BC, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x000027BE, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                    TX_CLK_PHASE - Addr: 0x000027BF, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x000027C1, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                     RX_DDR_MODE - Addr: 0x000027C7, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x000027C9, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x000027CA, Size:  6, Value: (0x00000000) 0
-                     RX_DPA_MODE - Addr: 0x000027D0, Size:  2, Value: (0x00000000) 0
-                    RX_MIPI_MODE - Addr: 0x000027D2, Size:  1, Value: (0x00000000) 0
-                         TX_MODE - Addr: 0x000027D3, Size:  1, Value: (0x00000000) 0
-                         RX_MODE - Addr: 0x000027D4, Size:  1, Value: (0x00000000) 0
-                     RX_CLOCK_IO - Addr: 0x000027D5, Size:  1, Value: (0x00000000) 0
-                            DFEN - Addr: 0x000027D6, Size:  1, Value: (0x00000000) 0
-                              SR - Addr: 0x000027D7, Size:  1, Value: (0x00000000) 0
-                              PE - Addr: 0x000027D8, Size:  1, Value: (0x00000000) 0
-                             PUD - Addr: 0x000027D9, Size:  1, Value: (0x00000000) 0
-                         DFODTEN - Addr: 0x000027DA, Size:  1, Value: (0x00000000) 0
-                              MC - Addr: 0x000027DB, Size:  4, Value: (0x00000000) 0
+                     RX_DPA_MODE - Addr: 0x000027D0, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                    RX_MIPI_MODE - Addr: 0x000027D2, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x000027D3, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x000027D4, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                     RX_CLOCK_IO - Addr: 0x000027D5, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                            DFEN - Addr: 0x000027D6, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                              SR - Addr: 0x000027D7, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x000027D8, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:WEAK_KEEPER==NONE] }
+                             PUD - Addr: 0x000027D9, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:WEAK_KEEPER==NONE] }
+                         DFODTEN - Addr: 0x000027DA, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                              MC - Addr: 0x000027DB, Size:  4, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_serdes_clk_out [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_2 [HR_2_5_2N]
   Attributes:
                             RATE - Addr: 0x000027DF, Size:  4, Value: (0x00000000) 0
@@ -5821,7 +5821,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_2 [HR_2_4_2P]
                     TX_CLK_PHASE - Addr: 0x00002813, Size:  2, Value: (0x00000003) 3 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT], o_serdes_clk [O_SERDES_CLK] [TX_CLK_PHASE:TX_phase_270] }
                           TX_DLY - Addr: 0x00002815, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000281B, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x0000281D, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x0000281D, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x0000281E, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00002824, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002826, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -5860,16 +5860,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_1 [HR_2_3_1N]
                               MC - Addr: 0x00002859, Size:  4, Value: (0x00000000) 0
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_1 [HR_2_2_1P]
   Attributes:
-                            RATE - Addr: 0x0000285D, Size:  4, Value: (0x00000004) 4 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT], o_serdes [O_SERDES] [RATE:4] }
+                            RATE - Addr: 0x0000285D, Size:  4, Value: (0x00000008) 8 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT], o_serdes [O_SERDES] [RATE:8] }
                     MASTER_SLAVE - Addr: 0x00002861, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                      PEER_IS_ON - Addr: 0x00002862, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT], o_serdes [O_SERDES] [PEER_IS_ON:PEER_on] }
+                      PEER_IS_ON - Addr: 0x00002862, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT], o_serdes [O_SERDES] [PEER_IS_ON:PEER_off] }
                      TX_CLOCK_IO - Addr: 0x00002863, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00002864, Size:  2, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT], o_serdes [O_SERDES] [O_SERDES:DDR_MODE==DDR] }
                        TX_BYPASS - Addr: 0x00002866, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT], o_serdes [O_SERDES] [TX_BYPASS:TX_gear_on] }
                     TX_CLK_PHASE - Addr: 0x00002867, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002869, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000286F, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00002871, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00002871, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00002872, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00002878, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x0000287A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout_serdes [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -5913,7 +5913,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_0 [HR_2_0_0P]
                       PEER_IS_ON - Addr: 0x000028B6, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_serdes [I_SERDES] [PEER_IS_ON:PEER_off] }
                      TX_CLOCK_IO - Addr: 0x000028B7, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x000028B8, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x000028BA, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x000028BA, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x000028BB, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x000028BD, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x000028C3, Size:  2, Value: (0x00000002) 2 { $ibuf$top.$ibuf_din_serdes [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_serdes [I_SERDES] [I_SERDES:DDR_MODE==SDR] }
@@ -5952,11 +5952,11 @@ Block u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_0 []
   Attributes:
               CDR_CLK_ROOT_SEL_B - Addr: 0x000028E9, Size:  5, Value: (0x00000000) 0
               CDR_CLK_ROOT_SEL_A - Addr: 0x000028EE, Size:  5, Value: (0x00000000) 0
-             CORE_CLK_ROOT_SEL_B - Addr: 0x000028F3, Size:  5, Value: (0x00000012) 18 { $clkbuf$top.$ibuf_clk0 [CLK_BUF] [CLK_BUF:ROOT_BANK_SRC==B --#MUX=18] [from HR_1_CC_38_19P] }
-             CORE_CLK_ROOT_SEL_A - Addr: 0x000028F8, Size:  5, Value: (0x00000000) 0
+             CORE_CLK_ROOT_SEL_B - Addr: 0x000028F3, Size:  5, Value: (0x00000000) 0
+             CORE_CLK_ROOT_SEL_A - Addr: 0x000028F8, Size:  5, Value: (0x00000004) 4 { $clkbuf$top.$ibuf_clk0 [CLK_BUF] [CLK_BUF:ROOT_BANK_SRC==A --#MUX=4] [from HR_1_CC_38_19P] }
 Block u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_1 []
   Attributes:
               CDR_CLK_ROOT_SEL_B - Addr: 0x000028FD, Size:  5, Value: (0x00000000) 0
               CDR_CLK_ROOT_SEL_A - Addr: 0x00002902, Size:  5, Value: (0x00000000) 0
              CORE_CLK_ROOT_SEL_B - Addr: 0x00002907, Size:  5, Value: (0x00000000) 0
-             CORE_CLK_ROOT_SEL_A - Addr: 0x0000290C, Size:  5, Value: (0x00000000) 0
+             CORE_CLK_ROOT_SEL_A - Addr: 0x0000290C, Size:  5, Value: (0x00000000) 0 { pll [PLL] [PLL:ROOT_BANK_SRC==A --#MUX=0] [from HP_1_CC_18_9P] }

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.negative.detail.bit
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.negative.detail.bit
@@ -1378,7 +1378,7 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_11 [HR_5_22_11P]
                       PEER_IS_ON - Addr: 0x0000095F, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00000960, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00000961, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00000963, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00000963, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00000964, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00000966, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x0000096C, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr_osc3 [I_DDR] [I_DDR:MODE==DDR] }
@@ -1426,7 +1426,7 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_10 [HR_5_20_10P]
                       PEER_IS_ON - Addr: 0x000009B3, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x000009B4, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x000009B5, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x000009B7, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x000009B7, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x000009B8, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x000009BA, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x000009C0, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr_osc1 [I_DDR] [I_DDR:MODE==DDR] }
@@ -1814,7 +1814,7 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_2 [HR_5_4_2P]
                     TX_CLK_PHASE - Addr: 0x00000C58, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00000C5A, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00000C60, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00000C62, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00000C62, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00000C63, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00000C69, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00000C6B, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -1858,7 +1858,7 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_1 [HR_5_2_1P]
                       PEER_IS_ON - Addr: 0x00000CA7, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00000CA8, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00000CA9, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00000CAB, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00000CAB, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00000CAC, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00000CAE, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00000CB4, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr11 [I_DDR] [I_DDR:MODE==DDR] }
@@ -2944,17 +2944,17 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_19 [HP_1_CC_38_19P]
                       PEER_IS_ON - Addr: 0x00001415, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00001416, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00001417, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00001419, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], $clkbuf$top.$ibuf_clk20 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00001419, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x0000141A, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x0000141C, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00001422, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00001424, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], $clkbuf$top.$ibuf_clk20 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00001424, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001425, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x0000142B, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x0000142D, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x0000142E, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                          RX_MODE - Addr: 0x0000142F, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00001430, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], $clkbuf$top.$ibuf_clk20 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
+                     RX_CLOCK_IO - Addr: 0x00001430, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00001431, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x00001432, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                               PE - Addr: 0x00001433, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:WEAK_KEEPER==NONE] }
@@ -3332,7 +3332,7 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_11 [HP_1_22_11P]
                     TX_CLK_PHASE - Addr: 0x000016BA, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x000016BC, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x000016C2, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x000016C4, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x000016C4, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x000016C5, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x000016CB, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000016CD, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -3376,7 +3376,7 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_10 [HP_1_20_10P]
                       PEER_IS_ON - Addr: 0x00001709, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x0000170A, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x0000170B, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x0000170D, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x0000170D, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x0000170E, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001710, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00001716, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr00 [I_DDR] [I_DDR:MODE==DDR] }
@@ -3899,8 +3899,8 @@ Block u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_0 []
   Attributes:
               CDR_CLK_ROOT_SEL_B - Addr: 0x00001A88, Size:  5, Value: (0x00000000) 0
               CDR_CLK_ROOT_SEL_A - Addr: 0x00001A8D, Size:  5, Value: (0x00000000) 0
-             CORE_CLK_ROOT_SEL_B - Addr: 0x00001A92, Size:  5, Value: (0x00000012) 18 { $clkbuf$top.$ibuf_clk20 [CLK_BUF] [CLK_BUF:ROOT_BANK_SRC==B --#MUX=18] [from HP_1_CC_38_19P] }
-             CORE_CLK_ROOT_SEL_A - Addr: 0x00001A97, Size:  5, Value: (0x00000012) 18 { clk_buf00 [CLK_BUF] [CLK_BUF:ROOT_BANK_SRC==A --#MUX=18] [from HP_1_CC_18_9P] }
+             CORE_CLK_ROOT_SEL_B - Addr: 0x00001A92, Size:  5, Value: (0x00000000) 0 { clk_buf00 [CLK_BUF] [CLK_BUF:ROOT_BANK_SRC==B --#MUX=0] [from HP_1_CC_18_9P] }
+             CORE_CLK_ROOT_SEL_A - Addr: 0x00001A97, Size:  5, Value: (0x00000000) 0
 Block u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_1 []
   Attributes:
               CDR_CLK_ROOT_SEL_B - Addr: 0x00001A9C, Size:  5, Value: (0x00000000) 0
@@ -3909,34 +3909,34 @@ Block u_GBOX_HP_40X2.u_gbox_root_bank_clkmux_1 []
              CORE_CLK_ROOT_SEL_A - Addr: 0x00001AAB, Size:  5, Value: (0x00000000) 0
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_0 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AB0, Size:  6, Value: (0x00000000) 0 { clk_buf00 [CLK_BUF] [ROOT_MUX_SEL:0] [from HP_1_CC_18_9P] }
+                    ROOT_MUX_SEL - Addr: 0x00001AB0, Size:  6, Value: (0x00000001) 1 { clk_buf00 [CLK_BUF] [ROOT_MUX_SEL:1] [from HP_1_CC_18_9P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_1 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AB6, Size:  6, Value: (0x00000020) 32 { pll00 [PLL] [ROOT_MUX_SEL:32] [from HP_1_CC_18_9P] }
+                    ROOT_MUX_SEL - Addr: 0x00001AB6, Size:  6, Value: (0x00000009) 9 { pll00 [PLL] [ROOT_MUX_SEL:9] [from HP_1_CC_18_9P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_2 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001ABC, Size:  6, Value: (0x00000021) 33 { pll00 [PLL] [ROOT_MUX_SEL:33] [from HP_1_CC_18_9P] }
+                    ROOT_MUX_SEL - Addr: 0x00001ABC, Size:  6, Value: (0x0000003F) 63
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_3 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AC2, Size:  6, Value: (0x00000022) 34 { pll00 [PLL] [ROOT_MUX_SEL:34] [from HP_1_CC_18_9P] }
+                    ROOT_MUX_SEL - Addr: 0x00001AC2, Size:  6, Value: (0x0000003F) 63
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_4 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AC8, Size:  6, Value: (0x00000023) 35 { pll00 [PLL] [ROOT_MUX_SEL:35] [from HP_1_CC_18_9P] }
+                    ROOT_MUX_SEL - Addr: 0x00001AC8, Size:  6, Value: (0x0000003F) 63
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_5 []
   Attributes:
                     ROOT_MUX_SEL - Addr: 0x00001ACE, Size:  6, Value: (0x0000003F) 63
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_6 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AD4, Size:  6, Value: (0x00000001) 1 { $clkbuf$top.$ibuf_clk20 [CLK_BUF] [ROOT_MUX_SEL:1] [from HP_1_CC_38_19P] }
+                    ROOT_MUX_SEL - Addr: 0x00001AD4, Size:  6, Value: (0x0000003F) 63
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_7 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001ADA, Size:  6, Value: (0x0000003F) 63
+                    ROOT_MUX_SEL - Addr: 0x00001ADA, Size:  6, Value: (0x00000021) 33 { pll00 [PLL] [ROOT_MUX_SEL:33] [from HP_1_CC_18_9P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_8 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AE0, Size:  6, Value: (0x0000003F) 63
+                    ROOT_MUX_SEL - Addr: 0x00001AE0, Size:  6, Value: (0x00000022) 34 { pll00 [PLL] [ROOT_MUX_SEL:34] [from HP_1_CC_18_9P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_9 []
   Attributes:
-                    ROOT_MUX_SEL - Addr: 0x00001AE6, Size:  6, Value: (0x0000003F) 63
+                    ROOT_MUX_SEL - Addr: 0x00001AE6, Size:  6, Value: (0x00000023) 35 { pll00 [PLL] [ROOT_MUX_SEL:35] [from HP_1_CC_18_9P] }
 Block u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left_10 []
   Attributes:
                     ROOT_MUX_SEL - Addr: 0x00001AEC, Size:  6, Value: (0x0000003F) 63
@@ -4233,7 +4233,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_15 [HR_1_30_15P]
                       PEER_IS_ON - Addr: 0x00001D3A, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00001D3B, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00001D3C, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00001D3E, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00001D3E, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001D3F, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001D41, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00001D47, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr_osc4 [I_DDR] [I_DDR:MODE==DDR] }
@@ -4333,7 +4333,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_13 [HR_1_26_13P]
                     TX_CLK_PHASE - Addr: 0x00001DE7, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001DE9, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001DEF, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00001DF1, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00001DF1, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001DF2, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00001DF8, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001DFA, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -4377,7 +4377,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_12 [HR_1_24_12P]
                       PEER_IS_ON - Addr: 0x00001E36, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00001E37, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00001E38, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00001E3A, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00001E3A, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001E3B, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001E3D, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00001E43, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr12 [I_DDR] [I_DDR:MODE==DDR] }
@@ -4429,7 +4429,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_11 [HR_1_22_11P]
                     TX_CLK_PHASE - Addr: 0x00001E8F, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001E91, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001E97, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00001E99, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00001E99, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001E9A, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00001EA0, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001EA2, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -4473,7 +4473,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_10 [HR_1_20_10P]
                       PEER_IS_ON - Addr: 0x00001EDE, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00001EDF, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00001EE0, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00001EE2, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00001EE2, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001EE3, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001EE5, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00001EEB, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr01 [I_DDR] [I_DDR:MODE==DDR] }
@@ -4521,7 +4521,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_9 [HR_1_CC_18_9P]
                       PEER_IS_ON - Addr: 0x00001F32, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00001F33, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00001F34, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00001F36, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00001F36, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001F37, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00001F39, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00001F3F, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -5001,7 +5001,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_19 [HR_2_CC_38_19P]
                       PEER_IS_ON - Addr: 0x0000227A, Size:  1, Value: (0x00000001) 1 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x0000227B, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x0000227C, Size:  2, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x0000227E, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x0000227E, Size:  1, Value: (0x00000001) 1 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x0000227F, Size:  2, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002281, Size:  6, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00002287, Size:  2, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -5389,7 +5389,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_11 [HR_2_22_11P]
                     TX_CLK_PHASE - Addr: 0x0000251F, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002521, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00002527, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00002529, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00002529, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x0000252A, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x00002530, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002532, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -5433,7 +5433,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_10 [HR_2_20_10P]
                       PEER_IS_ON - Addr: 0x0000256E, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x0000256F, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00002570, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00002572, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00002572, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00002573, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002575, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x0000257B, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr_osc0 [I_DDR] [I_DDR:MODE==DDR] }
@@ -5692,28 +5692,28 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_5 [HR_2_10_5P]
                               MC - Addr: 0x00002733, Size:  4, Value: (0x00000000) 0
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_4 [HR_2_9_4N]
   Attributes:
-                            RATE - Addr: 0x00002737, Size:  4, Value: (0x00000000) 0
-                    MASTER_SLAVE - Addr: 0x0000273B, Size:  1, Value: (0x00000000) 0
-                      PEER_IS_ON - Addr: 0x0000273C, Size:  1, Value: (0x00000000) 0
-                     TX_CLOCK_IO - Addr: 0x0000273D, Size:  1, Value: (0x00000000) 0
-                     TX_DDR_MODE - Addr: 0x0000273E, Size:  2, Value: (0x00000000) 0
-                       TX_BYPASS - Addr: 0x00002740, Size:  1, Value: (0x00000000) 0
-                    TX_CLK_PHASE - Addr: 0x00002741, Size:  2, Value: (0x00000000) 0
+                            RATE - Addr: 0x00002737, Size:  4, Value: (0x00000003) 3 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                    MASTER_SLAVE - Addr: 0x0000273B, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                      PEER_IS_ON - Addr: 0x0000273C, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                     TX_CLOCK_IO - Addr: 0x0000273D, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                     TX_DDR_MODE - Addr: 0x0000273E, Size:  2, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT], o_serdes_clk_osc [O_SERDES_CLK] [O_SERDES_CLK:DDR_MODE==DDR] }
+                       TX_BYPASS - Addr: 0x00002740, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                    TX_CLK_PHASE - Addr: 0x00002741, Size:  2, Value: (0x00000002) 2 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT], o_serdes_clk_osc [O_SERDES_CLK] [TX_CLK_PHASE:TX_phase_180] }
                           TX_DLY - Addr: 0x00002743, Size:  6, Value: (0x00000000) 0
-                     RX_DDR_MODE - Addr: 0x00002749, Size:  2, Value: (0x00000000) 0
-                       RX_BYPASS - Addr: 0x0000274B, Size:  1, Value: (0x00000000) 0
-                          RX_DLY - Addr: 0x0000274C, Size:  6, Value: (0x00000000) 0
-                     RX_DPA_MODE - Addr: 0x00002752, Size:  2, Value: (0x00000000) 0
-                    RX_MIPI_MODE - Addr: 0x00002754, Size:  1, Value: (0x00000000) 0
-                         TX_MODE - Addr: 0x00002755, Size:  1, Value: (0x00000000) 0
-                         RX_MODE - Addr: 0x00002756, Size:  1, Value: (0x00000000) 0
-                     RX_CLOCK_IO - Addr: 0x00002757, Size:  1, Value: (0x00000000) 0
-                            DFEN - Addr: 0x00002758, Size:  1, Value: (0x00000000) 0
-                              SR - Addr: 0x00002759, Size:  1, Value: (0x00000000) 0
-                              PE - Addr: 0x0000275A, Size:  1, Value: (0x00000000) 0
-                             PUD - Addr: 0x0000275B, Size:  1, Value: (0x00000000) 0
-                         DFODTEN - Addr: 0x0000275C, Size:  1, Value: (0x00000000) 0
-                              MC - Addr: 0x0000275D, Size:  4, Value: (0x00000000) 0
+                     RX_DDR_MODE - Addr: 0x00002749, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x0000274B, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x0000274C, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                     RX_DPA_MODE - Addr: 0x00002752, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                    RX_MIPI_MODE - Addr: 0x00002754, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00002755, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00002756, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                     RX_CLOCK_IO - Addr: 0x00002757, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                            DFEN - Addr: 0x00002758, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              SR - Addr: 0x00002759, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x0000275A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                             PUD - Addr: 0x0000275B, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         DFODTEN - Addr: 0x0000275C, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              MC - Addr: 0x0000275D, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_4 [HR_2_8_4P]
   Attributes:
                             RATE - Addr: 0x00002761, Size:  4, Value: (0x00000003) 3 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -5725,7 +5725,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_4 [HR_2_8_4P]
                     TX_CLK_PHASE - Addr: 0x0000276B, Size:  2, Value: (0x00000003) 3 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT], o_serdes_clk [O_SERDES_CLK] [TX_CLK_PHASE:TX_phase_270] }
                           TX_DLY - Addr: 0x0000276D, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00002773, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                       RX_BYPASS - Addr: 0x00002775, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                       RX_BYPASS - Addr: 0x00002775, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00002776, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                      RX_DPA_MODE - Addr: 0x0000277C, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x0000277E, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
@@ -5841,7 +5841,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_1 [HR_2_3_1N]
                       PEER_IS_ON - Addr: 0x00002838, Size:  1, Value: (0x00000001) 1 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00002839, Size:  1, Value: (0x00000000) 0 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x0000283A, Size:  2, Value: (0x00000000) 0 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x0000283C, Size:  1, Value: (0x00000000) 0 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x0000283C, Size:  1, Value: (0x00000001) 1 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x0000283D, Size:  2, Value: (0x00000000) 0 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x0000283F, Size:  6, Value: (0x00000000) 0 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00002845, Size:  2, Value: (0x00000001) 1 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT], i_ddr31 [I_DDR] [I_DDR:MODE==DDR] }
@@ -5865,7 +5865,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_1 [HR_2_2_1P]
                       PEER_IS_ON - Addr: 0x00002862, Size:  1, Value: (0x00000001) 1 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x00002863, Size:  1, Value: (0x00000000) 0 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x00002864, Size:  2, Value: (0x00000000) 0 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00002866, Size:  1, Value: (0x00000000) 0 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00002866, Size:  1, Value: (0x00000001) 1 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00002867, Size:  2, Value: (0x00000000) 0 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002869, Size:  6, Value: (0x00000000) 0 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x0000286F, Size:  2, Value: (0x00000001) 1 { i_buf_ds31 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT], i_ddr31 [I_DDR] [I_DDR:MODE==DDR] }
@@ -5889,7 +5889,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_0 [HR_2_1_0N]
                       PEER_IS_ON - Addr: 0x0000288C, Size:  1, Value: (0x00000001) 1 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x0000288D, Size:  1, Value: (0x00000000) 0 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x0000288E, Size:  2, Value: (0x00000000) 0 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x00002890, Size:  1, Value: (0x00000000) 0 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x00002890, Size:  1, Value: (0x00000001) 1 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00002891, Size:  2, Value: (0x00000000) 0 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x00002893, Size:  6, Value: (0x00000000) 0 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x00002899, Size:  2, Value: (0x00000001) 1 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT], i_ddr30 [I_DDR] [I_DDR:MODE==DDR] }
@@ -5913,7 +5913,7 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_0 [HR_2_0_0P]
                       PEER_IS_ON - Addr: 0x000028B6, Size:  1, Value: (0x00000001) 1 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_CLOCK_IO - Addr: 0x000028B7, Size:  1, Value: (0x00000000) 0 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      TX_DDR_MODE - Addr: 0x000028B8, Size:  2, Value: (0x00000000) 0 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
-                       TX_BYPASS - Addr: 0x000028BA, Size:  1, Value: (0x00000000) 0 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
+                       TX_BYPASS - Addr: 0x000028BA, Size:  1, Value: (0x00000001) 1 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x000028BB, Size:  2, Value: (0x00000000) 0 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                           TX_DLY - Addr: 0x000028BD, Size:  6, Value: (0x00000000) 0 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT] }
                      RX_DDR_MODE - Addr: 0x000028C3, Size:  2, Value: (0x00000001) 1 { i_buf_ds30 [I_BUF_DS] [I_BUF_DS:IOSTANDARD==DEFAULT], i_ddr30 [I_DDR] [I_DDR:MODE==DDR] }
@@ -5952,7 +5952,7 @@ Block u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_0 []
   Attributes:
               CDR_CLK_ROOT_SEL_B - Addr: 0x000028E9, Size:  5, Value: (0x00000000) 0
               CDR_CLK_ROOT_SEL_A - Addr: 0x000028EE, Size:  5, Value: (0x00000000) 0
-             CORE_CLK_ROOT_SEL_B - Addr: 0x000028F3, Size:  5, Value: (0x00000000) 0
+             CORE_CLK_ROOT_SEL_B - Addr: 0x000028F3, Size:  5, Value: (0x00000000) 0 { pll00 [PLL] [PLL:ROOT_BANK_SRC==B --#MUX=0] [from HP_1_CC_18_9P] }
              CORE_CLK_ROOT_SEL_A - Addr: 0x000028F8, Size:  5, Value: (0x00000000) 0
 Block u_GBOX_HV_40X2_VL.u_gbox_root_bank_clkmux_1 []
   Attributes:

--- a/tests/unittest/ModelConfig/golden/model_config_io_bitstream.negative.detail.bit
+++ b/tests/unittest/ModelConfig/golden/model_config_io_bitstream.negative.detail.bit
@@ -36,13 +36,13 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK0_A_19 [HR_3_CC_38_19P]
                      TX_DDR_MODE - Addr: 0x00000031, Size:  2, Value: (0x00000000) 0 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00000033, Size:  1, Value: (0x00000001) 1 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], clk_buf31 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00000034, Size:  2, Value: (0x00000000) 0 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00000036, Size:  6, Value: (0x00000000) 0 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00000036, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000003C, Size:  2, Value: (0x00000000) 0 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x0000003E, Size:  1, Value: (0x00000001) 1 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], clk_buf31 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                           RX_DLY - Addr: 0x0000003F, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00000045, Size:  2, Value: (0x00000000) 0 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00000047, Size:  1, Value: (0x00000000) 0 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00000048, Size:  1, Value: (0x00000000) 0 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00000048, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00000049, Size:  1, Value: (0x00000001) 1 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x0000004A, Size:  1, Value: (0x00000001) 1 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], clk_buf31 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                             DFEN - Addr: 0x0000004B, Size:  1, Value: (0x00000000) 0 { i_buf31 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -1380,13 +1380,13 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_11 [HR_5_22_11P]
                      TX_DDR_MODE - Addr: 0x00000961, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00000963, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00000964, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00000966, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00000966, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000096C, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr_osc3 [I_DDR] [I_DDR:MODE==DDR] }
                        RX_BYPASS - Addr: 0x0000096E, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x0000096F, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00000975, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00000977, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00000978, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00000978, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00000979, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x0000097A, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x0000097B, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc3 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -1428,13 +1428,13 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_10 [HR_5_20_10P]
                      TX_DDR_MODE - Addr: 0x000009B5, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x000009B7, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x000009B8, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x000009BA, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x000009BA, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x000009C0, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr_osc1 [I_DDR] [I_DDR:MODE==DDR] }
                        RX_BYPASS - Addr: 0x000009C2, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x000009C3, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x000009C9, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000009CB, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x000009CC, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x000009CC, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x000009CD, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x000009CE, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x000009CF, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc1 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -1815,16 +1815,16 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_2 [HR_5_4_2P]
                           TX_DLY - Addr: 0x00000C5A, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00000C60, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00000C62, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x00000C63, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x00000C63, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00000C69, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00000C6B, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x00000C6C, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x00000C6D, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00000C6E, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00000C6D, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00000C6E, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x00000C6F, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x00000C70, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x00000C71, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x00000C72, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00000C71, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x00000C72, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x00000C73, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x00000C74, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_dout11 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_B_1 [HR_5_3_1N]
@@ -1860,13 +1860,13 @@ Block u_GBOX_HV_40X2_VR.u_HV_GBOX_BK1_A_1 [HR_5_2_1P]
                      TX_DDR_MODE - Addr: 0x00000CA9, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00000CAB, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00000CAC, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00000CAE, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00000CAE, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00000CB4, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr11 [I_DDR] [I_DDR:MODE==DDR] }
                        RX_BYPASS - Addr: 0x00000CB6, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00000CB7, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00000CBD, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00000CBF, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00000CC0, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00000CC0, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00000CC1, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00000CC2, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00000CC3, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din11 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -2946,13 +2946,13 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_19 [HP_1_CC_38_19P]
                      TX_DDR_MODE - Addr: 0x00001417, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00001419, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x0000141A, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x0000141C, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x0000141C, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001422, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00001424, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001425, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x0000142B, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x0000142D, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x0000142E, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x0000142E, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x0000142F, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00001430, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00001431, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk20 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -3333,16 +3333,16 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_11 [HP_1_22_11P]
                           TX_DLY - Addr: 0x000016BC, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x000016C2, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x000016C4, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x000016C5, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x000016C5, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x000016CB, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x000016CD, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x000016CE, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x000016CF, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x000016D0, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x000016CF, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x000016D0, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x000016D1, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x000016D2, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x000016D3, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x000016D4, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x000016D3, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x000016D4, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x000016D5, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x000016D6, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_dout00 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_B_10 [HP_1_21_10N]
@@ -3378,13 +3378,13 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_10 [HP_1_20_10P]
                      TX_DDR_MODE - Addr: 0x0000170B, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x0000170D, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x0000170E, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00001710, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00001710, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001716, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr00 [I_DDR] [I_DDR:MODE==DDR] }
                        RX_BYPASS - Addr: 0x00001718, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001719, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x0000171F, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001721, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00001722, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00001722, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00001723, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00001724, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00001725, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -3426,13 +3426,13 @@ Block u_GBOX_HP_40X2.u_HP_GBOX_BK0_A_9 [HP_1_CC_18_9P]
                      TX_DDR_MODE - Addr: 0x0000175F, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00001761, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], clk_buf00 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001762, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00001764, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00001764, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000176A, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x0000176C, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], clk_buf00 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                           RX_DLY - Addr: 0x0000176D, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001773, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001775, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00001776, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00001776, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00001777, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00001778, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], clk_buf00 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                             DFEN - Addr: 0x00001779, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk00 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -4043,13 +4043,13 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_19 [HR_1_CC_38_19P]
                      TX_DDR_MODE - Addr: 0x00001BEC, Size:  2, Value: (0x00000000) 0 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00001BEE, Size:  1, Value: (0x00000001) 1 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], clk_buf30 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001BEF, Size:  2, Value: (0x00000000) 0 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00001BF1, Size:  6, Value: (0x00000000) 0 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00001BF1, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001BF7, Size:  2, Value: (0x00000000) 0 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00001BF9, Size:  1, Value: (0x00000001) 1 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], clk_buf30 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                           RX_DLY - Addr: 0x00001BFA, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001C00, Size:  2, Value: (0x00000000) 0 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001C02, Size:  1, Value: (0x00000000) 0 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00001C03, Size:  1, Value: (0x00000000) 0 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00001C03, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00001C04, Size:  1, Value: (0x00000001) 1 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00001C05, Size:  1, Value: (0x00000001) 1 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], clk_buf30 [CLK_BUF] [CLK_BUF:GBOX_TOP_SRC==DEFAULT] }
                             DFEN - Addr: 0x00001C06, Size:  1, Value: (0x00000000) 0 { i_buf30 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -4235,13 +4235,13 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_15 [HR_1_30_15P]
                      TX_DDR_MODE - Addr: 0x00001D3C, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00001D3E, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001D3F, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00001D41, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00001D41, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001D47, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr_osc4 [I_DDR] [I_DDR:MODE==DDR] }
                        RX_BYPASS - Addr: 0x00001D49, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001D4A, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001D50, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001D52, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00001D53, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00001D53, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00001D54, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00001D55, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00001D56, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc4 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -4334,16 +4334,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_13 [HR_1_26_13P]
                           TX_DLY - Addr: 0x00001DE9, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001DEF, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00001DF1, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x00001DF2, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x00001DF2, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001DF8, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001DFA, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x00001DFB, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x00001DFC, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00001DFD, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00001DFC, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00001DFD, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x00001DFE, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x00001DFF, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x00001E00, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x00001E01, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00001E00, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x00001E01, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x00001E02, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x00001E03, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_dout12 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_B_12 [HR_1_25_12N]
@@ -4379,13 +4379,13 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_12 [HR_1_24_12P]
                      TX_DDR_MODE - Addr: 0x00001E38, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00001E3A, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001E3B, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00001E3D, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00001E3D, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001E43, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr12 [I_DDR] [I_DDR:MODE==DDR] }
                        RX_BYPASS - Addr: 0x00001E45, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001E46, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001E4C, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001E4E, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00001E4F, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00001E4F, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00001E50, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00001E51, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00001E52, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din12 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -4430,16 +4430,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_11 [HR_1_22_11P]
                           TX_DLY - Addr: 0x00001E91, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001E97, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00001E99, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x00001E9A, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x00001E9A, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001EA0, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001EA2, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x00001EA3, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x00001EA4, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00001EA5, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00001EA4, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00001EA5, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x00001EA6, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x00001EA7, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x00001EA8, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x00001EA9, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00001EA8, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x00001EA9, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x00001EAA, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x00001EAB, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_dout01 [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_B_10 [HR_1_21_10N]
@@ -4475,13 +4475,13 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_10 [HR_1_20_10P]
                      TX_DDR_MODE - Addr: 0x00001EE0, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00001EE2, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001EE3, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00001EE5, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00001EE5, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001EEB, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr01 [I_DDR] [I_DDR:MODE==DDR] }
                        RX_BYPASS - Addr: 0x00001EED, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001EEE, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001EF4, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001EF6, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00001EF7, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00001EF7, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00001EF8, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00001EF9, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00001EFA, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_din01 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -4523,13 +4523,13 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK0_A_9 [HR_1_CC_18_9P]
                      TX_DDR_MODE - Addr: 0x00001F34, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00001F36, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00001F37, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00001F39, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00001F39, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00001F3F, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00001F41, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x00001F42, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00001F48, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00001F4A, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00001F4B, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00001F4B, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00001F4C, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00001F4D, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00001F4E, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_clk10 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -5003,13 +5003,13 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_19 [HR_2_CC_38_19P]
                      TX_DDR_MODE - Addr: 0x0000227C, Size:  2, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x0000227E, Size:  1, Value: (0x00000001) 1 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x0000227F, Size:  2, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00002281, Size:  6, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00002281, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00002287, Size:  2, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00002289, Size:  1, Value: (0x00000001) 1 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x0000228A, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00002290, Size:  2, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002292, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00002293, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00002293, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00002294, Size:  1, Value: (0x00000001) 1 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00002295, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x00002296, Size:  1, Value: (0x00000000) 0 { i_buf40 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -5390,16 +5390,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_11 [HR_2_22_11P]
                           TX_DLY - Addr: 0x00002521, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00002527, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00002529, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x0000252A, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x0000252A, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00002530, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002532, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x00002533, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x00002534, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00002535, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00002534, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00002535, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x00002536, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x00002537, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x00002538, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x00002539, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00002538, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x00002539, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x0000253A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x0000253B, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_dinoutosc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_10 [HR_2_21_10N]
@@ -5435,13 +5435,13 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_10 [HR_2_20_10P]
                      TX_DDR_MODE - Addr: 0x00002570, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                        TX_BYPASS - Addr: 0x00002572, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     TX_CLK_PHASE - Addr: 0x00002573, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                          TX_DLY - Addr: 0x00002575, Size:  6, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                          TX_DLY - Addr: 0x00002575, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x0000257B, Size:  2, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT], i_ddr_osc0 [I_DDR] [I_DDR:MODE==DDR] }
                        RX_BYPASS - Addr: 0x0000257D, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                           RX_DLY - Addr: 0x0000257E, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00002584, Size:  2, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002586, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
-                         TX_MODE - Addr: 0x00002587, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
+                         TX_MODE - Addr: 0x00002587, Size:  1, Value: (0x00000000) 0
                          RX_MODE - Addr: 0x00002588, Size:  1, Value: (0x00000001) 1 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                      RX_CLOCK_IO - Addr: 0x00002589, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
                             DFEN - Addr: 0x0000258A, Size:  1, Value: (0x00000000) 0 { $ibuf$top.$ibuf_dinosc0 [I_BUF] [I_BUF:IOSTANDARD==DEFAULT] }
@@ -5702,16 +5702,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_4 [HR_2_9_4N]
                           TX_DLY - Addr: 0x00002743, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00002749, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x0000274B, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x0000274C, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x0000274C, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x00002752, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x00002754, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x00002755, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x00002756, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00002757, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00002756, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00002757, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x00002758, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x00002759, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x0000275A, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x0000275B, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x0000275A, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x0000275B, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x0000275C, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x0000275D, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out_osc [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_4 [HR_2_8_4P]
@@ -5726,16 +5726,16 @@ Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_A_4 [HR_2_8_4P]
                           TX_DLY - Addr: 0x0000276D, Size:  6, Value: (0x00000000) 0
                      RX_DDR_MODE - Addr: 0x00002773, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                        RX_BYPASS - Addr: 0x00002775, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                          RX_DLY - Addr: 0x00002776, Size:  6, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                          RX_DLY - Addr: 0x00002776, Size:  6, Value: (0x00000000) 0
                      RX_DPA_MODE - Addr: 0x0000277C, Size:  2, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                     RX_MIPI_MODE - Addr: 0x0000277E, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                          TX_MODE - Addr: 0x0000277F, Size:  1, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                         RX_MODE - Addr: 0x00002780, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                     RX_CLOCK_IO - Addr: 0x00002781, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                         RX_MODE - Addr: 0x00002780, Size:  1, Value: (0x00000000) 0
+                     RX_CLOCK_IO - Addr: 0x00002781, Size:  1, Value: (0x00000000) 0
                             DFEN - Addr: 0x00002782, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               SR - Addr: 0x00002783, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                              PE - Addr: 0x00002784, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
-                             PUD - Addr: 0x00002785, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
+                              PE - Addr: 0x00002784, Size:  1, Value: (0x00000000) 0
+                             PUD - Addr: 0x00002785, Size:  1, Value: (0x00000000) 0
                          DFODTEN - Addr: 0x00002786, Size:  1, Value: (0x00000000) 0 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
                               MC - Addr: 0x00002787, Size:  4, Value: (0x00000001) 1 { $obuf$top.$obuf_clk_out [O_BUFT] [O_BUFT:IOSTANDARD==DEFAULT] }
 Block u_GBOX_HV_40X2_VL.u_HV_GBOX_BK1_B_3 [HR_2_7_3N]

--- a/tests/unittest/ModelConfig/model_config_netlist.negative.ppdb.json
+++ b/tests/unittest/ModelConfig/model_config_netlist.negative.ppdb.json
@@ -38,116 +38,116 @@
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_clk00",
     "      Cell port \\I is connected to input port \\clk00",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_clk10",
     "      Cell port \\I is connected to input port \\clk10",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_clk20",
     "      Cell port \\I is connected to input port \\clk20",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_din00",
     "      Cell port \\I is connected to input port \\din00",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_din01",
     "      Cell port \\I is connected to input port \\din01",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_din10",
     "      Cell port \\I is connected to input port \\din10",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_din11",
     "      Cell port \\I is connected to input port \\din11",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_din12",
     "      Cell port \\I is connected to input port \\din12",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_din20",
     "      Cell port \\I is connected to input port \\din20",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_dinosc0",
     "      Cell port \\I is connected to input port \\dinosc0",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_dinosc1",
     "      Cell port \\I is connected to input port \\dinosc1",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_dinosc2",
     "      Cell port \\I is connected to input port \\dinosc2",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_dinosc3",
     "      Cell port \\I is connected to input port \\dinosc3",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_dinosc4",
     "      Cell port \\I is connected to input port \\dinosc4",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_clk_out",
     "      Cell port \\O is connected to output port \\clk_out",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_clk_out_osc",
     "      Cell port \\O is connected to output port \\clk_out_osc",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_dinoutosc",
     "      Cell port \\O is connected to output port \\dinoutosc",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_dout00",
     "      Cell port \\O is connected to output port \\dout00",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_dout01",
     "      Cell port \\O is connected to output port \\dout01",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_dout10",
     "      Cell port \\O is connected to output port \\dout10",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_dout11",
     "      Cell port \\O is connected to output port \\dout11",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_dout12",
     "      Cell port \\O is connected to output port \\dout12",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_dout20",
     "      Cell port \\O is connected to output port \\dout20",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\BOOT_CLOCK \\boot_clock",
     "        Parameter \\PERIOD: 25",
     "        Data Width: -2",
     "    Get important connection of cell \\I_BUF \\i_buf30",
     "      Cell port \\I is connected to input port \\clk30",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF \\i_buf31",
     "      Cell port \\I is connected to input port \\clk31",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF \\i_buf40",
     "      Cell port \\I is connected to input port \\clk40",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF_DS \\i_buf_ds30",
     "      Cell port \\I_N is connected to input port \\din30_n",
     "      Cell port \\I_P is connected to input port \\din30_p",
     "        Parameter \\DIFFERENTIAL_TERMINATION: \"TRUE\"",
     "        Parameter \\IOSTANDARD: \"DEFAULT\"",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF_DS \\i_buf_ds31",
     "      Cell port \\I_N is connected to input port \\din31_n",
     "      Cell port \\I_P is connected to input port \\din31_p",
     "        Parameter \\DIFFERENTIAL_TERMINATION: \"TRUE\"",
     "        Parameter \\IOSTANDARD: \"DEFAULT\"",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUF_DS \\o_buf_ds",
     "      Cell port \\O_N is connected to output port \\dout30_n",
     "      Cell port \\O_P is connected to output port \\dout30_p",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "  Trace \\I_BUF --> \\CLK_BUF",
     "    Try \\I_BUF $ibuf$top.$ibuf_clk00 out connection: $ibuf_clk00 -> \\clk_buf00",
     "      Connected \\clk_buf00",
@@ -228,43 +228,43 @@
     "  Trace \\I_BUF --> \\I_DDR",
     "    Try \\I_BUF $ibuf$top.$ibuf_din00 out connection: $ibuf_din00 -> \\i_ddr00",
     "      Connected \\i_ddr00",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\I_BUF $ibuf$top.$ibuf_din01 out connection: $ibuf_din01 -> \\i_ddr01",
     "      Connected \\i_ddr01",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\I_BUF $ibuf$top.$ibuf_din10 out connection: $ibuf_din10 -> \\i_ddr10",
     "      Connected \\i_ddr10",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\I_BUF $ibuf$top.$ibuf_din11 out connection: $ibuf_din11 -> \\i_ddr11",
     "      Connected \\i_ddr11",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\I_BUF $ibuf$top.$ibuf_din12 out connection: $ibuf_din12 -> \\i_ddr12",
     "      Connected \\i_ddr12",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\I_BUF $ibuf$top.$ibuf_dinosc0 out connection: $ibuf_dinosc0 -> \\i_ddr_osc0",
     "      Connected \\i_ddr_osc0",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\I_BUF $ibuf$top.$ibuf_dinosc1 out connection: $ibuf_dinosc1 -> \\i_ddr_osc1",
     "      Connected \\i_ddr_osc1",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\I_BUF $ibuf$top.$ibuf_dinosc2 out connection: $ibuf_dinosc2 -> \\i_ddr_osc2",
     "      Connected \\i_ddr_osc2",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\I_BUF $ibuf$top.$ibuf_dinosc3 out connection: $ibuf_dinosc3 -> \\i_ddr_osc3",
     "      Connected \\i_ddr_osc3",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\I_BUF $ibuf$top.$ibuf_dinosc4 out connection: $ibuf_dinosc4 -> \\i_ddr_osc4",
     "      Connected \\i_ddr_osc4",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "  Trace \\I_BUF --> \\I_SERDES",
     "  Trace \\I_BUF_DS --> \\I_DELAY",
     "  Trace \\I_BUF_DS --> \\I_DDR",
     "    Try \\I_BUF_DS \\i_buf_ds30 out connection: \\din30_ds -> \\i_ddr30",
     "      Connected \\i_ddr30",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\I_BUF_DS \\i_buf_ds31 out connection: \\din31_ds -> \\i_ddr31",
     "      Connected \\i_ddr31",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "  Trace \\I_BUF_DS --> \\I_SERDES",
     "  Trace \\I_DELAY --> \\I_DDR",
     "  Trace \\I_DELAY --> \\I_SERDES",
@@ -275,25 +275,25 @@
     "  Trace \\O_BUFT --> \\O_DDR",
     "    Try \\O_BUFT $obuf$top.$obuf_dout00 out connection: $obuf_dout00 -> \\o_ddr00",
     "      Connected \\o_ddr00",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\O_BUFT $obuf$top.$obuf_dout01 out connection: $obuf_dout01 -> \\o_ddr01",
     "      Connected \\o_ddr01",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\O_BUFT $obuf$top.$obuf_dout10 out connection: $obuf_dout10 -> \\o_ddr10",
     "      Connected \\o_ddr10",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\O_BUFT $obuf$top.$obuf_dout11 out connection: $obuf_dout11 -> \\o_ddr11",
     "      Connected \\o_ddr11",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\O_BUFT $obuf$top.$obuf_dout12 out connection: $obuf_dout12 -> \\o_ddr12",
     "      Connected \\o_ddr12",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "  Trace \\O_BUFT --> \\O_SERDES",
     "  Trace \\O_BUF_DS --> \\O_DELAY",
     "  Trace \\O_BUF_DS --> \\O_DDR",
     "    Try \\O_BUF_DS \\o_buf_ds out connection: \\dout_oddr3x -> \\o_ddr3x",
     "      Connected \\o_ddr3x",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "  Trace \\O_BUF_DS --> \\O_SERDES",
     "  Trace \\O_BUFT_DS --> \\O_DELAY",
     "  Trace \\O_BUFT_DS --> \\O_DDR",
@@ -315,129 +315,158 @@
     "  Trace \\O_BUF_DS --> \\O_SERDES_CLK",
     "  Trace \\O_BUFT_DS --> \\O_SERDES_CLK",
     "  Trace fabric clock buffer",
-    "  Trace gearbox clock source",
-    "    \\I_DDR \\i_ddr00 port \\C: \\clkbuf00",
-    "      Connected to \\CLK_BUF \\clk_buf00 port \\O",
-    "    \\I_DDR \\i_ddr01 port \\C: \\pll00_clk1",
-    "      Connected to \\PLL \\pll00 port \\CLK_OUT",
-    "    \\I_DDR \\i_ddr10 port \\C: \\clkbuf10",
-    "      Connected to \\CLK_BUF \\clk_buf10 port \\O",
-    "    \\I_DDR \\i_ddr11 port \\C: \\clkbuf10",
-    "      Connected to \\CLK_BUF \\clk_buf10 port \\O",
-    "    \\I_DDR \\i_ddr12 port \\C: \\clkbuf10",
-    "      Connected to \\CLK_BUF \\clk_buf10 port \\O",
-    "    \\I_DDR \\i_ddr_osc0 port \\C: \\pllosc0_clk0",
-    "      Connected to \\PLL \\pllosc0 port \\CLK_OUT",
-    "    \\I_DDR \\i_ddr_osc1 port \\C: \\pllosc0_clk0",
-    "      Connected to \\PLL \\pllosc0 port \\CLK_OUT",
-    "    \\I_DDR \\i_ddr_osc2 port \\C: \\pllosc0_clk0",
-    "      Connected to \\PLL \\pllosc0 port \\CLK_OUT",
-    "    \\I_DDR \\i_ddr_osc3 port \\C: \\pllosc1_clk1",
-    "      Connected to \\PLL \\pllosc1 port \\CLK_OUT_DIV2",
-    "    \\I_DDR \\i_ddr_osc4 port \\C: \\pllosc2_clk0",
-    "      Connected to \\PLL \\pllosc2 port \\CLK_OUT",
-    "    \\I_DDR \\i_ddr30 port \\C: \\pll30_clk",
-    "      Connected to \\PLL \\pll30 port \\CLK_OUT",
-    "    \\I_DDR \\i_ddr31 port \\C: \\pll31_clk",
-    "      Connected to \\PLL \\pll31 port \\CLK_OUT",
-    "    \\O_SERDES_CLK \\o_serdes_clk port \\PLL_CLK: \\clkbuf40",
-    "      Connected to \\CLK_BUF \\clk_buf40 port \\O",
-    "    \\O_SERDES_CLK \\o_serdes_clk_osc port \\PLL_CLK: \\osc",
-    "      Warning: Not able to route signal \\osc to port \\PLL_CLK",
-    "  Trace Fabric Clock",
+    "  Trace gearbox fast clock source",
+    "    \\CLK_BUF \\clk_buf00 port \\O: \\clkbuf00",
+    "      Driving \\I_DDR \\i_ddr00 port \\C",
+    "      Driving \\O_DDR \\o_ddr00 port \\C",
+    "    \\CLK_BUF \\clk_buf10 port \\O: \\clkbuf10",
+    "      Driving \\I_DDR \\i_ddr10 port \\C",
+    "      Driving \\I_DDR \\i_ddr11 port \\C",
+    "      Driving \\I_DDR \\i_ddr12 port \\C",
+    "      Driving \\O_DDR \\o_ddr10 port \\C",
+    "      Driving \\O_DDR \\o_ddr11 port \\C",
+    "      Driving \\O_DDR \\o_ddr12 port \\C",
+    "    \\CLK_BUF $clkbuf$top.$ibuf_clk20 port \\O: $clk_buf_$ibuf_clk20",
+    "    \\CLK_BUF \\clk_buf30 port \\O: \\clkbuf30",
+    "    \\CLK_BUF \\clk_buf31 port \\O: \\clkbuf31",
+    "    \\CLK_BUF \\clk_buf40 port \\O: \\clkbuf40",
+    "      Driving \\O_SERDES_CLK \\o_serdes_clk port \\PLL_CLK",
+    "    \\PLL \\pll00 port \\CLK_OUT: \\pll00_clk1",
+    "      Driving \\I_DDR \\i_ddr01 port \\C",
+    "      Driving \\O_DDR \\o_ddr01 port \\C",
+    "    \\PLL \\pll00 port \\CLK_OUT_DIV2: \\pll00_clk2",
+    "    \\PLL \\pll00 port \\CLK_OUT_DIV3: \\pll00_clk3",
+    "    \\PLL \\pll00 port \\CLK_OUT_DIV4: \\pll00_clk4",
+    "    \\PLL \\pll30 port \\CLK_OUT: \\pll30_clk",
+    "      Driving \\I_DDR \\i_ddr30 port \\C",
+    "    \\PLL \\pll31 port \\CLK_OUT: \\pll31_clk",
+    "      Driving \\I_DDR \\i_ddr31 port \\C",
+    "      Driving \\O_DDR \\o_ddr3x port \\C",
+    "    \\PLL \\pllosc0 port \\CLK_OUT: \\pllosc0_clk0",
+    "      Driving \\I_DDR \\i_ddr_osc0 port \\C",
+    "      Driving \\I_DDR \\i_ddr_osc1 port \\C",
+    "      Driving \\I_DDR \\i_ddr_osc2 port \\C",
+    "    \\PLL \\pllosc1 port \\CLK_OUT_DIV2: \\pllosc1_clk1",
+    "      Driving \\I_DDR \\i_ddr_osc3 port \\C",
+    "    \\PLL \\pllosc2 port \\CLK_OUT: \\pllosc2_clk0",
+    "      Driving \\I_DDR \\i_ddr_osc4 port \\C",
+    "  Double check if any gearbox fast clock is unconnected",
+    "    Error: \\O_SERDES_CLK \\o_serdes_clk_osc port \\PLL_CLK are not driven any fast clock",
+    "  Figure unique core clock (which will be driven to fabric)",
+    "    Clock source: \\CLK_BUF \\clk_buf00 port \\O",
+    "      Needed by \\I_DDR \\i_ddr00 port \\C",
+    "        Categoried to chain with linked-object: din00 [data_width=1]",
+    "          Use slot 0",
+    "      Needed by \\O_DDR \\o_ddr00 port \\C",
+    "        Categoried to chain with linked-object: dout00 [data_width=1]",
+    "          Shared with din00 (slot=0)",
+    "    Clock source: \\PLL \\pll00 port \\CLK_OUT",
+    "      Needed by \\I_DDR \\i_ddr01 port \\C",
+    "        Categoried to chain with linked-object: din01 [data_width=1]",
+    "          Use slot 1",
+    "      Needed by \\O_DDR \\o_ddr01 port \\C",
+    "        Categoried to chain with linked-object: dout01 [data_width=1]",
+    "          Shared with din01 (slot=1)",
+    "    Clock source: \\CLK_BUF \\clk_buf10 port \\O",
+    "      Needed by \\I_DDR \\i_ddr10 port \\C",
+    "        Categoried to chain with linked-object: din10 [data_width=1]",
+    "          Use slot 2",
+    "      Needed by \\I_DDR \\i_ddr11 port \\C",
+    "        Categoried to chain with linked-object: din11 [data_width=1]",
+    "          Shared with din10 (slot=2)",
+    "      Needed by \\I_DDR \\i_ddr12 port \\C",
+    "        Categoried to chain with linked-object: din12 [data_width=1]",
+    "          Shared with din10 (slot=2)",
+    "      Needed by \\O_DDR \\o_ddr10 port \\C",
+    "        Categoried to chain with linked-object: dout10 [data_width=1]",
+    "          Shared with din10 (slot=2)",
+    "      Needed by \\O_DDR \\o_ddr11 port \\C",
+    "        Categoried to chain with linked-object: dout11 [data_width=1]",
+    "          Shared with din10 (slot=2)",
+    "      Needed by \\O_DDR \\o_ddr12 port \\C",
+    "        Categoried to chain with linked-object: dout12 [data_width=1]",
+    "          Shared with din10 (slot=2)",
+    "    Clock source: \\PLL \\pllosc0 port \\CLK_OUT",
+    "      Needed by \\I_DDR \\i_ddr_osc0 port \\C",
+    "        Categoried to chain with linked-object: dinosc0 [data_width=1]",
+    "          Use slot 3",
+    "      Needed by \\I_DDR \\i_ddr_osc1 port \\C",
+    "        Categoried to chain with linked-object: dinosc1 [data_width=1]",
+    "          Shared with dinosc0 (slot=3)",
+    "      Needed by \\I_DDR \\i_ddr_osc2 port \\C",
+    "        Categoried to chain with linked-object: dinosc2 [data_width=1]",
+    "          Shared with dinosc0 (slot=3)",
+    "    Clock source: \\PLL \\pllosc2 port \\CLK_OUT",
+    "      Needed by \\I_DDR \\i_ddr_osc4 port \\C",
+    "        Categoried to chain with linked-object: dinosc4 [data_width=1]",
+    "          Use slot 4",
+    "    Clock source: \\PLL \\pll30 port \\CLK_OUT",
+    "      Needed by \\I_DDR \\i_ddr30 port \\C",
+    "        Categoried to chain with linked-object: din30_n+din30_p [data_width=1]",
+    "          Use slot 5",
+    "    Clock source: \\PLL \\pll31 port \\CLK_OUT",
+    "      Needed by \\I_DDR \\i_ddr31 port \\C",
+    "        Categoried to chain with linked-object: din31_n+din31_p [data_width=1]",
+    "          Use slot 6",
+    "      Needed by \\O_DDR \\o_ddr3x port \\C",
+    "        Categoried to chain with linked-object: dout30_n+dout30_p [data_width=1]",
+    "          Shared with din31_n+din31_p (slot=6)",
+    "    Clock source: \\CLK_BUF \\clk_buf40 port \\O",
+    "  Figure fabric clock that needed by fabric logic",
     "    Module \\CLK_BUF \\clk_buf00: clock port \\O, net \\clkbuf00",
     "      Connected to cell \\I_DDR \\i_ddr00",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\O_DDR \\o_ddr00",
-    "        Which is a primitive",
-    "        This is gearbox core_clk. Send to fabric",
+    "      Connected to cell \\PLL \\pll00",
     "    Module \\PLL \\pll00: clock port \\CLK_OUT, net \\pll00_clk1",
     "      Connected to cell \\I_DDR \\i_ddr01",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\O_DDR \\o_ddr01",
-    "        Which is a primitive",
-    "        This is gearbox core_clk. Send to fabric",
     "    Module \\PLL \\pll00: clock port \\CLK_OUT_DIV2, net \\pll00_clk2",
     "      Connected to cell \\DFFRE $abc$277$auto_278",
     "        Which is not a IO primitive. Send to fabric",
+    "          Use slot 7",
     "    Module \\PLL \\pll00: clock port \\CLK_OUT_DIV3, net \\pll00_clk3",
     "      Connected to cell \\DFFRE $abc$270$auto_271",
     "        Which is not a IO primitive. Send to fabric",
+    "          Use slot 8",
     "    Module \\PLL \\pll00: clock port \\CLK_OUT_DIV4, net \\pll00_clk4",
     "      Connected to cell \\DFFRE $abc$263$auto_264",
     "        Which is not a IO primitive. Send to fabric",
+    "          Use slot 9",
     "    Module \\CLK_BUF \\clk_buf10: clock port \\O, net \\clkbuf10",
     "      Connected to cell \\I_DDR \\i_ddr10",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\I_DDR \\i_ddr11",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\I_DDR \\i_ddr12",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\O_DDR \\o_ddr10",
-    "        Which is a primitive",
-    "        This is gearbox core_clk. Send to fabric",
+    "      Connected to cell \\O_DDR \\o_ddr11",
+    "      Connected to cell \\O_DDR \\o_ddr12",
     "    Module \\CLK_BUF $clkbuf$top.$ibuf_clk20: clock port \\O, net $clk_buf_$ibuf_clk20",
     "      Connected to cell \\DFFRE $abc$284$auto_285",
     "        Which is not a IO primitive. Send to fabric",
+    "          Use slot 10",
     "    Module \\BOOT_CLOCK \\boot_clock: clock port \\O, net \\osc",
     "      Connected to cell \\O_SERDES_CLK \\o_serdes_clk_osc",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\PLL \\pllosc0",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\PLL \\pllosc1",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\PLL \\pllosc2",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "    Module \\PLL \\pllosc0: clock port \\CLK_OUT, net \\pllosc0_clk0",
     "      Connected to cell \\I_DDR \\i_ddr_osc0",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\I_DDR \\i_ddr_osc1",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\I_DDR \\i_ddr_osc2",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "    Module \\PLL \\pllosc1: clock port \\CLK_OUT_DIV2, net \\pllosc1_clk1",
     "      Connected to cell \\I_DDR \\i_ddr_osc3",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "    Module \\PLL \\pllosc2: clock port \\CLK_OUT, net \\pllosc2_clk0",
     "      Connected to cell \\I_DDR \\i_ddr_osc4",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "    Module \\CLK_BUF \\clk_buf30: clock port \\O, net \\clkbuf30",
     "      Connected to cell \\PLL \\pll30",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "    Module \\PLL \\pll30: clock port \\CLK_OUT, net \\pll30_clk",
     "      Connected to cell \\I_DDR \\i_ddr30",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "    Module \\CLK_BUF \\clk_buf31: clock port \\O, net \\clkbuf31",
     "      Connected to cell \\PLL \\pll31",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "    Module \\PLL \\pll31: clock port \\CLK_OUT, net \\pll31_clk",
     "      Connected to cell \\I_DDR \\i_ddr31",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\O_DDR \\o_ddr3x",
-    "        Which is a primitive",
-    "        This is gearbox core_clk. Send to fabric",
     "    Module \\CLK_BUF \\clk_buf40: clock port \\O, net \\clkbuf40",
     "      Connected to cell \\O_SERDES_CLK \\o_serdes_clk",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "  Summary",
     "        |-----------------------------------------------------------------------------------------------|",
     "        |                 ***********************************************************                   |",
@@ -675,15 +704,9 @@
     "      Module=I_DDR LinkedObject=dinosc4 Location=HR_1_30_15P Port=R Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
     "      Module=O_BUFT LinkedObject=clk_out Location=HR_2_8_4P Port=T Signal=in:f2g_tx_oe_{A|B}",
-    "      Module=O_SERDES_CLK LinkedObject=clk_out Location=HR_2_8_4P Port=CLK_EN Signal=in:TO_BE_DETERMINED",
-    "        Skip reason: TO_BE_DETERMINED",
-    "      Module=O_SERDES_CLK LinkedObject=clk_out Location=HR_2_8_4P Port=PLL_LOCK Signal=in:TO_BE_DETERMINED",
-    "        Skip reason: User design does not utilize linked-object clk_out wrapped-instance port PLL_LOCK",
+    "      Module=O_SERDES_CLK LinkedObject=clk_out Location=HR_2_8_4P Port=CLK_EN Signal=in:f2g_tx_clk_en_{A|B} ",
     "      Module=O_BUFT LinkedObject=clk_out_osc Location=HR_2_9_4N Port=T Signal=in:f2g_tx_oe_{A|B}",
-    "      Module=O_SERDES_CLK LinkedObject=clk_out_osc Location=HR_2_9_4N Port=CLK_EN Signal=in:TO_BE_DETERMINED",
-    "        Skip reason: TO_BE_DETERMINED",
-    "      Module=O_SERDES_CLK LinkedObject=clk_out_osc Location=HR_2_9_4N Port=PLL_LOCK Signal=in:TO_BE_DETERMINED",
-    "        Skip reason: User design does not utilize linked-object clk_out_osc wrapped-instance port PLL_LOCK",
+    "      Module=O_SERDES_CLK LinkedObject=clk_out_osc Location=HR_2_9_4N Port=CLK_EN Signal=in:f2g_tx_clk_en_{A|B} ",
     "      Module=O_BUFT LinkedObject=dinoutosc Location=HR_2_22_11P Port=T Signal=in:f2g_tx_oe_{A|B}",
     "      Module=O_BUFT LinkedObject=dout00 Location=HP_1_22_11P Port=T Signal=in:f2g_tx_oe_{A|B}",
     "      Module=O_DDR LinkedObject=dout00 Location=HP_1_22_11P Port=E Signal=in:TO_BE_DETERMINED",
@@ -740,18 +763,18 @@
     "      Module=I_BUF LinkedObject=clk40 Location=HR_2_CC_38_19P Port=EN Signal=in:f2g_in_en_{A|B}",
     "        Skip reason: User design does not utilize linked-object clk40 wrapped-instance port EN",
     "      Module=I_BUF_DS LinkedObject=din30_n+din30_p Location=HR_2_0_0P Port=EN Signal=in:f2g_in_en_{A|B}",
-    "      Module=I_DDR LinkedObject=din30_n+din30_p Location=HR_2_1_0N Port=E Signal=in:TO_BE_DETERMINED",
+    "      Module=I_DDR LinkedObject=din30_n+din30_p Location=HR_2_0_0P Port=E Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
-    "      Module=I_DDR LinkedObject=din30_n+din30_p Location=HR_2_1_0N Port=R Signal=in:TO_BE_DETERMINED",
+    "      Module=I_DDR LinkedObject=din30_n+din30_p Location=HR_2_0_0P Port=R Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
     "      Module=I_BUF_DS LinkedObject=din31_n+din31_p Location=HR_2_2_1P Port=EN Signal=in:f2g_in_en_{A|B}",
-    "      Module=I_DDR LinkedObject=din31_n+din31_p Location=HR_2_3_1N Port=E Signal=in:TO_BE_DETERMINED",
+    "      Module=I_DDR LinkedObject=din31_n+din31_p Location=HR_2_2_1P Port=E Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
-    "      Module=I_DDR LinkedObject=din31_n+din31_p Location=HR_2_3_1N Port=R Signal=in:TO_BE_DETERMINED",
+    "      Module=I_DDR LinkedObject=din31_n+din31_p Location=HR_2_2_1P Port=R Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
-    "      Module=O_DDR LinkedObject=dout30_n+dout30_p Location=HR_2_7_3N Port=E Signal=in:TO_BE_DETERMINED",
+    "      Module=O_DDR LinkedObject=dout30_n+dout30_p Location=HR_2_4_2P Port=E Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
-    "      Module=O_DDR LinkedObject=dout30_n+dout30_p Location=HR_2_7_3N Port=R Signal=in:TO_BE_DETERMINED",
+    "      Module=O_DDR LinkedObject=dout30_n+dout30_p Location=HR_2_4_2P Port=R Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
     "End of IO Analysis"
   ],
@@ -759,6 +782,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk00",
+      "location_object" : "clk00",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk00",
       "linked_objects" : {
         "clk00" : {
@@ -786,12 +811,14 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf00",
+      "location_object" : "clk00",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk00",
       "linked_objects" : {
         "clk00" : {
           "location" : "HP_1_CC_18_9P",
           "properties" : {
-            "ROUTE_TO_FABRIC_CLK" : "0"
+            "ROUTE_TO_FABRIC_CLK" : "i_ddr00=0;o_ddr00=0"
           }
         }
       },
@@ -800,7 +827,7 @@
         "O" : "clkbuf00"
       },
       "parameters" : {
-        "ROUTE_TO_FABRIC_CLK" : "0"
+        "ROUTE_TO_FABRIC_CLK" : "i_ddr00=0;o_ddr00=0"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -808,7 +835,8 @@
       ],
       "route_clock_to" : {
         "O" : [
-          "i_ddr00"
+          "i_ddr00",
+          "o_ddr00"
         ]
       },
       "errors" : [
@@ -817,15 +845,17 @@
     {
       "module" : "PLL",
       "name" : "pll00",
+      "location_object" : "clk00",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk00",
       "linked_objects" : {
         "clk00" : {
           "location" : "HP_1_CC_18_9P",
           "properties" : {
-            "OUT0_ROUTE_TO_FABRIC_CLK" : "1",
-            "OUT1_ROUTE_TO_FABRIC_CLK" : "2",
-            "OUT2_ROUTE_TO_FABRIC_CLK" : "3",
-            "OUT3_ROUTE_TO_FABRIC_CLK" : "4"
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr01=1;o_ddr01=1",
+            "OUT1_ROUTE_TO_FABRIC_CLK" : "7",
+            "OUT2_ROUTE_TO_FABRIC_CLK" : "8",
+            "OUT3_ROUTE_TO_FABRIC_CLK" : "9"
           }
         }
       },
@@ -839,10 +869,10 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
-        "OUT0_ROUTE_TO_FABRIC_CLK" : "1",
-        "OUT1_ROUTE_TO_FABRIC_CLK" : "2",
-        "OUT2_ROUTE_TO_FABRIC_CLK" : "3",
-        "OUT3_ROUTE_TO_FABRIC_CLK" : "4",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr01=1;o_ddr01=1",
+        "OUT1_ROUTE_TO_FABRIC_CLK" : "7",
+        "OUT2_ROUTE_TO_FABRIC_CLK" : "8",
+        "OUT3_ROUTE_TO_FABRIC_CLK" : "9",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -853,7 +883,8 @@
       ],
       "route_clock_to" : {
         "CLK_OUT" : [
-          "i_ddr01"
+          "i_ddr01",
+          "o_ddr01"
         ]
       },
       "errors" : [
@@ -862,6 +893,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk10",
+      "location_object" : "clk10",
+      "location" : "HR_1_CC_18_9P",
       "linked_object" : "clk10",
       "linked_objects" : {
         "clk10" : {
@@ -889,12 +922,14 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf10",
+      "location_object" : "clk10",
+      "location" : "HR_1_CC_18_9P",
       "linked_object" : "clk10",
       "linked_objects" : {
         "clk10" : {
           "location" : "HR_1_CC_18_9P",
           "properties" : {
-            "ROUTE_TO_FABRIC_CLK" : "5"
+            "ROUTE_TO_FABRIC_CLK" : "i_ddr10=2;i_ddr11=2;i_ddr12=2;o_ddr10=2;o_ddr11=2;o_ddr12=2"
           }
         }
       },
@@ -903,7 +938,7 @@
         "O" : "clkbuf10"
       },
       "parameters" : {
-        "ROUTE_TO_FABRIC_CLK" : "5"
+        "ROUTE_TO_FABRIC_CLK" : "i_ddr10=2;i_ddr11=2;i_ddr12=2;o_ddr10=2;o_ddr11=2;o_ddr12=2"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -912,7 +947,10 @@
         "O" : [
           "i_ddr10",
           "i_ddr11",
-          "i_ddr12"
+          "i_ddr12",
+          "o_ddr10",
+          "o_ddr11",
+          "o_ddr12"
         ]
       },
       "errors" : [
@@ -921,6 +959,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk20",
+      "location_object" : "clk20",
+      "location" : "HP_1_CC_38_19P",
       "linked_object" : "clk20",
       "linked_objects" : {
         "clk20" : {
@@ -948,12 +988,14 @@
     {
       "module" : "CLK_BUF",
       "name" : "$clkbuf$top.$ibuf_clk20",
+      "location_object" : "clk20",
+      "location" : "HP_1_CC_38_19P",
       "linked_object" : "clk20",
       "linked_objects" : {
         "clk20" : {
           "location" : "HP_1_CC_38_19P",
           "properties" : {
-            "ROUTE_TO_FABRIC_CLK" : "6"
+            "ROUTE_TO_FABRIC_CLK" : "10"
           }
         }
       },
@@ -962,7 +1004,7 @@
         "O" : "$clk_buf_$ibuf_clk20"
       },
       "parameters" : {
-        "ROUTE_TO_FABRIC_CLK" : "6"
+        "ROUTE_TO_FABRIC_CLK" : "10"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -975,6 +1017,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din00",
+      "location_object" : "din00",
+      "location" : "HP_1_20_10P",
       "linked_object" : "din00",
       "linked_objects" : {
         "din00" : {
@@ -1002,6 +1046,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr00",
+      "location_object" : "din00",
+      "location" : "HP_1_20_10P",
       "linked_object" : "din00",
       "linked_objects" : {
         "din00" : {
@@ -1027,6 +1073,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din01",
+      "location_object" : "din01",
+      "location" : "HR_1_20_10P",
       "linked_object" : "din01",
       "linked_objects" : {
         "din01" : {
@@ -1054,6 +1102,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr01",
+      "location_object" : "din01",
+      "location" : "HR_1_20_10P",
       "linked_object" : "din01",
       "linked_objects" : {
         "din01" : {
@@ -1079,6 +1129,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din10",
+      "location_object" : "din10",
+      "location" : "",
       "linked_object" : "din10",
       "linked_objects" : {
         "din10" : {
@@ -1106,6 +1158,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr10",
+      "location_object" : "din10",
+      "location" : "",
       "linked_object" : "din10",
       "linked_objects" : {
         "din10" : {
@@ -1131,6 +1185,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din11",
+      "location_object" : "din11",
+      "location" : "HR_5_2_1P",
       "linked_object" : "din11",
       "linked_objects" : {
         "din11" : {
@@ -1158,6 +1214,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr11",
+      "location_object" : "din11",
+      "location" : "HR_5_2_1P",
       "linked_object" : "din11",
       "linked_objects" : {
         "din11" : {
@@ -1183,6 +1241,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din12",
+      "location_object" : "din12",
+      "location" : "HR_1_24_12P",
       "linked_object" : "din12",
       "linked_objects" : {
         "din12" : {
@@ -1210,6 +1270,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr12",
+      "location_object" : "din12",
+      "location" : "HR_1_24_12P",
       "linked_object" : "din12",
       "linked_objects" : {
         "din12" : {
@@ -1235,6 +1297,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din20",
+      "location_object" : "din20",
+      "location" : "",
       "linked_object" : "din20",
       "linked_objects" : {
         "din20" : {
@@ -1261,6 +1325,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_dinosc0",
+      "location_object" : "dinosc0",
+      "location" : "HR_2_20_10P",
       "linked_object" : "dinosc0",
       "linked_objects" : {
         "dinosc0" : {
@@ -1288,6 +1354,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr_osc0",
+      "location_object" : "dinosc0",
+      "location" : "HR_2_20_10P",
       "linked_object" : "dinosc0",
       "linked_objects" : {
         "dinosc0" : {
@@ -1313,6 +1381,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_dinosc1",
+      "location_object" : "dinosc1",
+      "location" : "HR_5_20_10P",
       "linked_object" : "dinosc1",
       "linked_objects" : {
         "dinosc1" : {
@@ -1340,6 +1410,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr_osc1",
+      "location_object" : "dinosc1",
+      "location" : "HR_5_20_10P",
       "linked_object" : "dinosc1",
       "linked_objects" : {
         "dinosc1" : {
@@ -1365,6 +1437,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_dinosc2",
+      "location_object" : "dinosc2",
+      "location" : "",
       "linked_object" : "dinosc2",
       "linked_objects" : {
         "dinosc2" : {
@@ -1392,6 +1466,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr_osc2",
+      "location_object" : "dinosc2",
+      "location" : "",
       "linked_object" : "dinosc2",
       "linked_objects" : {
         "dinosc2" : {
@@ -1417,6 +1493,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_dinosc3",
+      "location_object" : "dinosc3",
+      "location" : "HR_5_22_11P",
       "linked_object" : "dinosc3",
       "linked_objects" : {
         "dinosc3" : {
@@ -1444,6 +1522,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr_osc3",
+      "location_object" : "dinosc3",
+      "location" : "HR_5_22_11P",
       "linked_object" : "dinosc3",
       "linked_objects" : {
         "dinosc3" : {
@@ -1469,6 +1549,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_dinosc4",
+      "location_object" : "dinosc4",
+      "location" : "HR_1_30_15P",
       "linked_object" : "dinosc4",
       "linked_objects" : {
         "dinosc4" : {
@@ -1496,6 +1578,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr_osc4",
+      "location_object" : "dinosc4",
+      "location" : "HR_1_30_15P",
       "linked_object" : "dinosc4",
       "linked_objects" : {
         "dinosc4" : {
@@ -1521,6 +1605,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_clk_out",
+      "location_object" : "clk_out",
+      "location" : "HR_2_8_4P",
       "linked_object" : "clk_out",
       "linked_objects" : {
         "clk_out" : {
@@ -1547,6 +1633,8 @@
     {
       "module" : "O_SERDES_CLK",
       "name" : "o_serdes_clk",
+      "location_object" : "clk_out",
+      "location" : "HR_2_8_4P",
       "linked_object" : "clk_out",
       "linked_objects" : {
         "clk_out" : {
@@ -1574,6 +1662,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_clk_out_osc",
+      "location_object" : "clk_out_osc",
+      "location" : "HR_2_9_4N",
       "linked_object" : "clk_out_osc",
       "linked_objects" : {
         "clk_out_osc" : {
@@ -1600,6 +1690,8 @@
     {
       "module" : "O_SERDES_CLK",
       "name" : "o_serdes_clk_osc",
+      "location_object" : "clk_out_osc",
+      "location" : "HR_2_9_4N",
       "linked_object" : "clk_out_osc",
       "linked_objects" : {
         "clk_out_osc" : {
@@ -1622,12 +1714,13 @@
       "route_clock_to" : {
       },
       "errors" : [
-        "Not able to route signal \\osc to port \\PLL_CLK"
       ]
     },
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dinoutosc",
+      "location_object" : "dinoutosc",
+      "location" : "HR_2_22_11P",
       "linked_object" : "dinoutosc",
       "linked_objects" : {
         "dinoutosc" : {
@@ -1653,6 +1746,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout00",
+      "location_object" : "dout00",
+      "location" : "HP_1_22_11P",
       "linked_object" : "dout00",
       "linked_objects" : {
         "dout00" : {
@@ -1679,6 +1774,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr00",
+      "location_object" : "dout00",
+      "location" : "HP_1_22_11P",
       "linked_object" : "dout00",
       "linked_objects" : {
         "dout00" : {
@@ -1704,6 +1801,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout01",
+      "location_object" : "dout01",
+      "location" : "HR_1_22_11P",
       "linked_object" : "dout01",
       "linked_objects" : {
         "dout01" : {
@@ -1730,6 +1829,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr01",
+      "location_object" : "dout01",
+      "location" : "HR_1_22_11P",
       "linked_object" : "dout01",
       "linked_objects" : {
         "dout01" : {
@@ -1755,6 +1856,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout10",
+      "location_object" : "dout10",
+      "location" : "",
       "linked_object" : "dout10",
       "linked_objects" : {
         "dout10" : {
@@ -1781,6 +1884,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr10",
+      "location_object" : "dout10",
+      "location" : "",
       "linked_object" : "dout10",
       "linked_objects" : {
         "dout10" : {
@@ -1806,6 +1911,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout11",
+      "location_object" : "dout11",
+      "location" : "HR_5_4_2P",
       "linked_object" : "dout11",
       "linked_objects" : {
         "dout11" : {
@@ -1832,6 +1939,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr11",
+      "location_object" : "dout11",
+      "location" : "HR_5_4_2P",
       "linked_object" : "dout11",
       "linked_objects" : {
         "dout11" : {
@@ -1857,6 +1966,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout12",
+      "location_object" : "dout12",
+      "location" : "HR_1_26_13P",
       "linked_object" : "dout12",
       "linked_objects" : {
         "dout12" : {
@@ -1883,6 +1994,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr12",
+      "location_object" : "dout12",
+      "location" : "HR_1_26_13P",
       "linked_object" : "dout12",
       "linked_objects" : {
         "dout12" : {
@@ -1908,6 +2021,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout20",
+      "location_object" : "dout20",
+      "location" : "",
       "linked_object" : "dout20",
       "linked_objects" : {
         "dout20" : {
@@ -1933,6 +2048,8 @@
     {
       "module" : "BOOT_CLOCK",
       "name" : "boot_clock",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
@@ -1961,11 +2078,14 @@
     {
       "module" : "PLL",
       "name" : "pllosc0",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
           "location" : "",
           "properties" : {
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr_osc0=3;i_ddr_osc1=3;i_ddr_osc2=3"
           }
         }
       },
@@ -1976,6 +2096,7 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr_osc0=3;i_ddr_osc1=3;i_ddr_osc2=3",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -1997,6 +2118,8 @@
     {
       "module" : "PLL",
       "name" : "pllosc1",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
@@ -2031,11 +2154,14 @@
     {
       "module" : "PLL",
       "name" : "pllosc2",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
           "location" : "",
           "properties" : {
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr_osc4=4"
           }
         }
       },
@@ -2046,6 +2172,7 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr_osc4=4",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -2065,6 +2192,8 @@
     {
       "module" : "I_BUF",
       "name" : "i_buf30",
+      "location_object" : "clk30",
+      "location" : "HR_1_CC_38_19P",
       "linked_object" : "clk30",
       "linked_objects" : {
         "clk30" : {
@@ -2091,6 +2220,8 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf30",
+      "location_object" : "clk30",
+      "location" : "HR_1_CC_38_19P",
       "linked_object" : "clk30",
       "linked_objects" : {
         "clk30" : {
@@ -2117,11 +2248,14 @@
     {
       "module" : "PLL",
       "name" : "pll30",
+      "location_object" : "clk30",
+      "location" : "HR_1_CC_38_19P",
       "linked_object" : "clk30",
       "linked_objects" : {
         "clk30" : {
           "location" : "HR_1_CC_38_19P",
           "properties" : {
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr30=5"
           }
         }
       },
@@ -2132,6 +2266,7 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr30=5",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -2151,6 +2286,8 @@
     {
       "module" : "I_BUF",
       "name" : "i_buf31",
+      "location_object" : "clk31",
+      "location" : "HR_3_CC_38_19P",
       "linked_object" : "clk31",
       "linked_objects" : {
         "clk31" : {
@@ -2177,6 +2314,8 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf31",
+      "location_object" : "clk31",
+      "location" : "HR_3_CC_38_19P",
       "linked_object" : "clk31",
       "linked_objects" : {
         "clk31" : {
@@ -2203,12 +2342,14 @@
     {
       "module" : "PLL",
       "name" : "pll31",
+      "location_object" : "clk31",
+      "location" : "HR_3_CC_38_19P",
       "linked_object" : "clk31",
       "linked_objects" : {
         "clk31" : {
           "location" : "HR_3_CC_38_19P",
           "properties" : {
-            "OUT0_ROUTE_TO_FABRIC_CLK" : "7"
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr31=6;o_ddr3x=6"
           }
         }
       },
@@ -2219,7 +2360,7 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
-        "OUT0_ROUTE_TO_FABRIC_CLK" : "7",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_ddr31=6;o_ddr3x=6",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -2230,7 +2371,8 @@
       ],
       "route_clock_to" : {
         "CLK_OUT" : [
-          "i_ddr31"
+          "i_ddr31",
+          "o_ddr3x"
         ]
       },
       "errors" : [
@@ -2239,6 +2381,8 @@
     {
       "module" : "I_BUF",
       "name" : "i_buf40",
+      "location_object" : "clk40",
+      "location" : "HR_2_CC_38_19P",
       "linked_object" : "clk40",
       "linked_objects" : {
         "clk40" : {
@@ -2265,6 +2409,8 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf40",
+      "location_object" : "clk40",
+      "location" : "HR_2_CC_38_19P",
       "linked_object" : "clk40",
       "linked_objects" : {
         "clk40" : {
@@ -2293,6 +2439,8 @@
     {
       "module" : "I_BUF_DS",
       "name" : "i_buf_ds30",
+      "location_object" : "din30_p",
+      "location" : "HR_2_0_0P",
       "linked_object" : "din30_n+din30_p",
       "linked_objects" : {
         "din30_n" : {
@@ -2328,6 +2476,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr30",
+      "location_object" : "din30_p",
+      "location" : "HR_2_0_0P",
       "linked_object" : "din30_n+din30_p",
       "linked_objects" : {
         "din30_n" : {
@@ -2358,6 +2508,8 @@
     {
       "module" : "I_BUF_DS",
       "name" : "i_buf_ds31",
+      "location_object" : "din31_p",
+      "location" : "HR_2_2_1P",
       "linked_object" : "din31_n+din31_p",
       "linked_objects" : {
         "din31_n" : {
@@ -2393,6 +2545,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr31",
+      "location_object" : "din31_p",
+      "location" : "HR_2_2_1P",
       "linked_object" : "din31_n+din31_p",
       "linked_objects" : {
         "din31_n" : {
@@ -2423,6 +2577,8 @@
     {
       "module" : "O_BUF_DS",
       "name" : "o_buf_ds",
+      "location_object" : "dout30_p",
+      "location" : "HR_2_4_2P",
       "linked_object" : "dout30_n+dout30_p",
       "linked_objects" : {
         "dout30_n" : {
@@ -2455,6 +2611,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr3x",
+      "location_object" : "dout30_p",
+      "location" : "HR_2_4_2P",
       "linked_object" : "dout30_n+dout30_p",
       "linked_objects" : {
         "dout30_n" : {

--- a/tests/unittest/ModelConfig/model_config_netlist.ppdb.json
+++ b/tests/unittest/ModelConfig/model_config_netlist.ppdb.json
@@ -17,6 +17,7 @@
     "    Detect input port \\din_n (index=0, width=1, offset=0)",
     "    Detect input port \\din_p (index=0, width=1, offset=0)",
     "    Detect input port \\din_serdes (index=0, width=1, offset=0)",
+    "    Detect input port \\din_serdes_clk_out (index=0, width=1, offset=0)",
     "    Detect output port \\dout (index=0, width=1, offset=0)",
     "    Detect output port \\dout_clk2 (index=0, width=1, offset=0)",
     "    Detect output port \\dout_n (index=0, width=1, offset=0)",
@@ -24,71 +25,79 @@
     "    Detect output port \\dout_osc_p (index=0, width=1, offset=0)",
     "    Detect output port \\dout_p (index=0, width=1, offset=0)",
     "    Detect output port \\dout_serdes (index=0, width=1, offset=0)",
+    "    Detect output port \\dout_serdes_clk_out (index=0, width=1, offset=0)",
     "    Detect input port \\enable (index=0, width=1, offset=0)",
     "    Detect input port \\reset (index=0, width=1, offset=0)",
     "  Get Port/Standalone Primitives",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_clk0",
     "      Cell port \\I is connected to input port \\clk0",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_clk1",
     "      Cell port \\I is connected to input port \\clk1",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_clk2",
     "      Cell port \\I is connected to input port \\clk2",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_din",
     "      Cell port \\I is connected to input port \\din",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_din_clk2",
     "      Cell port \\I is connected to input port \\din_clk2",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_din_serdes",
     "      Cell port \\I is connected to input port \\din_serdes",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
+    "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_din_serdes_clk_out",
+    "      Cell port \\I is connected to input port \\din_serdes_clk_out",
+    "        Parameter \\WEAK_KEEPER: \"NONE\"",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_enable",
     "      Cell port \\I is connected to input port \\enable",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\I_BUF $ibuf$top.$ibuf_reset",
     "      Cell port \\I is connected to input port \\reset",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_clk_out",
     "      Cell port \\O is connected to output port \\clk_out",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_delay_tap",
     "      Cell port \\O is connected to output port \\delay_tap[0]",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_delay_tap_1",
     "      Cell port \\O is connected to output port \\delay_tap[1]",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_delay_tap_2",
     "      Cell port \\O is connected to output port \\delay_tap[2]",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_delay_tap_3",
     "      Cell port \\O is connected to output port \\delay_tap[3]",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_delay_tap_4",
     "      Cell port \\O is connected to output port \\delay_tap[4]",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_delay_tap_5",
     "      Cell port \\O is connected to output port \\delay_tap[5]",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_dout",
     "      Cell port \\O is connected to output port \\dout",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_dout_clk2",
     "      Cell port \\O is connected to output port \\dout_clk2",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_dout_serdes",
     "      Cell port \\O is connected to output port \\dout_serdes",
-    "        Data Width: 1",
+    "        Data Width: -2",
+    "    Get important connection of cell \\O_BUFT $obuf$top.$obuf_dout_serdes_clk_out",
+    "      Cell port \\O is connected to output port \\dout_serdes_clk_out",
+    "        Data Width: -2",
     "    Get important connection of cell \\BOOT_CLOCK \\boot_clock",
     "        Parameter \\PERIOD: 25",
     "        Data Width: -2",
@@ -98,15 +107,15 @@
     "        Parameter \\DIFFERENTIAL_TERMINATION: \"TRUE\"",
     "        Parameter \\IOSTANDARD: \"DEFAULT\"",
     "        Parameter \\WEAK_KEEPER: \"NONE\"",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUF_DS \\o_buf_ds",
     "      Cell port \\O_N is connected to output port \\dout_n",
     "      Cell port \\O_P is connected to output port \\dout_p",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "    Get important connection of cell \\O_BUF_DS \\o_buf_ds_osc",
     "      Cell port \\O_N is connected to output port \\dout_osc_n",
     "      Cell port \\O_P is connected to output port \\dout_osc_p",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "  Trace \\I_BUF --> \\CLK_BUF",
     "    Try \\I_BUF $ibuf$top.$ibuf_clk0 out connection: $ibuf_clk0 -> $clkbuf$top.$ibuf_clk0",
     "      Connected $clkbuf$top.$ibuf_clk0",
@@ -142,7 +151,7 @@
     "    Try \\I_BUF $ibuf$top.$ibuf_din out connection: $ibuf_din -> \\i_delay",
     "      Connected \\i_delay",
     "        Parameter \\DELAY: 50",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "  Trace \\I_BUF --> \\I_DDR",
     "  Trace \\I_BUF --> \\I_SERDES",
     "    Try \\I_BUF $ibuf$top.$ibuf_din_serdes out connection: $ibuf_din_serdes -> \\i_serdes",
@@ -155,7 +164,7 @@
     "  Trace \\I_BUF_DS --> \\I_DDR",
     "    Try \\I_BUF_DS \\i_buf_ds out connection: \\i_ddr_d -> \\i_ddr",
     "      Connected \\i_ddr",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "  Trace \\I_BUF_DS --> \\I_SERDES",
     "  Trace \\I_DELAY --> \\I_DDR",
     "  Trace \\I_DELAY --> \\I_SERDES",
@@ -166,22 +175,22 @@
     "    Try \\O_BUFT $obuf$top.$obuf_dout out connection: $obuf_dout -> \\o_delay",
     "      Connected \\o_delay",
     "        Parameter \\DELAY: 60",
-    "        Data Width: 1",
+    "        Data Width: -2",
     "  Trace \\O_BUFT --> \\O_DDR",
     "  Trace \\O_BUFT --> \\O_SERDES",
     "    Try \\O_BUFT $obuf$top.$obuf_dout_serdes out connection: $obuf_dout_serdes -> \\o_serdes",
     "      Connected \\o_serdes",
     "        Parameter \\DATA_RATE: \"DDR\"",
-    "        Parameter \\WIDTH: 4",
-    "        Data Width: 4",
+    "        Parameter \\WIDTH: 8",
+    "        Data Width: 8",
     "  Trace \\O_BUF_DS --> \\O_DELAY",
     "  Trace \\O_BUF_DS --> \\O_DDR",
     "    Try \\O_BUF_DS \\o_buf_ds out connection: \\o_buf_ds_i -> \\o_ddr",
     "      Connected \\o_ddr",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "    Try \\O_BUF_DS \\o_buf_ds_osc out connection: \\o_buf_ds_i_osc -> \\o_ddr_osc",
     "      Connected \\o_ddr_osc",
-    "        Data Width: 2",
+    "        Data Width: -2",
     "  Trace \\O_BUF_DS --> \\O_SERDES",
     "  Trace \\O_BUFT_DS --> \\O_DELAY",
     "  Trace \\O_BUFT_DS --> \\O_DDR",
@@ -201,83 +210,112 @@
     "    Detect fabric clock buffer",
     "      \\I : \\clk0_div",
     "      \\O : $fclk_buf_clk0_div",
-    "  Trace gearbox clock source",
-    "    \\I_DELAY \\i_delay port \\CLK_IN: $clk_buf_$ibuf_clk0",
-    "      Connected to \\CLK_BUF $clkbuf$top.$ibuf_clk0 port \\O",
-    "    \\I_SERDES \\i_serdes port \\PLL_CLK: \\pll_clk",
-    "      Connected to \\PLL \\pll port \\CLK_OUT",
-    "    \\I_DDR \\i_ddr port \\C: \\pll_clk",
-    "      Connected to \\PLL \\pll port \\CLK_OUT",
-    "    \\O_DELAY \\o_delay port \\CLK_IN: \\clk1_buf",
-    "      Connected to \\CLK_BUF \\clk_buf port \\O",
-    "    \\O_SERDES \\o_serdes port \\PLL_CLK: \\pll_clk",
-    "      Connected to \\PLL \\pll port \\CLK_OUT",
-    "    \\O_SERDES_CLK \\o_serdes_clk port \\PLL_CLK: \\pll_clk",
-    "      Connected to \\PLL \\pll port \\CLK_OUT",
-    "  Trace Fabric Clock",
+    "  Trace gearbox fast clock source",
+    "    \\CLK_BUF $clkbuf$top.$ibuf_clk0 port \\O: $clk_buf_$ibuf_clk0",
+    "      Driving \\I_DELAY \\i_delay port \\CLK_IN",
+    "    \\CLK_BUF \\clk_buf port \\O: \\clk1_buf",
+    "      Driving \\O_DELAY \\o_delay port \\CLK_IN",
+    "    \\CLK_BUF $clkbuf$top.$ibuf_clk2 port \\O: $clk_buf_$ibuf_clk2",
+    "    \\PLL \\pll port \\CLK_OUT: \\pll_clk",
+    "      Driving \\I_SERDES \\i_serdes port \\CLK_IN",
+    "      Driving \\I_DDR \\i_ddr port \\C",
+    "      Driving \\O_SERDES \\o_serdes port \\CLK_IN",
+    "      Driving \\O_DDR \\o_ddr port \\C",
+    "      Driving \\O_SERDES_CLK \\o_serdes_clk port \\PLL_CLK",
+    "    \\PLL \\pll port \\CLK_OUT_DIV4: $delete_wire$499",
+    "    \\PLL \\pll_osc port \\CLK_OUT: \\osc_pll",
+    "      Driving \\O_DDR \\o_ddr_osc port \\C",
+    "  Double check if any gearbox fast clock is unconnected",
+    "  Figure unique core clock (which will be driven to fabric)",
+    "    Clock source: \\CLK_BUF $clkbuf$top.$ibuf_clk0 port \\O",
+    "      Needed by \\I_DELAY \\i_delay port \\CLK_IN",
+    "        Categoried to chain with linked-object: din [data_width=1]",
+    "          Use slot 0",
+    "    Clock source: \\CLK_BUF \\clk_buf port \\O",
+    "      Needed by \\O_DELAY \\o_delay port \\CLK_IN",
+    "        Categoried to chain with linked-object: dout [data_width=1]",
+    "          Use slot 1",
+    "    Clock source: \\PLL \\pll port \\CLK_OUT",
+    "      Needed by \\I_SERDES \\i_serdes port \\CLK_IN",
+    "        Categoried to chain with linked-object: din_serdes [data_width=8]",
+    "          Use slot 2",
+    "      Needed by \\I_DDR \\i_ddr port \\C",
+    "        Categoried to chain with linked-object: din_n+din_p [data_width=1]",
+    "          Use slot 3",
+    "      Needed by \\O_SERDES \\o_serdes port \\CLK_IN",
+    "        Categoried to chain with linked-object: dout_serdes [data_width=8]",
+    "          Shared with din_serdes (slot=2)",
+    "      Needed by \\O_DDR \\o_ddr port \\C",
+    "        Categoried to chain with linked-object: dout_n+dout_p [data_width=1]",
+    "          Shared with din_n+din_p (slot=3)",
+    "    Clock source: \\PLL \\pll_osc port \\CLK_OUT",
+    "      Needed by \\O_DDR \\o_ddr_osc port \\C",
+    "        Categoried to chain with linked-object: dout_osc_n+dout_osc_p [data_width=1]",
+    "          Use slot 4",
+    "  Figure fabric clock that needed by fabric logic",
     "    Module \\CLK_BUF $clkbuf$top.$ibuf_clk0: clock port \\O, net $clk_buf_$ibuf_clk0",
-    "      Connected to cell \\DFFRE $abc$218$auto_219",
+    "      Connected to cell \\DFFRE $abc$216$auto_217",
     "        Which is not a IO primitive. Send to fabric",
+    "          Shared with din (slot=0)",
     "    Module \\CLK_BUF \\clk_buf: clock port \\O, net \\clk1_buf",
     "      Connected to cell \\O_DELAY \\o_delay",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\PLL \\pll",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "    Module \\PLL \\pll: clock port \\CLK_OUT, net \\pll_clk",
     "      Connected to cell \\I_DDR \\i_ddr",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "      Connected to cell \\I_SERDES \\i_serdes",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
+    "      Connected to cell \\I_SERDES \\i_serdes",
     "      Connected to cell \\O_DDR \\o_ddr",
-    "        Which is a primitive",
-    "        This is gearbox core_clk. Send to fabric",
-    "    Module \\PLL \\pll: clock port \\CLK_OUT_DIV4, net $delete_wire$530",
+    "      Connected to cell \\O_SERDES \\o_serdes",
+    "      Connected to cell \\O_SERDES \\o_serdes",
+    "      Connected to cell \\O_SERDES_CLK \\o_serdes_clk",
+    "    Module \\PLL \\pll: clock port \\CLK_OUT_DIV4, net $delete_wire$499",
     "    Module \\CLK_BUF $clkbuf$top.$ibuf_clk2: clock port \\O, net $clk_buf_$ibuf_clk2",
-    "      Connected to cell \\DFFRE $abc$222$auto_223",
+    "      Connected to cell \\DFFRE $abc$220$auto_221",
     "        Which is not a IO primitive. Send to fabric",
+    "          Use slot 5",
+    "    Module \\I_SERDES \\i_serdes: clock port \\CLK_OUT, net \\iserdes_clk_out",
+    "      Connected to cell \\DFFRE $abc$208$auto_209",
+    "        Which is not a IO primitive. Send to fabric",
+    "          This none-clock primitive is clocked by PLL pll port CLK_OUT [data_width=8]",
+    "          Shared with din_serdes (slot=2)",
     "    Module \\BOOT_CLOCK \\boot_clock: clock port \\O, net \\osc",
     "      Connected to cell \\PLL \\pll_osc",
-    "        Which is a primitive",
-    "        Does not meet core_clk checking criteria. Not sending to fabric",
     "    Module \\PLL \\pll_osc: clock port \\CLK_OUT, net \\osc_pll",
     "      Connected to cell \\O_DDR \\o_ddr_osc",
-    "        Which is a primitive",
-    "        This is gearbox core_clk. Send to fabric",
     "    Module \\FCLK_BUF $clkbuf$top.clk0_div: clock port \\O, net $fclk_buf_clk0_div",
-    "      Connected to cell \\DFFRE $abc$210$auto_211",
+    "      Connected to cell \\DFFRE $abc$212$auto_213",
     "        Which is not a IO primitive. Send to fabric",
+    "          Use slot 6",
     "  Summary",
-    "        |---------------------------------------------------------------------------------------------------|",
-    "        |                 ***********************************************************                       |",
-    "    IN  |            clk0 * I_BUF |-> CLK_BUF                                       *                       |",
-    "    IN  |            clk1 * I_BUF |-> CLK_BUF |-> PLL                               *                       |",
-    "    IN  |            clk2 * I_BUF |-> CLK_BUF                                       *                       |",
-    "    IN  |             din * I_BUF |-> I_DELAY                                       *                       |",
-    "    IN  |        din_clk2 * I_BUF                                                   *                       |",
-    "    IN  |      din_serdes * I_BUF |-> I_SERDES                                      *                       |",
-    "    IN  |          enable * I_BUF                                                   *                       |",
-    "    IN  |           reset * I_BUF                                                   *                       |",
-    "    OUT |                 *                                 O_SERDES_CLK |-> O_BUFT * clk_out               |",
-    "    OUT |                 *                                                  O_BUFT * delay_tap[0]          |",
-    "    OUT |                 *                                                  O_BUFT * delay_tap[1]          |",
-    "    OUT |                 *                                                  O_BUFT * delay_tap[2]          |",
-    "    OUT |                 *                                                  O_BUFT * delay_tap[3]          |",
-    "    OUT |                 *                                                  O_BUFT * delay_tap[4]          |",
-    "    OUT |                 *                                                  O_BUFT * delay_tap[5]          |",
-    "    OUT |                 *                                      O_DELAY |-> O_BUFT * dout                  |",
-    "    OUT |                 *                                                  O_BUFT * dout_clk2             |",
-    "    OUT |                 *                                     O_SERDES |-> O_BUFT * dout_serdes           |",
-    "    IN  |    BOOT_CLOCK#0 * BOOT_CLOCK |-> PLL                                      *                       |",
-    "    IN  |     din_n+din_p * I_BUF_DS |-> I_DDR                                      *                       |",
-    "    OUT |                 *                                      O_DDR |-> O_BUF_DS * dout_n+dout_p         |",
-    "    OUT |                 *                                      O_DDR |-> O_BUF_DS * dout_osc_n+dout_osc_p |",
-    "    IN  | FABRIC_CLKBUF#0 * FCLK_BUF                                                *                       |",
-    "        |                 ***********************************************************                       |",
-    "        |---------------------------------------------------------------------------------------------------|",
+    "        |------------------------------------------------------------------------------------------------------|",
+    "        |                    ***********************************************************                       |",
+    "    IN  |               clk0 * I_BUF |-> CLK_BUF                                       *                       |",
+    "    IN  |               clk1 * I_BUF |-> CLK_BUF |-> PLL                               *                       |",
+    "    IN  |               clk2 * I_BUF |-> CLK_BUF                                       *                       |",
+    "    IN  |                din * I_BUF |-> I_DELAY                                       *                       |",
+    "    IN  |           din_clk2 * I_BUF                                                   *                       |",
+    "    IN  |         din_serdes * I_BUF |-> I_SERDES                                      *                       |",
+    "    IN  | din_serdes_clk_out * I_BUF                                                   *                       |",
+    "    IN  |             enable * I_BUF                                                   *                       |",
+    "    IN  |              reset * I_BUF                                                   *                       |",
+    "    OUT |                    *                                 O_SERDES_CLK |-> O_BUFT * clk_out               |",
+    "    OUT |                    *                                                  O_BUFT * delay_tap[0]          |",
+    "    OUT |                    *                                                  O_BUFT * delay_tap[1]          |",
+    "    OUT |                    *                                                  O_BUFT * delay_tap[2]          |",
+    "    OUT |                    *                                                  O_BUFT * delay_tap[3]          |",
+    "    OUT |                    *                                                  O_BUFT * delay_tap[4]          |",
+    "    OUT |                    *                                                  O_BUFT * delay_tap[5]          |",
+    "    OUT |                    *                                      O_DELAY |-> O_BUFT * dout                  |",
+    "    OUT |                    *                                                  O_BUFT * dout_clk2             |",
+    "    OUT |                    *                                     O_SERDES |-> O_BUFT * dout_serdes           |",
+    "    OUT |                    *                                                  O_BUFT * dout_serdes_clk_out   |",
+    "    IN  |       BOOT_CLOCK#0 * BOOT_CLOCK |-> PLL                                      *                       |",
+    "    IN  |        din_n+din_p * I_BUF_DS |-> I_DDR                                      *                       |",
+    "    OUT |                    *                                      O_DDR |-> O_BUF_DS * dout_n+dout_p         |",
+    "    OUT |                    *                                      O_DDR |-> O_BUF_DS * dout_osc_n+dout_osc_p |",
+    "    IN  |    FABRIC_CLKBUF#0 * FCLK_BUF                                                *                       |",
+    "        |                    ***********************************************************                       |",
+    "        |------------------------------------------------------------------------------------------------------|",
     "  Final checking is good",
     "  Assign location HR_1_CC_18_9P (and properties) to Port clk0",
     "  Assign location HP_1_CC_18_9P (and properties) to Port clk1",
@@ -295,6 +333,8 @@
     "  Assign location HR_5_1_0N (and properties) to Port dout_clk2",
     "  Assign location HR_2_0_0P (and properties) to Port din_serdes",
     "  Assign location HR_2_2_1P (and properties) to Port dout_serdes",
+    "  Assign location HR_2_6_3P (and properties) to Port din_serdes_clk_out",
+    "  Assign location HR_2_7_3N (and properties) to Port dout_serdes_clk_out",
     "  Assign location HR_2_4_2P (and properties) to Port clk_out",
     "  Assign location HR_2_20_10P (and properties) to Port delay_tap[0]",
     "  Assign location HR_2_22_11P (and properties) to Port delay_tap[1]",
@@ -307,14 +347,14 @@
     "    Determine data signals",
     "      Pin object=clk0, location: HR_1_CC_18_9P",
     "        Data signal from object clk0",
-    "          Module=I_BUF Linked-object=clk0 Port=O Net=$flatten$auto_577.$ibuf_clk0 - Not found",
+    "          Module=I_BUF Linked-object=clk0 Port=O Net=$flatten$auto_562.$ibuf_clk0 - Not found",
     "          Fail reason: Clock data from object clk0 port O is not routed to fabric",
     "      Pin object=clk1, location: HP_1_CC_18_9P",
     "        Data signal from object clk1",
     "          Fail reason: Object clk1 is primitive \\PLL but data signal is not defined",
     "      Pin object=clk2, location: HR_5_CC_38_19P",
     "        Data signal from object clk2",
-    "          Module=I_BUF Linked-object=clk2 Port=O Net=$flatten$auto_577.$ibuf_clk2 - Not found",
+    "          Module=I_BUF Linked-object=clk2 Port=O Net=$flatten$auto_562.$ibuf_clk2 - Not found",
     "          Fail reason: Clock data from object clk2 port O is not routed to fabric",
     "      Pin object=din, location: HP_1_20_10P",
     "        Data signal from object din",
@@ -332,6 +372,9 @@
     "          Module=I_SERDES Linked-object=din_serdes Port=Q Net=serdes_data[5] - Found",
     "          Module=I_SERDES Linked-object=din_serdes Port=Q Net=serdes_data[6] - Found",
     "          Module=I_SERDES Linked-object=din_serdes Port=Q Net=serdes_data[7] - Found",
+    "      Pin object=din_serdes_clk_out, location: HR_2_6_3P",
+    "        Data signal from object din_serdes_clk_out",
+    "          Module=I_BUF Linked-object=din_serdes_clk_out Port=O Net=$ibuf_din_serdes_clk_out - Found",
     "      Pin object=enable, location: ",
     "        Pin location is not assigned",
     "      Pin object=reset, location: HP_1_0_0P",
@@ -366,10 +409,17 @@
     "          Module=O_BUFT Linked-object=dout_clk2 Port=I Net=$obuf_dout_clk2 - Found",
     "      Pin object=dout_serdes, location: HR_2_2_1P",
     "        Data signal from object dout_serdes",
-    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$abc$194$xor$/home/cschai/desktop/raptor_projects/ppdb/foedag_unit_test/./top.v:199$5_Y[0] - Found",
-    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$abc$194$xor$/home/cschai/desktop/raptor_projects/ppdb/foedag_unit_test/./top.v:199$5_Y[1] - Found",
-    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$abc$194$xor$/home/cschai/desktop/raptor_projects/ppdb/foedag_unit_test/./top.v:199$5_Y[2] - Found",
-    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$abc$194$xor$/home/cschai/desktop/raptor_projects/ppdb/foedag_unit_test/./top.v:199$5_Y[3] - Found",
+    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$auto_540 - Found",
+    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$auto_541 - Found",
+    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$auto_542 - Found",
+    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$auto_543 - Found",
+    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$auto_544 - Found",
+    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$auto_545 - Found",
+    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$auto_546 - Found",
+    "          Module=O_SERDES Linked-object=dout_serdes Port=D Net=$auto_547 - Found",
+    "      Pin object=dout_serdes_clk_out, location: HR_2_7_3N",
+    "        Data signal from object dout_serdes_clk_out",
+    "          Module=O_BUFT Linked-object=dout_serdes_clk_out Port=I Net=$obuf_dout_serdes_clk_out - Found",
     "      Pin object=din_n, location: HP_1_5_2N",
     "        Skip this because 'This is secondary pin. But IO bitstream generation will still make sure it is used in pair. Otherwise the IO bitstream will be invalid'",
     "      Pin object=din_p, location: HP_1_4_2P",
@@ -380,14 +430,14 @@
     "        Skip this because 'This is secondary pin. But IO bitstream generation will still make sure it is used in pair. Otherwise the IO bitstream will be invalid'",
     "      Pin object=dout_p, location: HP_1_8_4P",
     "        Data signal from object dout_p",
-    "          Module=O_DDR Linked-object=dout_n+dout_p Port=D Net=$auto_567 - Found",
-    "          Module=O_DDR Linked-object=dout_n+dout_p Port=D Net=$auto_568 - Found",
+    "          Module=O_DDR Linked-object=dout_n+dout_p Port=D Net=$auto_536 - Found",
+    "          Module=O_DDR Linked-object=dout_n+dout_p Port=D Net=$auto_537 - Found",
     "      Pin object=dout_osc_n, location: HP_2_23_11N",
     "        Skip this because 'This is secondary pin. But IO bitstream generation will still make sure it is used in pair. Otherwise the IO bitstream will be invalid'",
     "      Pin object=dout_osc_p, location: HP_2_22_11P",
     "        Data signal from object dout_osc_p",
-    "          Module=O_DDR Linked-object=dout_osc_n+dout_osc_p Port=D Net=$auto_569 - Found",
-    "          Module=O_DDR Linked-object=dout_osc_n+dout_osc_p Port=D Net=$auto_570 - Found",
+    "          Module=O_DDR Linked-object=dout_osc_n+dout_osc_p Port=D Net=$auto_538 - Found",
+    "          Module=O_DDR Linked-object=dout_osc_n+dout_osc_p Port=D Net=$auto_539 - Found",
     "    Determine internal control signals",
     "      Module=I_BUF LinkedObject=clk0 Location=HR_1_CC_18_9P Port=EN Signal=in:f2g_in_en_{A|B}",
     "      Module=I_BUF LinkedObject=clk1 Location=HP_1_CC_18_9P Port=EN Signal=in:f2g_in_en_{A|B}",
@@ -403,27 +453,22 @@
     "      Module=I_DELAY LinkedObject=din Location=HP_1_20_10P Port=DLY_TAP_VALUE Signal=out:rule=half-first:g2f_trx_dly_tap",
     "      Module=I_BUF LinkedObject=din_clk2 Location=HR_5_0_0P Port=EN Signal=in:f2g_in_en_{A|B}",
     "      Module=I_BUF LinkedObject=din_serdes Location=HR_2_0_0P Port=EN Signal=in:f2g_in_en_{A|B}",
-    "      Module=I_SERDES LinkedObject=din_serdes Location=HR_2_0_0P Port=BITSLIP_ADJ Signal=in:TO_BE_DETERMINED",
-    "        Skip reason: TO_BE_DETERMINED",
+    "      Module=I_SERDES LinkedObject=din_serdes Location=HR_2_0_0P Port=BITSLIP_ADJ Signal=in:rule=half-first:f2g_rx_bitslip_adj",
     "      Module=I_SERDES LinkedObject=din_serdes Location=HR_2_0_0P Port=DATA_VALID Signal=out:g2f_rx_dvalid_{A|B}",
     "        Skip reason: User design does not utilize linked-object din_serdes wrapped-instance port DATA_VALID",
-    "      Module=I_SERDES LinkedObject=din_serdes Location=HR_2_0_0P Port=DPA_ERROR Signal=out:TO_BE_DETERMINED",
+    "      Module=I_SERDES LinkedObject=din_serdes Location=HR_2_0_0P Port=DPA_ERROR Signal=out:rule=half-first:g2f_rx_dpa_error",
     "        Skip reason: User design does not utilize linked-object din_serdes wrapped-instance port DPA_ERROR",
-    "      Module=I_SERDES LinkedObject=din_serdes Location=HR_2_0_0P Port=DPA_LOCK Signal=out:TO_BE_DETERMINED",
+    "      Module=I_SERDES LinkedObject=din_serdes Location=HR_2_0_0P Port=DPA_LOCK Signal=out:rule=half-first:g2f_rx_dpa_lock",
     "        Skip reason: User design does not utilize linked-object din_serdes wrapped-instance port DPA_LOCK",
     "      Module=I_SERDES LinkedObject=din_serdes Location=HR_2_0_0P Port=EN Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
-    "      Module=I_SERDES LinkedObject=din_serdes Location=HR_2_0_0P Port=PLL_LOCK Signal=in:TO_BE_DETERMINED",
-    "        Skip reason: User design does not utilize linked-object din_serdes wrapped-instance port PLL_LOCK",
     "      Module=I_SERDES LinkedObject=din_serdes Location=HR_2_0_0P Port=RST Signal=in:f2g_trx_reset_n_{A|B}",
+    "      Module=I_BUF LinkedObject=din_serdes_clk_out Location=HR_2_6_3P Port=EN Signal=in:f2g_in_en_{A|B}",
     "      Module=I_BUF LinkedObject=enable Location= Port=EN Signal=in:f2g_in_en_{A|B}",
     "        Skip reason: Location  does not have any mode to begin with",
     "      Module=I_BUF LinkedObject=reset Location=HP_1_0_0P Port=EN Signal=in:f2g_in_en_{A|B}",
     "      Module=O_BUFT LinkedObject=clk_out Location=HR_2_4_2P Port=T Signal=in:f2g_tx_oe_{A|B}",
-    "      Module=O_SERDES_CLK LinkedObject=clk_out Location=HR_2_4_2P Port=CLK_EN Signal=in:TO_BE_DETERMINED",
-    "        Skip reason: TO_BE_DETERMINED",
-    "      Module=O_SERDES_CLK LinkedObject=clk_out Location=HR_2_4_2P Port=PLL_LOCK Signal=in:TO_BE_DETERMINED",
-    "        Skip reason: User design does not utilize linked-object clk_out wrapped-instance port PLL_LOCK",
+    "      Module=O_SERDES_CLK LinkedObject=clk_out Location=HR_2_4_2P Port=CLK_EN Signal=in:f2g_tx_clk_en_{A|B} ",
     "      Module=O_BUFT LinkedObject=delay_tap[0] Location=HR_2_20_10P Port=T Signal=in:f2g_tx_oe_{A|B}",
     "      Module=O_BUFT LinkedObject=delay_tap[1] Location=HR_2_22_11P Port=T Signal=in:f2g_tx_oe_{A|B}",
     "      Module=O_BUFT LinkedObject=delay_tap[2] Location=HR_2_24_12P Port=T Signal=in:f2g_tx_oe_{A|B}",
@@ -450,22 +495,23 @@
     "      Module=O_SERDES LinkedObject=dout_serdes Location=HR_2_2_1P Port=PLL_LOCK Signal=in:TO_BE_DETERMINED",
     "        Skip reason: User design does not utilize linked-object dout_serdes wrapped-instance port PLL_LOCK",
     "      Module=O_SERDES LinkedObject=dout_serdes Location=HR_2_2_1P Port=RST Signal=in:f2g_trx_reset_n_{A|B}",
+    "      Module=O_BUFT LinkedObject=dout_serdes_clk_out Location=HR_2_7_3N Port=T Signal=in:f2g_tx_oe_{A|B}",
     "      Module=PLL LinkedObject=BOOT_CLOCK#0 Location= Port=LOCK Signal=out:TO_BE_DETERMINED",
     "        Skip reason: Location  does not have any mode to begin with",
     "      Module=PLL LinkedObject=BOOT_CLOCK#0 Location= Port=PLL_EN Signal=in:TO_BE_DETERMINED",
     "        Skip reason: Location  does not have any mode to begin with",
     "      Module=I_BUF_DS LinkedObject=din_n+din_p Location=HP_1_4_2P Port=EN Signal=in:f2g_in_en_{A|B}",
-    "      Module=I_DDR LinkedObject=din_n+din_p Location=HP_1_5_2N Port=E Signal=in:TO_BE_DETERMINED",
+    "      Module=I_DDR LinkedObject=din_n+din_p Location=HP_1_4_2P Port=E Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
-    "      Module=I_DDR LinkedObject=din_n+din_p Location=HP_1_5_2N Port=R Signal=in:TO_BE_DETERMINED",
+    "      Module=I_DDR LinkedObject=din_n+din_p Location=HP_1_4_2P Port=R Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
-    "      Module=O_DDR LinkedObject=dout_n+dout_p Location=HP_1_9_4N Port=E Signal=in:TO_BE_DETERMINED",
+    "      Module=O_DDR LinkedObject=dout_n+dout_p Location=HP_1_8_4P Port=E Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
-    "      Module=O_DDR LinkedObject=dout_n+dout_p Location=HP_1_9_4N Port=R Signal=in:TO_BE_DETERMINED",
+    "      Module=O_DDR LinkedObject=dout_n+dout_p Location=HP_1_8_4P Port=R Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
-    "      Module=O_DDR LinkedObject=dout_osc_n+dout_osc_p Location=HP_2_23_11N Port=E Signal=in:TO_BE_DETERMINED",
+    "      Module=O_DDR LinkedObject=dout_osc_n+dout_osc_p Location=HP_2_22_11P Port=E Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
-    "      Module=O_DDR LinkedObject=dout_osc_n+dout_osc_p Location=HP_2_23_11N Port=R Signal=in:TO_BE_DETERMINED",
+    "      Module=O_DDR LinkedObject=dout_osc_n+dout_osc_p Location=HP_2_22_11P Port=R Signal=in:TO_BE_DETERMINED",
     "        Skip reason: TO_BE_DETERMINED",
     "End of IO Analysis"
   ],
@@ -473,6 +519,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk0",
+      "location_object" : "clk0",
+      "location" : "HR_1_CC_18_9P",
       "linked_object" : "clk0",
       "linked_objects" : {
         "clk0" : {
@@ -500,12 +548,14 @@
     {
       "module" : "CLK_BUF",
       "name" : "$clkbuf$top.$ibuf_clk0",
+      "location_object" : "clk0",
+      "location" : "HR_1_CC_18_9P",
       "linked_object" : "clk0",
       "linked_objects" : {
         "clk0" : {
           "location" : "HR_1_CC_18_9P",
           "properties" : {
-            "ROUTE_TO_FABRIC_CLK" : "0"
+            "ROUTE_TO_FABRIC_CLK" : "i_delay=0;0"
           }
         }
       },
@@ -514,7 +564,7 @@
         "O" : "$clk_buf_$ibuf_clk0"
       },
       "parameters" : {
-        "ROUTE_TO_FABRIC_CLK" : "0"
+        "ROUTE_TO_FABRIC_CLK" : "i_delay=0;0"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -530,6 +580,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk1",
+      "location_object" : "clk1",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk1",
       "linked_objects" : {
         "clk1" : {
@@ -557,11 +609,14 @@
     {
       "module" : "CLK_BUF",
       "name" : "clk_buf",
+      "location_object" : "clk1",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk1",
       "linked_objects" : {
         "clk1" : {
           "location" : "HP_1_CC_18_9P",
           "properties" : {
+            "ROUTE_TO_FABRIC_CLK" : "o_delay=1"
           }
         }
       },
@@ -570,6 +625,7 @@
         "O" : "clk1_buf"
       },
       "parameters" : {
+        "ROUTE_TO_FABRIC_CLK" : "o_delay=1"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -586,24 +642,26 @@
     {
       "module" : "PLL",
       "name" : "pll",
+      "location_object" : "clk1",
+      "location" : "HP_1_CC_18_9P",
       "linked_object" : "clk1",
       "linked_objects" : {
         "clk1" : {
           "location" : "HP_1_CC_18_9P",
           "properties" : {
-            "OUT0_ROUTE_TO_FABRIC_CLK" : "1"
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "i_serdes=2;i_ddr=3;o_serdes=2;o_ddr=3"
           }
         }
       },
       "connectivity" : {
         "CLK_IN" : "clk1_buf",
         "CLK_OUT" : "pll_clk",
-        "CLK_OUT_DIV4" : "$delete_wire$530"
+        "CLK_OUT_DIV4" : "$delete_wire$499"
       },
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "FALSE",
-        "OUT0_ROUTE_TO_FABRIC_CLK" : "1",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "i_serdes=2;i_ddr=3;o_serdes=2;o_ddr=3",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -617,6 +675,7 @@
           "i_serdes",
           "i_ddr",
           "o_serdes",
+          "o_ddr",
           "o_serdes_clk"
         ]
       },
@@ -626,6 +685,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_clk2",
+      "location_object" : "clk2",
+      "location" : "HR_5_CC_38_19P",
       "linked_object" : "clk2",
       "linked_objects" : {
         "clk2" : {
@@ -653,12 +714,14 @@
     {
       "module" : "CLK_BUF",
       "name" : "$clkbuf$top.$ibuf_clk2",
+      "location_object" : "clk2",
+      "location" : "HR_5_CC_38_19P",
       "linked_object" : "clk2",
       "linked_objects" : {
         "clk2" : {
           "location" : "HR_5_CC_38_19P",
           "properties" : {
-            "ROUTE_TO_FABRIC_CLK" : "2"
+            "ROUTE_TO_FABRIC_CLK" : "5"
           }
         }
       },
@@ -667,7 +730,7 @@
         "O" : "$clk_buf_$ibuf_clk2"
       },
       "parameters" : {
-        "ROUTE_TO_FABRIC_CLK" : "2"
+        "ROUTE_TO_FABRIC_CLK" : "5"
       },
       "pre_primitive" : "I_BUF",
       "post_primitives" : [
@@ -680,6 +743,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din",
+      "location_object" : "din",
+      "location" : "HP_1_20_10P",
       "linked_object" : "din",
       "linked_objects" : {
         "din" : {
@@ -707,6 +772,8 @@
     {
       "module" : "I_DELAY",
       "name" : "i_delay",
+      "location_object" : "din",
+      "location" : "HP_1_20_10P",
       "linked_object" : "din",
       "linked_objects" : {
         "din" : {
@@ -734,6 +801,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din_clk2",
+      "location_object" : "din_clk2",
+      "location" : "HR_5_0_0P",
       "linked_object" : "din_clk2",
       "linked_objects" : {
         "din_clk2" : {
@@ -760,6 +829,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_din_serdes",
+      "location_object" : "din_serdes",
+      "location" : "HR_2_0_0P",
       "linked_object" : "din_serdes",
       "linked_objects" : {
         "din_serdes" : {
@@ -787,22 +858,27 @@
     {
       "module" : "I_SERDES",
       "name" : "i_serdes",
+      "location_object" : "din_serdes",
+      "location" : "HR_2_0_0P",
       "linked_object" : "din_serdes",
       "linked_objects" : {
         "din_serdes" : {
           "location" : "HR_2_0_0P",
           "properties" : {
+            "ROUTE_TO_FABRIC_CLK" : "2"
           }
         }
       },
       "connectivity" : {
-        "CLK_IN" : "1'1",
+        "CLK_IN" : "pll_clk",
+        "CLK_OUT" : "iserdes_clk_out",
         "D" : "$ibuf_din_serdes",
         "PLL_CLK" : "pll_clk"
       },
       "parameters" : {
         "DATA_RATE" : "SDR",
         "DPA_MODE" : "DPA",
+        "ROUTE_TO_FABRIC_CLK" : "2",
         "WIDTH" : "8"
       },
       "pre_primitive" : "I_BUF",
@@ -815,7 +891,37 @@
     },
     {
       "module" : "I_BUF",
+      "name" : "$ibuf$top.$ibuf_din_serdes_clk_out",
+      "location_object" : "din_serdes_clk_out",
+      "location" : "HR_2_6_3P",
+      "linked_object" : "din_serdes_clk_out",
+      "linked_objects" : {
+        "din_serdes_clk_out" : {
+          "location" : "HR_2_6_3P",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "I" : "din_serdes_clk_out",
+        "O" : "$ibuf_din_serdes_clk_out"
+      },
+      "parameters" : {
+        "WEAK_KEEPER" : "NONE"
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+      },
+      "errors" : [
+      ]
+    },
+    {
+      "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_enable",
+      "location_object" : "enable",
+      "location" : "",
       "linked_object" : "enable",
       "linked_objects" : {
         "enable" : {
@@ -842,6 +948,8 @@
     {
       "module" : "I_BUF",
       "name" : "$ibuf$top.$ibuf_reset",
+      "location_object" : "reset",
+      "location" : "HP_1_0_0P",
       "linked_object" : "reset",
       "linked_objects" : {
         "reset" : {
@@ -868,6 +976,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_clk_out",
+      "location_object" : "clk_out",
+      "location" : "HR_2_4_2P",
       "linked_object" : "clk_out",
       "linked_objects" : {
         "clk_out" : {
@@ -894,6 +1004,8 @@
     {
       "module" : "O_SERDES_CLK",
       "name" : "o_serdes_clk",
+      "location_object" : "clk_out",
+      "location" : "HR_2_4_2P",
       "linked_object" : "clk_out",
       "linked_objects" : {
         "clk_out" : {
@@ -921,6 +1033,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap",
+      "location_object" : "delay_tap[0]",
+      "location" : "HR_2_20_10P",
       "linked_object" : "delay_tap[0]",
       "linked_objects" : {
         "delay_tap[0]" : {
@@ -946,6 +1060,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap_1",
+      "location_object" : "delay_tap[1]",
+      "location" : "HR_2_22_11P",
       "linked_object" : "delay_tap[1]",
       "linked_objects" : {
         "delay_tap[1]" : {
@@ -971,6 +1087,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap_2",
+      "location_object" : "delay_tap[2]",
+      "location" : "HR_2_24_12P",
       "linked_object" : "delay_tap[2]",
       "linked_objects" : {
         "delay_tap[2]" : {
@@ -996,6 +1114,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap_3",
+      "location_object" : "delay_tap[3]",
+      "location" : "HR_2_26_13P",
       "linked_object" : "delay_tap[3]",
       "linked_objects" : {
         "delay_tap[3]" : {
@@ -1021,6 +1141,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap_4",
+      "location_object" : "delay_tap[4]",
+      "location" : "HR_2_28_14P",
       "linked_object" : "delay_tap[4]",
       "linked_objects" : {
         "delay_tap[4]" : {
@@ -1046,6 +1168,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_delay_tap_5",
+      "location_object" : "delay_tap[5]",
+      "location" : "HR_2_30_15P",
       "linked_object" : "delay_tap[5]",
       "linked_objects" : {
         "delay_tap[5]" : {
@@ -1071,6 +1195,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout",
+      "location_object" : "dout",
+      "location" : "HP_2_20_10P",
       "linked_object" : "dout",
       "linked_objects" : {
         "dout" : {
@@ -1097,6 +1223,8 @@
     {
       "module" : "O_DELAY",
       "name" : "o_delay",
+      "location_object" : "dout",
+      "location" : "HP_2_20_10P",
       "linked_object" : "dout",
       "linked_objects" : {
         "dout" : {
@@ -1124,6 +1252,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout_clk2",
+      "location_object" : "dout_clk2",
+      "location" : "HR_5_1_0N",
       "linked_object" : "dout_clk2",
       "linked_objects" : {
         "dout_clk2" : {
@@ -1149,6 +1279,8 @@
     {
       "module" : "O_BUFT",
       "name" : "$obuf$top.$obuf_dout_serdes",
+      "location_object" : "dout_serdes",
+      "location" : "HR_2_2_1P",
       "linked_object" : "dout_serdes",
       "linked_objects" : {
         "dout_serdes" : {
@@ -1175,6 +1307,8 @@
     {
       "module" : "O_SERDES",
       "name" : "o_serdes",
+      "location_object" : "dout_serdes",
+      "location" : "HR_2_2_1P",
       "linked_object" : "dout_serdes",
       "linked_objects" : {
         "dout_serdes" : {
@@ -1184,13 +1318,13 @@
         }
       },
       "connectivity" : {
-        "CLK_IN" : "1'1",
+        "CLK_IN" : "pll_clk",
         "PLL_CLK" : "pll_clk",
         "Q" : "$obuf_dout_serdes"
       },
       "parameters" : {
         "DATA_RATE" : "DDR",
-        "WIDTH" : "4"
+        "WIDTH" : "8"
       },
       "pre_primitive" : "O_BUFT",
       "post_primitives" : [
@@ -1201,8 +1335,37 @@
       ]
     },
     {
+      "module" : "O_BUFT",
+      "name" : "$obuf$top.$obuf_dout_serdes_clk_out",
+      "location_object" : "dout_serdes_clk_out",
+      "location" : "HR_2_7_3N",
+      "linked_object" : "dout_serdes_clk_out",
+      "linked_objects" : {
+        "dout_serdes_clk_out" : {
+          "location" : "HR_2_7_3N",
+          "properties" : {
+          }
+        }
+      },
+      "connectivity" : {
+        "I" : "$obuf_dout_serdes_clk_out",
+        "O" : "dout_serdes_clk_out"
+      },
+      "parameters" : {
+      },
+      "pre_primitive" : "",
+      "post_primitives" : [
+      ],
+      "route_clock_to" : {
+      },
+      "errors" : [
+      ]
+    },
+    {
       "module" : "BOOT_CLOCK",
       "name" : "boot_clock",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
@@ -1229,12 +1392,14 @@
     {
       "module" : "PLL",
       "name" : "pll_osc",
+      "location_object" : "BOOT_CLOCK#0",
+      "location" : "",
       "linked_object" : "BOOT_CLOCK#0",
       "linked_objects" : {
         "BOOT_CLOCK#0" : {
           "location" : "",
           "properties" : {
-            "OUT0_ROUTE_TO_FABRIC_CLK" : "3"
+            "OUT0_ROUTE_TO_FABRIC_CLK" : "o_ddr_osc=4"
           }
         }
       },
@@ -1245,7 +1410,7 @@
       "parameters" : {
         "DEV_FAMILY" : "VIRGO",
         "DIVIDE_CLK_IN_BY_2" : "TRUE",
-        "OUT0_ROUTE_TO_FABRIC_CLK" : "3",
+        "OUT0_ROUTE_TO_FABRIC_CLK" : "o_ddr_osc=4",
         "PLL_DIV" : "1",
         "PLL_MULT" : "16",
         "PLL_MULT_FRAC" : "0",
@@ -1255,6 +1420,9 @@
       "post_primitives" : [
       ],
       "route_clock_to" : {
+        "CLK_OUT" : [
+          "o_ddr_osc"
+        ]
       },
       "errors" : [
       ]
@@ -1262,6 +1430,8 @@
     {
       "module" : "I_BUF_DS",
       "name" : "i_buf_ds",
+      "location_object" : "din_p",
+      "location" : "HP_1_4_2P",
       "linked_object" : "din_n+din_p",
       "linked_objects" : {
         "din_n" : {
@@ -1297,6 +1467,8 @@
     {
       "module" : "I_DDR",
       "name" : "i_ddr",
+      "location_object" : "din_p",
+      "location" : "HP_1_4_2P",
       "linked_object" : "din_n+din_p",
       "linked_objects" : {
         "din_n" : {
@@ -1327,6 +1499,8 @@
     {
       "module" : "O_BUF_DS",
       "name" : "o_buf_ds",
+      "location_object" : "dout_p",
+      "location" : "HP_1_8_4P",
       "linked_object" : "dout_n+dout_p",
       "linked_objects" : {
         "dout_n" : {
@@ -1359,6 +1533,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr",
+      "location_object" : "dout_p",
+      "location" : "HP_1_8_4P",
       "linked_object" : "dout_n+dout_p",
       "linked_objects" : {
         "dout_n" : {
@@ -1389,6 +1565,8 @@
     {
       "module" : "O_BUF_DS",
       "name" : "o_buf_ds_osc",
+      "location_object" : "dout_osc_p",
+      "location" : "HP_2_22_11P",
       "linked_object" : "dout_osc_n+dout_osc_p",
       "linked_objects" : {
         "dout_osc_n" : {
@@ -1421,6 +1599,8 @@
     {
       "module" : "O_DDR",
       "name" : "o_ddr_osc",
+      "location_object" : "dout_osc_p",
+      "location" : "HP_2_22_11P",
       "linked_object" : "dout_osc_n+dout_osc_p",
       "linked_objects" : {
         "dout_osc_n" : {
@@ -1451,13 +1631,15 @@
     {
       "module" : "FCLK_BUF",
       "name" : "$clkbuf$top.clk0_div",
+      "location_object" : "FABRIC_CLKBUF#0",
+      "location" : "",
       "linked_object" : "FABRIC_CLKBUF#0",
       "linked_objects" : {
         "FABRIC_CLKBUF#0" : {
           "location" : "",
           "properties" : {
             "ROUTE_FROM_FABRIC_CLK" : "0",
-            "ROUTE_TO_FABRIC_CLK" : "4"
+            "ROUTE_TO_FABRIC_CLK" : "6"
           }
         }
       },
@@ -1467,7 +1649,7 @@
       },
       "parameters" : {
         "ROUTE_FROM_FABRIC_CLK" : "0",
-        "ROUTE_TO_FABRIC_CLK" : "4"
+        "ROUTE_TO_FABRIC_CLK" : "6"
       },
       "pre_primitive" : "",
       "post_primitives" : [

--- a/tests/unittest/ModelConfig/ric/I_BUF.api.json
+++ b/tests/unittest/ModelConfig/ric/I_BUF.api.json
@@ -23,7 +23,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -101,7 +101,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -179,7 +179,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -257,7 +257,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -335,7 +335,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -413,7 +413,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -491,7 +491,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",

--- a/tests/unittest/ModelConfig/ric/I_BUF.api.json
+++ b/tests/unittest/ModelConfig/ric/I_BUF.api.json
@@ -31,7 +31,7 @@
       },
       {
         "attr": "TX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DDR_MODE",
@@ -51,7 +51,7 @@
       },
       {
         "attr": "TX_MODE",
-        "value": "TX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_MODE",
@@ -109,7 +109,7 @@
       },
       {
         "attr": "TX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DDR_MODE",
@@ -129,7 +129,7 @@
       },
       {
         "attr": "TX_MODE",
-        "value": "TX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_MODE",
@@ -187,7 +187,7 @@
       },
       {
         "attr": "TX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DDR_MODE",
@@ -207,7 +207,7 @@
       },
       {
         "attr": "TX_MODE",
-        "value": "TX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_MODE",
@@ -265,7 +265,7 @@
       },
       {
         "attr": "TX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DDR_MODE",
@@ -285,7 +285,7 @@
       },
       {
         "attr": "TX_MODE",
-        "value": "TX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_MODE",
@@ -343,7 +343,7 @@
       },
       {
         "attr": "TX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DDR_MODE",
@@ -363,7 +363,7 @@
       },
       {
         "attr": "TX_MODE",
-        "value": "TX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_MODE",
@@ -421,7 +421,7 @@
       },
       {
         "attr": "TX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DDR_MODE",
@@ -441,7 +441,7 @@
       },
       {
         "attr": "TX_MODE",
-        "value": "TX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_MODE",
@@ -499,7 +499,7 @@
       },
       {
         "attr": "TX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DDR_MODE",
@@ -519,7 +519,7 @@
       },
       {
         "attr": "TX_MODE",
-        "value": "TX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_MODE",

--- a/tests/unittest/ModelConfig/ric/I_BUF_DS.api.json
+++ b/tests/unittest/ModelConfig/ric/I_BUF_DS.api.json
@@ -23,7 +23,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -101,7 +101,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -179,7 +179,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -257,7 +257,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -335,7 +335,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -413,7 +413,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -491,7 +491,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",

--- a/tests/unittest/ModelConfig/ric/O_BUF.api.json
+++ b/tests/unittest/ModelConfig/ric/O_BUF.api.json
@@ -35,7 +35,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -121,7 +121,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -207,7 +207,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -293,7 +293,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -379,7 +379,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -465,7 +465,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -551,7 +551,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",

--- a/tests/unittest/ModelConfig/ric/O_BUFT.api.json
+++ b/tests/unittest/ModelConfig/ric/O_BUFT.api.json
@@ -39,7 +39,7 @@
       },
       {
         "attr": "RX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DPA_MODE",
@@ -55,11 +55,11 @@
       },
       {
         "attr": "RX_MODE",
-        "value": "RX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_CLOCK_IO",
-        "value": "RX_normal_IO"
+        "value": "__DONT__"
       },
       {
         "attr": "DFEN",
@@ -71,11 +71,11 @@
       },
       {
         "attr": "PE",
-        "value": "PE_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "PUD",
-        "value": "PUD_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "DFODTEN",
@@ -125,7 +125,7 @@
       },
       {
         "attr": "RX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DPA_MODE",
@@ -141,11 +141,11 @@
       },
       {
         "attr": "RX_MODE",
-        "value": "RX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_CLOCK_IO",
-        "value": "RX_normal_IO"
+        "value": "__DONT__"
       },
       {
         "attr": "DFEN",
@@ -157,11 +157,11 @@
       },
       {
         "attr": "PE",
-        "value": "PE_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "PUD",
-        "value": "PUD_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "DFODTEN",
@@ -211,7 +211,7 @@
       },
       {
         "attr": "RX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DPA_MODE",
@@ -227,11 +227,11 @@
       },
       {
         "attr": "RX_MODE",
-        "value": "RX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_CLOCK_IO",
-        "value": "RX_normal_IO"
+        "value": "__DONT__"
       },
       {
         "attr": "DFEN",
@@ -243,11 +243,11 @@
       },
       {
         "attr": "PE",
-        "value": "PE_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "PUD",
-        "value": "PUD_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "DFODTEN",
@@ -297,7 +297,7 @@
       },
       {
         "attr": "RX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DPA_MODE",
@@ -313,11 +313,11 @@
       },
       {
         "attr": "RX_MODE",
-        "value": "RX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_CLOCK_IO",
-        "value": "RX_normal_IO"
+        "value": "__DONT__"
       },
       {
         "attr": "DFEN",
@@ -329,11 +329,11 @@
       },
       {
         "attr": "PE",
-        "value": "PE_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "PUD",
-        "value": "PUD_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "DFODTEN",
@@ -383,7 +383,7 @@
       },
       {
         "attr": "RX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DPA_MODE",
@@ -399,11 +399,11 @@
       },
       {
         "attr": "RX_MODE",
-        "value": "RX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_CLOCK_IO",
-        "value": "RX_normal_IO"
+        "value": "__DONT__"
       },
       {
         "attr": "DFEN",
@@ -415,11 +415,11 @@
       },
       {
         "attr": "PE",
-        "value": "PE_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "PUD",
-        "value": "PUD_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "DFODTEN",
@@ -469,7 +469,7 @@
       },
       {
         "attr": "RX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DPA_MODE",
@@ -485,11 +485,11 @@
       },
       {
         "attr": "RX_MODE",
-        "value": "RX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_CLOCK_IO",
-        "value": "RX_normal_IO"
+        "value": "__DONT__"
       },
       {
         "attr": "DFEN",
@@ -501,11 +501,11 @@
       },
       {
         "attr": "PE",
-        "value": "PE_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "PUD",
-        "value": "PUD_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "DFODTEN",
@@ -555,7 +555,7 @@
       },
       {
         "attr": "RX_DLY",
-        "value": "6'd0"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_DPA_MODE",
@@ -571,11 +571,11 @@
       },
       {
         "attr": "RX_MODE",
-        "value": "RX_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "RX_CLOCK_IO",
-        "value": "RX_normal_IO"
+        "value": "__DONT__"
       },
       {
         "attr": "DFEN",
@@ -587,11 +587,11 @@
       },
       {
         "attr": "PE",
-        "value": "PE_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "PUD",
-        "value": "PUD_disable"
+        "value": "__DONT__"
       },
       {
         "attr": "DFODTEN",

--- a/tests/unittest/ModelConfig/ric/O_BUFT.api.json
+++ b/tests/unittest/ModelConfig/ric/O_BUFT.api.json
@@ -35,7 +35,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -121,7 +121,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -207,7 +207,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -293,7 +293,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -379,7 +379,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -465,7 +465,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -551,7 +551,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",

--- a/tests/unittest/ModelConfig/ric/O_BUFT_DS.api.json
+++ b/tests/unittest/ModelConfig/ric/O_BUFT_DS.api.json
@@ -35,7 +35,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -121,7 +121,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -207,7 +207,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -293,7 +293,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -379,7 +379,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -465,7 +465,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -551,7 +551,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",

--- a/tests/unittest/ModelConfig/ric/O_BUF_DS.api.json
+++ b/tests/unittest/ModelConfig/ric/O_BUF_DS.api.json
@@ -35,7 +35,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -121,7 +121,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -207,7 +207,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -293,7 +293,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -379,7 +379,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -465,7 +465,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -551,7 +551,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",

--- a/tests/unittest/ModelConfig/ric/PLL.api.json
+++ b/tests/unittest/ModelConfig/ric/PLL.api.json
@@ -143,6 +143,42 @@
         "attr": "pll_DACEN",
         "value": "DACEN_0"
       }
+    ],
+    "ROOT_BANK_SRC==A": [
+      {
+        "attr": "CDR_CLK_ROOT_SEL_B",
+        "value": "__DONT__"
+      },
+      {
+        "attr": "CDR_CLK_ROOT_SEL_A",
+        "value": "__DONT__"
+      },
+      {
+        "attr": "CORE_CLK_ROOT_SEL_B",
+        "value": "__DONT__"
+      },
+      {
+        "attr": "CORE_CLK_ROOT_SEL_A",
+        "value": "#MUX"
+      }
+    ],
+    "ROOT_BANK_SRC==B": [
+      {
+        "attr": "CDR_CLK_ROOT_SEL_B",
+        "value": "__DONT__"
+      },
+      {
+        "attr": "CDR_CLK_ROOT_SEL_A",
+        "value": "__DONT__"
+      },
+      {
+        "attr": "CORE_CLK_ROOT_SEL_B",
+        "value": "#MUX"
+      },
+      {
+        "attr": "CORE_CLK_ROOT_SEL_A",
+        "value": "__DONT__"
+      }
     ]
   }
 }

--- a/tests/unittest/ModelConfig/ric/gbox_mode.api.json
+++ b/tests/unittest/ModelConfig/ric/gbox_mode.api.json
@@ -23,7 +23,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -129,7 +129,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -203,7 +203,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -309,7 +309,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",
@@ -383,7 +383,7 @@
       },
       {
         "attr": "TX_BYPASS",
-        "value": "TX_gear_on"
+        "value": "TX_bypass"
       },
       {
         "attr": "TX_CLK_PHASE",
@@ -399,7 +399,7 @@
       },
       {
         "attr": "RX_BYPASS",
-        "value": "RX_gear_on"
+        "value": "RX_bypass"
       },
       {
         "attr": "RX_DLY",

--- a/tests/unittest/ModelConfig/ric/pll_refmux.tcl
+++ b/tests/unittest/ModelConfig/ric/pll_refmux.tcl
@@ -22,15 +22,51 @@ define_attr -block PLLREF_MUX -name cfg_pllref_use_div           -addr 8 -width 
 # Constraints within block attributes 
 ####################################
 define_constraint -block PLLREF_MUX -constraint {(cfg_pllref_hv_bank_rx_io_sel > 2) -> FALSE}
+
 ######################################
-define_ports -block PLLREF_MUX -in system_reset_n 
-define_ports -block PLLREF_MUX -in cfg_done 
-define_ports -block PLLREF_MUX -in rosc_clk 
-define_ports -block PLLREF_MUX -in hp_rx_io_clk_0 
-define_ports -block PLLREF_MUX -in hp_rx_io_clk_1 
-define_ports -block PLLREF_MUX -in hv_rx_io_clk_0 
-define_ports -block PLLREF_MUX -in hv_rx_io_clk_1 
-define_ports -block PLLREF_MUX -in hv_rx_io_clk_2 
-######################################
+# Ports
+# Not in diagram: define_ports -block PLLREF_MUX -in system_reset_n 
+# Not in diagram: define_ports -block PLLREF_MUX -in cfg_done 
+# Not in diagram: define_ports -block PLLREF_MUX -in rosc_clk 
+define_ports -block PLLREF_MUX -in hp_rx_io_clk_0_1
+define_ports -block PLLREF_MUX -in hp_rx_io_clk_0_0 
+define_ports -block PLLREF_MUX -in hp_rx_io_clk_1_1
+define_ports -block PLLREF_MUX -in hp_rx_io_clk_1_0 
+define_ports -block PLLREF_MUX -in hv_rx_io_clk_0_1
+define_ports -block PLLREF_MUX -in hv_rx_io_clk_0_0 
+define_ports -block PLLREF_MUX -in hv_rx_io_clk_1_1
+define_ports -block PLLREF_MUX -in hv_rx_io_clk_1_0 
+define_ports -block PLLREF_MUX -in xin_clk_l_r
 define_ports -block PLLREF_MUX -out pll_refmux_out 
 ######################################
+
+######################################
+# Define the connectivity table
+# Setting the memory (in bits as layed out above)
+# will connect the signal (input) before "._to_." 
+# to the signal after it.
+# Note that the table definition does not have to be in the same file
+# it can be in another file and loaded.
+# The addressing can also be loaded as of a predefined policy
+######################################
+
+define_properties -block PLLREF_MUX -____0____._to_.pll_refmux_out  "xxxxxx100"
+define_properties -block PLLREF_MUX -hp_rx_io_clk_0_1._to_.pll_refmux_out  "xxx0x0000"
+define_properties -block PLLREF_MUX -hp_rx_io_clk_0_0._to_.pll_refmux_out  "xxx1x0000" 
+define_properties -block PLLREF_MUX -hp_rx_io_clk_1_1._to_.pll_refmux_out  "xxxx01000" 
+define_properties -block PLLREF_MUX -hp_rx_io_clk_1_0._to_.pll_refmux_out  "xxxx11000"  
+define_properties -block PLLREF_MUX -hv_rx_io_clk_0_1._to_.pll_refmux_out  "010xxx100" 
+define_properties -block PLLREF_MUX -hv_rx_io_clk_0_0._to_.pll_refmux_out  "011xxx100"  
+define_properties -block PLLREF_MUX -hv_rx_io_clk_1_1._to_.pll_refmux_out  "110xxx100" 
+define_properties -block PLLREF_MUX -hv_rx_io_clk_1_0._to_.pll_refmux_out  "111xxx100"  
+define_properties -block PLLREF_MUX -xin_clk_l_r._to_.pll_refmux_out       "xxxxxxx10"
+define_properties -block PLLREF_MUX -____0_____DIVIDED._to_.pll_refmux_out "xxxxxx101" 
+define_properties -block PLLREF_MUX -hp_rx_io_clk_0_1_DIVIDED._to_.pll_refmux_out "xxx0x0001" 
+define_properties -block PLLREF_MUX -hp_rx_io_clk_0_0_DIVIDED._to_.pll_refmux_out "xxx1x0001"  
+define_properties -block PLLREF_MUX -hp_rx_io_clk_1_1_DIVIDED._to_.pll_refmux_out "xxxx01001" 
+define_properties -block PLLREF_MUX -hp_rx_io_clk_1_0_DIVIDED._to_.pll_refmux_out "xxxx11001"  
+define_properties -block PLLREF_MUX -hv_rx_io_clk_0_1_DIVIDED._to_.pll_refmux_out "010xxx101" 
+define_properties -block PLLREF_MUX -hv_rx_io_clk_0_0_DIVIDED._to_.pll_refmux_out "011xxx101"  
+define_properties -block PLLREF_MUX -hv_rx_io_clk_1_1_DIVIDED._to_.pll_refmux_out "110xxx101" 
+define_properties -block PLLREF_MUX -hv_rx_io_clk_1_0_DIVIDED._to_.pll_refmux_out "111xxx101"  
+define_properties -block PLLREF_MUX -xin_clk_l_r_DIVIDED._to_.pll_refmux_out "xxxxxxx11"


### PR DESCRIPTION
<Put hold on while waiting RIC API be updated - see https://rapidsilicon.atlassian.net/browse/VIRGO-384>

> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, FOEDAG has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->
Together with https://github.com/os-fpga/yosys_verific_rs/pull/760 and https://github.com/os-fpga/Raptor/pull/1923, this changes auto-determine the needed core-clock. All the clock input is treated as fast clock

Also initial support of bidirectional pin

Testing done:
- Port all these 4 changes (3 os-fpga repo + RIC API update) into latest NS Raptor
- Run test/batch, test/batch_gen2 and test/batch_gen3

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Library: <Specify the library name>
> - [ ] Plug-in: <Specify the plugin name>
> - [ ] Engine
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
