### PR TITLE
Fix Xvfb error for GUI Testcase in CGA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 414)
+set(VERSION_PATCH 415)
 
 
 option(

--- a/tests/TestGui/compiler_flow/raptor_run.sh
+++ b/tests/TestGui/compiler_flow/raptor_run.sh
@@ -17,7 +17,7 @@ function end_time(){
 function parse_cga(){
     cd $main_path
     tail -n100 ./results_dir/raptor.log > ./results_dir/raptor_tail.log
-    timeout 15m python3 .../../../../../parser.py ./results_dir/results.log ./results_dir/raptor_perf.log
+    timeout 15m python3 ../../../../../parser.py ./results_dir/results.log ./results_dir/raptor_perf.log
     mv CGA_Result.json ./results_dir
 }
 

--- a/tests/TestGui/compiler_flow/raptor_run.sh
+++ b/tests/TestGui/compiler_flow/raptor_run.sh
@@ -91,7 +91,8 @@ fi
 
 function compile () {
 
-
+    module unload synopsys/1.0
+    
     cd $main_path/results_dir
     echo $PWD
 

--- a/tests/TestGui/compiler_flow/raptor_run.sh
+++ b/tests/TestGui/compiler_flow/raptor_run.sh
@@ -17,7 +17,7 @@ function end_time(){
 function parse_cga(){
     cd $main_path
     tail -n100 ./results_dir/raptor.log > ./results_dir/raptor_tail.log
-    timeout 15m python3 ../../../parser.py ./results_dir/results.log ./results_dir/raptor_perf.log
+    timeout 15m python3 .../../../../../parser.py ./results_dir/results.log ./results_dir/raptor_perf.log
     mv CGA_Result.json ./results_dir
 }
 


### PR DESCRIPTION
Xvfb could not run in the CGA environment due to conflicting dependencies with Verdi. Removed Verdi to let Xvfb run.
Fix the parser path.