### PR TITLE
Fix Pin Planner crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(VERSION_MINOR 0)
 # Add the spdlog directory to the include path
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk ${CMAKE_CURRENT_SOURCE_DIR}/third_party/scope_guard) 
 
-set(VERSION_PATCH 431)
+set(VERSION_PATCH 432)
 
 
 option(

--- a/src/MainWindow/main_window.cpp
+++ b/src/MainWindow/main_window.cpp
@@ -897,9 +897,7 @@ void MainWindow::createMenus() {
 
   toolsMenu = menuBar()->addMenu("&Tools");
   toolsMenu->addAction(ipConfiguratorAction);
-#ifndef PRODUCTION_BUILD
   toolsMenu->addAction(pinAssignmentAction);
-#endif
   toolsMenu->addAction(programmerAction);
   toolsMenu->addAction(eFpgaConfigurator);
 
@@ -914,9 +912,7 @@ void MainWindow::createMenus() {
   helpMenu->addAction(compressProjectAction);
 
   preferencesMenu->addAction(defualtProjectPathAction);
-#ifndef PRODUCTION_BUILD
   preferencesMenu->addAction(pinPlannerPinNameAction);
-#endif
   preferencesMenu->addAction(editorSettingsAction);
   preferencesMenu->addAction(showWelcomePageAction);
   preferencesMenu->addAction(stopCompileMessageAction);

--- a/src/PinAssignment/PinAssignmentBaseView.cpp
+++ b/src/PinAssignment/PinAssignmentBaseView.cpp
@@ -109,7 +109,9 @@ void PinAssignmentBaseView::insertCombo(QComboBox *combo,
 }
 
 void PinAssignmentBaseView::removeFromList(QObject *obj) {
-  m_allCombo.remove(qobject_cast<QComboBox *>(obj));
+  // Bug: qobject_cast<QComboBox*> returns 0 now the type is ComboBox
+  // Use brute force cast for now.
+  m_allCombo.remove((QComboBox *)obj);
 }
 
 }  // namespace FOEDAG


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

Bug: qobject_cast<QComboBox*> returns 0 now the type is ComboBox
Use brute force cast for now.