### PR TITLE
SDF timescale conversion for Icarus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 423)
+set(VERSION_PATCH 424)
 
 
 option(

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -1220,6 +1220,8 @@ bool Simulator::SimulatePNR(SimulatorType type) {
 
   std::string netlistFile =
       "fabric_" + m_compiler->DesignTopModule() + "_post_route.v";
+  std::string sdfFile =
+      "fabric_" + m_compiler->DesignTopModule() + "_post_route.sdf";
 
   std::string wrapperFile =
       m_compiler
@@ -1232,6 +1234,7 @@ bool Simulator::SimulatePNR(SimulatorType type) {
 
   netlistFile =
       m_compiler->FilePath(Compiler::Action::Routing, netlistFile).string();
+  sdfFile = m_compiler->FilePath(Compiler::Action::Routing, sdfFile).string();
 
   fileList += " " + netlistFile + " ";
   for (auto path : m_gateSimulationModels) {
@@ -1244,6 +1247,13 @@ bool Simulator::SimulatePNR(SimulatorType type) {
     fileList = " -DTIMED_SIM=1 " + fileList;
     if (type == SimulatorType::Icarus) {
       fileList = " -gspecify " + fileList;
+      std::filesystem::path sdfFilePath = sdfFile;
+      // Icarus ignores the timescale present in the SDF file, so we need 
+      // to scale the content from ps to ns to match the simulation timescale.
+      if (!FileUtils::convertPstoNsInSDFFile(sdfFilePath)) {
+        ErrorMessage("SDF Unit Conversion for Icarus failed!\n");
+        return false;
+      }
     }
   }
 

--- a/src/Simulation/Simulator.cpp
+++ b/src/Simulation/Simulator.cpp
@@ -1248,7 +1248,7 @@ bool Simulator::SimulatePNR(SimulatorType type) {
     if (type == SimulatorType::Icarus) {
       fileList = " -gspecify " + fileList;
       std::filesystem::path sdfFilePath = sdfFile;
-      // Icarus ignores the timescale present in the SDF file, so we need 
+      // Icarus ignores the timescale present in the SDF file, so we need
       // to scale the content from ps to ns to match the simulation timescale.
       if (!FileUtils::convertPstoNsInSDFFile(sdfFilePath)) {
         ErrorMessage("SDF Unit Conversion for Icarus failed!\n");

--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -432,8 +432,9 @@ bool FileUtils::convertPstoNsInSDFFile(const std::filesystem::path& path) {
   if (content.find("TIMESCALE 1 ns") != std::string::npos) {
     // Already converted
     return true;
-  } 
-  content = StringUtils::replaceAll(content, "TIMESCALE 1 ps", "TIMESCALE 1 ns");
+  }
+  content =
+      StringUtils::replaceAll(content, "TIMESCALE 1 ps", "TIMESCALE 1 ns");
   std::string result;
 
   for (unsigned int i = 0; i < content.size(); i++) {

--- a/src/Utils/FileUtils.h
+++ b/src/Utils/FileUtils.h
@@ -111,6 +111,8 @@ class FileUtils final {
 
   static void terminateSystemCommand();
 
+  static bool convertPstoNsInSDFFile(const std::filesystem::path& path);
+
  private:
   FileUtils() = delete;
   FileUtils(const FileUtils& orig) = delete;


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ x] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

Icarus ignores the timescale present in the SDF file, so we need 
to scale the content from ps to ns to match the simulation timescale.