### PR TITLE
Update main.yml to use GCC 12 as GCC 11 is no longer available on macos image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -418,8 +418,8 @@ jobs:
         # https://github.com/actions/runner-images/issues/6350
         sudo xcode-select -s '/Applications/Xcode_13.4.1.app/Contents/Developer'
         
-        echo 'CC=gcc-11' >> $GITHUB_ENV
-        echo 'CXX=g++-11' >> $GITHUB_ENV
+        echo 'CC=gcc-12' >> $GITHUB_ENV
+        echo 'CXX=g++-12' >> $GITHUB_ENV
         echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
         echo 'PREFIX=${GITHUB_WORKSPACE}/install' >> $GITHUB_ENV
         echo "$PREFIX" >> $GITHUB_PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 416)
+set(VERSION_PATCH 417)
 
 
 option(


### PR DESCRIPTION
[macOS] GCC 11 will be removed from all macOS images on August 12](https://github.com/actions/runner-images/issues/10213)

> ### Motivate of the pull request
> - [ x] To address an existing issue.

> ### Describe the technical details
GitHub MacOS 12 has no longer GCC-11 so bumping the GCC version to 12.
