### PR TITLE
Remove openOCD submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "third_party/gtkwave"]
 	path = third_party/gtkwave
 	url = https://github.com/gtkwave/gtkwave.git
-[submodule "third_party/openocd"]
-	path = third_party/openocd
-	url = https://github.com/RapidSilicon/openocd.git
 [submodule "third_party/exprtk"]
 	path = third_party/exprtk
 	url = https://github.com/ArashPartow/exprtk.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 424)
+set(VERSION_PATCH 425)
 
 
 option(


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x ] To address an existing issue. If so, please provide a link to the issue: <issue id>

OpenOCD a submodule, contains git2cl as submodule. Git2Cl is hosted on `git.savannah.nongnu.org`. Sometimes this website faces issues entertaining the cloning request especially if the request originates from GitHub Actions servers. Since our code base compilation does not directly depend upon OpenOCD so, we can remove it to avoid the failure of GH Actions due to this issue.